### PR TITLE
use the `log` crate + `env_logger`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,18 @@ name = "miri"
 version = "0.1.0"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiletest_rs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiletest_rs 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log_settings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,14 +24,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "compiletest_rs"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "log"
 version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log_settings"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ test = false
 
 [dependencies]
 byteorder = "0.4.2"
+env_logger = "0.3.3"
+log = "0.3.6"
+log_settings = "0.1.1"
 
 [dev-dependencies]
 compiletest_rs = "0.1.1"

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -52,8 +52,8 @@ fn init_logger() {
     let mut builder = env_logger::LogBuilder::new();
     builder.format(format).filter(None, log::LogLevelFilter::Info);
 
-    if std::env::var("RUST_LOG").is_ok() {
-        builder.parse(&std::env::var("RUST_LOG").unwrap());
+    if std::env::var("MIRI_LOG").is_ok() {
+        builder.parse(&std::env::var("MIRI_LOG").unwrap());
     }
 
     builder.init().unwrap();

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -5,6 +5,9 @@ extern crate getopts;
 extern crate miri;
 extern crate rustc;
 extern crate rustc_driver;
+extern crate env_logger;
+extern crate log_settings;
+extern crate log;
 
 use miri::interpreter;
 use rustc::session::Session;
@@ -31,6 +34,27 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
 
 #[miri_run]
 fn main() {
+    init_logger();
     let args: Vec<String> = std::env::args().collect();
     rustc_driver::run_compiler(&args, &mut MiriCompilerCalls);
+}
+
+#[miri_run]
+fn init_logger() {
+    let format = |record: &log::LogRecord| {
+        // prepend spaces to indent the final string
+        let indentation = log_settings::settings().indentation;
+        let spaces = "                                  ";
+        let indentation = &spaces[..std::cmp::min(indentation, spaces.len())];
+        format!("{} -{} {}", record.level(), indentation, record.args())
+    };
+
+    let mut builder = env_logger::LogBuilder::new();
+    builder.format(format).filter(None, log::LogLevelFilter::Info);
+
+    if std::env::var("RUST_LOG").is_ok() {
+        builder.parse(&std::env::var("RUST_LOG").unwrap());
+    }
+
+    builder.init().unwrap();
 }

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -44,8 +44,8 @@ fn init_logger() {
     let format = |record: &log::LogRecord| {
         // prepend spaces to indent the final string
         let indentation = log_settings::settings().indentation;
-        let spaces = "    |    |    |    |    |    |    |    |    ";
-        let indentation = &spaces[..std::cmp::min(indentation, spaces.len())];
+        let spaces = "    |    |    |    |    |    |    |    |    |";
+        let indentation = &spaces[..std::cmp::min(indentation, 44)];
         format!("{}:{}|{} {}", record.level(), record.location().module_path(), indentation, record.args())
     };
 

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -45,13 +45,11 @@ fn init_logger() {
     let format = |record: &log::LogRecord| {
         // prepend spaces to indent the final string
         let indentation = log_settings::settings().indentation;
-        let depth = indentation / NSPACES;
-        let indentation = indentation % NSPACES;
-        format!("{lvl}:{module}{depth:2}{indent:<indentation$}{text}",
+        format!("{lvl}:{module}{depth:2}{indent:<indentation$} {text}",
             lvl = record.level(),
             module = record.location().module_path(),
-            depth = depth,
-            indentation = indentation,
+            depth = indentation / NSPACES,
+            indentation = indentation % NSPACES,
             indent = "",
             text = record.args())
     };

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -44,9 +44,11 @@ fn init_logger() {
     let format = |record: &log::LogRecord| {
         // prepend spaces to indent the final string
         let indentation = log_settings::settings().indentation;
-        let spaces = "    |    |    |    |    |    |    |    |    |";
-        let indentation = &spaces[..std::cmp::min(indentation, 44)];
-        format!("{}:{}|{} {}", record.level(), record.location().module_path(), indentation, record.args())
+        let spaces = "                                        ";
+        let depth = indentation / spaces.len();
+        let indentation = indentation % spaces.len();
+        let indentation = &spaces[..indentation];
+        format!("{}:{}{:2}{} {}", record.level(), record.location().module_path(), depth, indentation, record.args())
     };
 
     let mut builder = env_logger::LogBuilder::new();

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -44,9 +44,9 @@ fn init_logger() {
     let format = |record: &log::LogRecord| {
         // prepend spaces to indent the final string
         let indentation = log_settings::settings().indentation;
-        let spaces = "                                  ";
+        let spaces = "    |    |    |    |    |    |    |    |    ";
         let indentation = &spaces[..std::cmp::min(indentation, spaces.len())];
-        format!("{} -{} {}", record.level(), indentation, record.args())
+        format!("{}:{}|{} {}", record.level(), record.location().module_path(), indentation, record.args())
     };
 
     let mut builder = env_logger::LogBuilder::new();

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -41,14 +41,19 @@ fn main() {
 
 #[miri_run]
 fn init_logger() {
+    const NSPACES: usize = 40;
     let format = |record: &log::LogRecord| {
         // prepend spaces to indent the final string
         let indentation = log_settings::settings().indentation;
-        let spaces = "                                        ";
-        let depth = indentation / spaces.len();
-        let indentation = indentation % spaces.len();
-        let indentation = &spaces[..indentation];
-        format!("{}:{}{:2}{} {}", record.level(), record.location().module_path(), depth, indentation, record.args())
+        let depth = indentation / NSPACES;
+        let indentation = indentation % NSPACES;
+        format!("{lvl}:{module}{depth:2}{indent:<indentation$}{text}",
+            lvl = record.level(),
+            module = record.location().module_path(),
+            depth = depth,
+            indentation = indentation,
+            indent = "",
+            text = record.args())
     };
 
     let mut builder = env_logger::LogBuilder::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 #[macro_use] extern crate rustc;
 extern crate rustc_mir;
 extern crate syntax;
+#[macro_use] extern crate log;
+extern crate log_settings;
 
 // From crates.io.
 extern crate byteorder;

--- a/tests/run-fail/inception.rs
+++ b/tests/run-fail/inception.rs
@@ -9,14 +9,32 @@ fn run_miri(file: &str, sysroot: &str) -> Output {
     let libpath = libpath.to_str().unwrap();
     let libpath2 = path.join("target").join("debug").join("deps");
     let libpath2 = libpath2.to_str().unwrap();
+    let mut args = vec![
+        "run".to_string(), "--".to_string(),
+        "--sysroot".to_string(), sysroot.to_string(),
+        "-L".to_string(), libpath.to_string(),
+        "-L".to_string(), libpath2.to_string(),
+        file.to_string()
+    ];
+    for file in std::fs::read_dir("target/debug/deps").unwrap() {
+        let file = file.unwrap();
+        if file.file_type().unwrap().is_file() {
+            let path = file.path();
+            if let Some(ext) = path.extension() {
+                if ext == "rlib" {
+                    let name = path.file_stem().unwrap().to_str().unwrap();
+                    if let Some(dash) = name.rfind('-') {
+                        if name.starts_with("lib") {
+                            args.push("--extern".to_string());
+                            args.push(format!("{}={}", &name[3..dash], path.to_str().unwrap()));
+                        }
+                    }
+                }
+            }
+        }
+    }
     Command::new("cargo")
-        .args(&[
-            "run", "--",
-            "--sysroot", sysroot,
-            "-L", libpath,
-            "-L", libpath2,
-            file
-        ])
+        .args(&args)
         .output()
         .unwrap_or_else(|e| panic!("failed to execute process: {}", e))
 }


### PR DESCRIPTION
The `MIRI_LOG` env var can now be used to change the logging granularity.

Example output:

```
DEBUG:miri::interpreter| Interpreting: out_of_bounds_read
TRACE:miri::interpreter|  // bb0
TRACE:miri::interpreter|  tmp3 = Box([u8; 2])
TRACE:miri::interpreter|  (*tmp3) = [const 1u8, const 2u8]
TRACE:miri::interpreter|  tmp2 = tmp3
TRACE:miri::interpreter|  tmp1 = tmp2 as Box<[u8]> (Unsize)
TRACE:miri::interpreter|  var0 = std::slice::<impl [T]><u8>::into_vec(tmp1) -> [return: bb5, unwind: bb4]
TRACE:miri::interpreter|   // bb0
TRACE:miri::interpreter|   var0 = arg0
TRACE:miri::interpreter|   tmp1 = var0
TRACE:miri::interpreter|   return = std::slice::hack::into_vec::<T>(tmp1) -> [return: bb5, unwind: bb4]
TRACE:miri::interpreter|    // bb0
TRACE:miri::interpreter|    var0 = arg0
TRACE:miri::interpreter|    tmp2 = &mut (*var0)
TRACE:miri::interpreter|    tmp1 = std::slice::<impl [T]><T>::as_mut_ptr(tmp2) -> [return: bb5, unwind: bb17]
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     var0 = arg0
TRACE:miri::interpreter|     tmp0 = &mut (*var0)
TRACE:miri::interpreter|     return = <[T] as core::slice::SliceExt>::as_mut_ptr(tmp0) -> bb1
TRACE:miri::interpreter|    | // bb0
TRACE:miri::interpreter|    | var0 = arg0
TRACE:miri::interpreter|    | tmp1 = &mut (*var0)
TRACE:miri::interpreter|    | tmp0 = tmp1 as *mut [T] (Misc)
TRACE:miri::interpreter|    | return = tmp0 as *mut T (Misc)
TRACE:miri::interpreter|    | return
TRACE:miri::interpreter|     // bb1
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb5
TRACE:miri::interpreter|    tmp4 = &(*var0)
TRACE:miri::interpreter|    tmp3 = std::slice::<impl [T]><T>::len(tmp4) -> [return: bb6, unwind: bb18]
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     var0 = arg0
TRACE:miri::interpreter|     tmp0 = &(*var0)
TRACE:miri::interpreter|     return = <[T] as core::slice::SliceExt>::len(tmp0) -> bb1
TRACE:miri::interpreter|    | // bb0
TRACE:miri::interpreter|    | var0 = arg0
TRACE:miri::interpreter|    | tmp2 = &(*var0)
TRACE:miri::interpreter|    | tmp1 = std::mem::transmute::<&'static [T], core::slice::Repr<T>>(tmp2) -> bb1
TRACE:miri::interpreter|    | // bb1
TRACE:miri::interpreter|    | tmp0 = (tmp1.1: usize)
TRACE:miri::interpreter|    | return = tmp0
TRACE:miri::interpreter|    | return
TRACE:miri::interpreter|     // bb1
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb6
TRACE:miri::interpreter|    tmp6 = &(*var0)
TRACE:miri::interpreter|    tmp5 = std::slice::<impl [T]><T>::len(tmp6) -> [return: bb7, unwind: bb19]
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     var0 = arg0
TRACE:miri::interpreter|     tmp0 = &(*var0)
TRACE:miri::interpreter|     return = <[T] as core::slice::SliceExt>::len(tmp0) -> bb1
TRACE:miri::interpreter|    | // bb0
TRACE:miri::interpreter|    | var0 = arg0
TRACE:miri::interpreter|    | tmp2 = &(*var0)
TRACE:miri::interpreter|    | tmp1 = std::mem::transmute::<&'static [T], core::slice::Repr<T>>(tmp2) -> bb1
TRACE:miri::interpreter|    | // bb1
TRACE:miri::interpreter|    | tmp0 = (tmp1.1: usize)
TRACE:miri::interpreter|    | return = tmp0
TRACE:miri::interpreter|    | return
TRACE:miri::interpreter|     // bb1
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb7
TRACE:miri::interpreter|    var1 = <std::vec::Vec<T>><T>::from_raw_parts(tmp1, tmp3, tmp5) -> [return: bb8, unwind: bb20]
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     var0 = arg0
TRACE:miri::interpreter|     var1 = arg1
TRACE:miri::interpreter|     var2 = arg2
TRACE:miri::interpreter|     tmp1 = var0
TRACE:miri::interpreter|     tmp2 = var2
TRACE:miri::interpreter|     tmp0 = <alloc::raw_vec::RawVec<T>><T>::from_raw_parts(tmp1, tmp2) -> bb1
TRACE:miri::interpreter|    | // bb0
TRACE:miri::interpreter|    | var0 = arg0
TRACE:miri::interpreter|    | var1 = arg1
TRACE:miri::interpreter|    | tmp1 = var0
TRACE:miri::interpreter|    | tmp0 = <std::ptr::Unique<T>><T>::new(tmp1) -> bb1
TRACE:miri::interpreter|    |  // bb0
TRACE:miri::interpreter|    |  var0 = arg0
TRACE:miri::interpreter|    |  tmp2 = var0
TRACE:miri::interpreter|    |  tmp1 = tmp2 as *const T (Misc)
TRACE:miri::interpreter|    |  tmp0 = <core::nonzero::NonZero<T>><*const T>::new(tmp1) -> bb1
TRACE:miri::interpreter|    |   // bb0
TRACE:miri::interpreter|    |   var0 = arg0
TRACE:miri::interpreter|    |   tmp0 = var0
TRACE:miri::interpreter|    |   return = core::nonzero::NonZero::{{constructor}}<T>(tmp0,)
TRACE:miri::interpreter|    |   drop(tmp0) -> [return: bb4, unwind: bb3]
DEBUG:miri::interpreter|    |   no need to drop *const u8
TRACE:miri::interpreter|    |   // bb4
TRACE:miri::interpreter|    |   drop(arg0) -> [return: bb5, unwind: bb7]
DEBUG:miri::interpreter|    |   no need to drop *const u8
TRACE:miri::interpreter|    |   // bb5
TRACE:miri::interpreter|    |   drop(var0) -> bb6
DEBUG:miri::interpreter|    |   no need to drop *const u8
TRACE:miri::interpreter|    |   // bb6
TRACE:miri::interpreter|    |   return
TRACE:miri::interpreter|    |  // bb1
TRACE:miri::interpreter|    |  tmp3 = std::marker::PhantomData::{{constructor}}<T>
TRACE:miri::interpreter|    |  return = std::ptr::Unique<T> { pointer: tmp0, _marker: tmp3 }
TRACE:miri::interpreter|    |  return
TRACE:miri::interpreter|    | // bb1
TRACE:miri::interpreter|    | tmp2 = var1
TRACE:miri::interpreter|    | return = alloc::raw_vec::RawVec<T> { ptr: tmp0, cap: tmp2 }
TRACE:miri::interpreter|    | return
TRACE:miri::interpreter|     // bb1
TRACE:miri::interpreter|     tmp4 = var1
TRACE:miri::interpreter|     return = std::vec::Vec<T> { buf: tmp0, len: tmp4 }
TRACE:miri::interpreter|     drop(tmp0) -> bb2
TRACE:miri::interpreter|     -need to drop alloc::raw_vec::RawVec<u8>
TRACE:miri::interpreter|     // bb2
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb8
TRACE:miri::interpreter|    tmp8 = var0
TRACE:miri::interpreter|    tmp7 = std::mem::forget::<Box<[T]>>(tmp8) -> [return: bb10, unwind: bb9]
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     var0 = arg0
TRACE:miri::interpreter|     tmp1 = var0
TRACE:miri::interpreter|     return = std::intrinsics::::forget::<T>(tmp1) -> [return: bb5, unwind: bb4]
TRACE:miri::interpreter|     // bb5
TRACE:miri::interpreter|     drop(tmp1) -> [return: bb6, unwind: bb9]
TRACE:miri::interpreter|     -need to drop Box<[u8]>
TRACE:miri::interpreter|     // bb6
TRACE:miri::interpreter|     drop(arg0) -> [return: bb7, unwind: bb10]
TRACE:miri::interpreter|     -need to drop Box<[u8]>
TRACE:miri::interpreter|     // bb7
TRACE:miri::interpreter|     drop(var0) -> bb8
TRACE:miri::interpreter|     -need to drop Box<[u8]>
TRACE:miri::interpreter|     // bb8
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb10
TRACE:miri::interpreter|    drop(tmp8) -> [return: bb11, unwind: bb21]
TRACE:miri::interpreter|    -need to drop Box<[u8]>
TRACE:miri::interpreter|    // bb11
TRACE:miri::interpreter|    tmp9 = var1
TRACE:miri::interpreter|    return = tmp9
TRACE:miri::interpreter|    drop(var1) -> [return: bb13, unwind: bb12]
TRACE:miri::interpreter|    -need to drop std::vec::Vec<u8>
TRACE:miri::interpreter|    // bb13
TRACE:miri::interpreter|    drop(tmp9) -> [return: bb14, unwind: bb22]
TRACE:miri::interpreter|    -need to drop std::vec::Vec<u8>
TRACE:miri::interpreter|    // bb14
TRACE:miri::interpreter|    drop(arg0) -> [return: bb15, unwind: bb23]
TRACE:miri::interpreter|    -need to drop Box<[u8]>
TRACE:miri::interpreter|    // bb15
TRACE:miri::interpreter|    drop(var0) -> bb16
TRACE:miri::interpreter|    -need to drop Box<[u8]>
TRACE:miri::interpreter|    // bb16
TRACE:miri::interpreter|    return
TRACE:miri::interpreter|   // bb5
TRACE:miri::interpreter|   drop(tmp1) -> [return: bb6, unwind: bb9]
TRACE:miri::interpreter|   -need to drop Box<[u8]>
TRACE:miri::interpreter|   // bb6
TRACE:miri::interpreter|   drop(arg0) -> [return: bb7, unwind: bb10]
TRACE:miri::interpreter|   -need to drop Box<[u8]>
TRACE:miri::interpreter|   // bb7
TRACE:miri::interpreter|   drop(var0) -> bb8
TRACE:miri::interpreter|   -need to drop Box<[u8]>
TRACE:miri::interpreter|   // bb8
TRACE:miri::interpreter|   return
TRACE:miri::interpreter|  // bb5
TRACE:miri::interpreter|  drop(tmp1) -> [return: bb6, unwind: bb3]
TRACE:miri::interpreter|  -need to drop Box<[u8]>
TRACE:miri::interpreter|  // bb6
TRACE:miri::interpreter|  drop(tmp2) -> [return: bb7, unwind: bb2]
TRACE:miri::interpreter|  -need to drop Box<[u8; 2]>
TRACE:miri::interpreter|  // bb7
TRACE:miri::interpreter|  tmp8 = &var0
TRACE:miri::interpreter|  tmp7 = <std::vec::Vec<u8> as std::ops::Deref>::deref(tmp8) -> [return: bb8, unwind: bb2]
TRACE:miri::interpreter|   // bb0
TRACE:miri::interpreter|   var0 = arg0
TRACE:miri::interpreter|   tmp0 = &((*var0).0: alloc::raw_vec::RawVec<T>)
TRACE:miri::interpreter|   var1 = <alloc::raw_vec::RawVec<T>><T>::ptr(tmp0) -> bb1
TRACE:miri::interpreter|    // bb0
TRACE:miri::interpreter|    var0 = arg0
TRACE:miri::interpreter|    tmp2 = &((*var0).0: std::ptr::Unique<T>)
TRACE:miri::interpreter|    tmp1 = <std::ptr::Unique<T> as std::ops::Deref>::deref(tmp2) -> bb1
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     var0 = arg0
TRACE:miri::interpreter|     tmp2 = &((*var0).0: core::nonzero::NonZero<*const T>)
TRACE:miri::interpreter|     tmp1 = <core::nonzero::NonZero<*const T> as std::ops::Deref>::deref(tmp2) -> bb1
TRACE:miri::interpreter|    | // bb0
TRACE:miri::interpreter|    | var0 = arg0
TRACE:miri::interpreter|    | var1 = &((*var0).0: T)
TRACE:miri::interpreter|    | return = &(*var1)
TRACE:miri::interpreter|    | return
TRACE:miri::interpreter|     // bb1
TRACE:miri::interpreter|     tmp0 = &(*tmp1)
TRACE:miri::interpreter|     return = std::mem::transmute::<&'static *const T, &'static *mut T>(tmp0) -> bb2
TRACE:miri::interpreter|     // bb2
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb1
TRACE:miri::interpreter|    tmp0 = (*tmp1)
TRACE:miri::interpreter|    return = tmp0
TRACE:miri::interpreter|    return
TRACE:miri::interpreter|   // bb1
TRACE:miri::interpreter|   tmp4 = var1
TRACE:miri::interpreter|   tmp3 = std::ptr::<impl *mut T><T>::is_null(tmp4) -> bb2
TRACE:miri::interpreter|    // bb0
TRACE:miri::interpreter|    var0 = arg0
TRACE:miri::interpreter|    tmp0 = var0
TRACE:miri::interpreter|    tmp1 = std::ptr::null_mut::<T>() -> bb1
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     return = const 0usize as *mut T (Misc)
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb1
TRACE:miri::interpreter|    return = Eq(tmp0, tmp1)
TRACE:miri::interpreter|    return
TRACE:miri::interpreter|   // bb2
TRACE:miri::interpreter|   tmp2 = Not(tmp3)
TRACE:miri::interpreter|   tmp1 = std::intrinsics::::assume(tmp2) -> bb3
TRACE:miri::interpreter|   // bb3
TRACE:miri::interpreter|   tmp7 = var1
TRACE:miri::interpreter|   tmp6 = tmp7 as *const T (Misc)
TRACE:miri::interpreter|   tmp8 = ((*var0).1: usize)
TRACE:miri::interpreter|   tmp5 = std::slice::from_raw_parts::<T>(tmp6, tmp8) -> bb4
TRACE:miri::interpreter|    // bb0
TRACE:miri::interpreter|    var0 = arg0
TRACE:miri::interpreter|    var1 = arg1
TRACE:miri::interpreter|    tmp1 = var0
TRACE:miri::interpreter|    tmp2 = var1
TRACE:miri::interpreter|    tmp0 = core::slice::Repr<T> { data: tmp1, len: tmp2 }
TRACE:miri::interpreter|    return = std::mem::transmute::<core::slice::Repr<T>, &'static [T]>(tmp0) -> bb1
TRACE:miri::interpreter|    // bb1
TRACE:miri::interpreter|    return
TRACE:miri::interpreter|   // bb4
TRACE:miri::interpreter|   return = &(*tmp5)
TRACE:miri::interpreter|   return
TRACE:miri::interpreter|  // bb8
TRACE:miri::interpreter|  tmp6 = &(*tmp7)
TRACE:miri::interpreter|  tmp5 = std::slice::<impl [T]><u8>::get_unchecked(tmp6, const 5usize) -> [return: bb9, unwind: bb2]
TRACE:miri::interpreter|   // bb0
TRACE:miri::interpreter|   var0 = arg0
TRACE:miri::interpreter|   var1 = arg1
TRACE:miri::interpreter|   tmp1 = &(*var0)
TRACE:miri::interpreter|   tmp2 = var1
TRACE:miri::interpreter|   tmp0 = <[T] as core::slice::SliceExt>::get_unchecked(tmp1, tmp2) -> bb1
TRACE:miri::interpreter|    // bb0
TRACE:miri::interpreter|    var0 = arg0
TRACE:miri::interpreter|    var1 = arg1
TRACE:miri::interpreter|    tmp3 = &(*var0)
TRACE:miri::interpreter|    tmp2 = <[T] as core::slice::SliceExt>::as_ptr(tmp3) -> bb1
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     var0 = arg0
TRACE:miri::interpreter|     tmp1 = &(*var0)
TRACE:miri::interpreter|     tmp0 = tmp1 as *const [T] (Misc)
TRACE:miri::interpreter|     return = tmp0 as *const T (Misc)
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb1
TRACE:miri::interpreter|    tmp5 = var1
TRACE:miri::interpreter|    tmp4 = tmp5 as isize (Misc)
TRACE:miri::interpreter|    tmp1 = std::ptr::<impl *const T><T>::offset(tmp2, tmp4) -> bb2
TRACE:miri::interpreter|     // bb0
TRACE:miri::interpreter|     var0 = arg0
TRACE:miri::interpreter|     var1 = arg1
TRACE:miri::interpreter|     tmp0 = var0
TRACE:miri::interpreter|     tmp1 = var1
TRACE:miri::interpreter|     return = std::intrinsics::::offset::<T>(tmp0, tmp1) -> bb1
TRACE:miri::interpreter|     // bb1
TRACE:miri::interpreter|     return
TRACE:miri::interpreter|    // bb2
TRACE:miri::interpreter|    tmp0 = &(*tmp1)
TRACE:miri::interpreter|    return = &(*tmp0)
TRACE:miri::interpreter|    return
TRACE:miri::interpreter|   // bb1
TRACE:miri::interpreter|   return = &(*tmp0)
TRACE:miri::interpreter|   return
TRACE:miri::interpreter|  // bb9
TRACE:miri::interpreter|  tmp4 = (*tmp5)
tests/compile-fail/errors.rs:39:14: 39:33 error: memory access of 5..6 outside bounds of allocation 11 which has size 2
tests/compile-fail/errors.rs:39     unsafe { *v.get_unchecked(5) } //~ ERROR: memory access of 5..6 outside bounds of allocation 11 which has size 2
                                             ^~~~~~~~~~~~~~~~~~~
```