### PR TITLE
create a miri-pass test that allows us to run miri for arbitrary targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ before_script:
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
 script:
-- |
-  travis-cargo build &&
-  env RUST_SYSROOT=$HOME/rust travis-cargo test
+- set -e
+- travis-cargo build
+- RUST_SYSROOT=$HOME/rust
+- travis-cargo test
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   export PATH=$HOME/.local/bin:$PATH
 script:
 - |
-  travis-cargo build &&
+  env RUST_SYSROOT=$HOME/rust travis-cargo build &&
   env RUST_SYSROOT=$HOME/rust travis-cargo test
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ before_script:
 script:
 - set -e
 - travis-cargo build
-- RUST_SYSROOT=$HOME/rust
-- travis-cargo test
+- env RUST_SYSROOT=$HOME/rust travis-cargo test
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ before_script:
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
 script:
-- set -e
-- travis-cargo build
-- env RUST_SYSROOT=$HOME/rust travis-cargo test
+- |
+  travis-cargo build &&
+  env RUST_SYSROOT=$HOME/rust travis-cargo test
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: rust
 rust:
 - nightly
-matrix:
-  allow_failures:
-  - rust: nightly
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "miri"
 version = "0.1.0"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "compiletest_rs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "compiletest_rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log_settings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -24,10 +24,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "compiletest_rs"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -94,6 +95,11 @@ dependencies = [
 [[package]]
 name = "regex-syntax"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ log = "0.3.6"
 log_settings = "0.1.1"
 
 [dev-dependencies]
-compiletest_rs = "0.1.1"
+compiletest_rs = "0.2"

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -17,7 +17,7 @@ use miri::{
     Frame,
 };
 use rustc::session::Session;
-use rustc_driver::{driver, CompilerCalls};
+use rustc_driver::{driver, CompilerCalls, Compilation};
 use rustc::ty::{TyCtxt, subst};
 use rustc::hir::def_id::DefId;
 
@@ -31,6 +31,7 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
     ) -> driver::CompileController<'a> {
         let mut control = driver::CompileController::basic();
 
+        control.after_analysis.stop = Compilation::Stop;
         control.after_analysis.callback = Box::new(|state| {
             state.session.abort_if_errors();
 
@@ -70,6 +71,7 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
                     }
                 }
             }
+            state.session.abort_if_errors();
         });
 
         control

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,11 +1,43 @@
 extern crate compiletest_rs as compiletest;
 
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
+use std::io::Write;
 
-fn run_mode(mode: &'static str) {
+fn run_mode(dir: &'static str, mode: &'static str, sysroot: &str) {
     // Disable rustc's new error fomatting. It breaks these tests.
     std::env::remove_var("RUST_NEW_ERROR_FORMAT");
+    let flags = format!("--sysroot {} -Dwarnings", sysroot);
+    for_all_targets(sysroot, |target| {
+        let mut config = compiletest::default_config();
+        config.host_rustcflags = Some(flags.clone());
+        config.mode = mode.parse().expect("Invalid mode");
+        config.run_lib_path = Path::new(sysroot).join("lib").join("rustlib").join(&target).join("lib");
+        config.rustc_path = "target/debug/miri".into();
+        config.src_base = PathBuf::from(format!("tests/{}", dir));
+        config.target = target.to_owned();
+        config.target_rustcflags = Some(flags.clone());
+        compiletest::run_tests(&config);
+    });
+}
 
+fn for_all_targets<F: Fn(String)>(sysroot: &str, f: F) {
+    for target in std::fs::read_dir(format!("{}/lib/rustlib/", sysroot)).unwrap() {
+        let target = target.unwrap();
+        if !target.metadata().unwrap().is_dir() {
+            continue;
+        }
+        let target = target.path().iter().rev().next().unwrap().to_str().unwrap().to_owned();
+        if target == "etc" {
+            continue;
+        }
+        let stderr = std::io::stderr();
+        writeln!(stderr.lock(), "running tests for target {}", target).unwrap();
+        f(target);
+    }
+}
+
+#[test]
+fn compile_test() {
     // Taken from https://github.com/Manishearth/rust-clippy/pull/911.
     let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
     let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
@@ -15,29 +47,27 @@ fn run_mode(mode: &'static str) {
             .expect("need to specify RUST_SYSROOT env var or use rustup or multirust")
             .to_owned(),
     };
-    let flags = format!("--sysroot {} -Dwarnings", sysroot);
-
-    // FIXME: read directories in sysroot/lib/rustlib and generate the test targets from that
-    let targets = &["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"];
-
-    for &target in targets {
-        use std::io::Write;
+    run_mode("compile-fail", "compile-fail", &sysroot);
+    for_all_targets(&sysroot, |target| {
+        for file in std::fs::read_dir("tests/run-pass").unwrap() {
+            let file = file.unwrap();
+            if !file.metadata().unwrap().is_file() {
+                continue;
+            }
+            let file = file.path();
+            let stderr = std::io::stderr();
+            writeln!(stderr.lock(), "test [miri-pass] {}", file.to_str().unwrap()).unwrap();
+            let mut cmd = std::process::Command::new("target/debug/miri");
+            cmd.arg(file);
+            cmd.arg(format!("--sysroot={}", sysroot));
+            cmd.arg("-Dwarnings");
+            cmd.arg(format!("-target={}", target));
+            let libs = Path::new(&sysroot).join("lib");
+            let sysroot = libs.join("rustlib").join(&target).join("lib");
+            let paths = std::env::join_paths(&[libs, sysroot]).unwrap();
+            cmd.env(compiletest::procsrv::dylib_env_var(), paths);
+        }
         let stderr = std::io::stderr();
-        write!(stderr.lock(), "running tests for target {}", target).unwrap();
-        let mut config = compiletest::default_config();
-        config.host_rustcflags = Some(flags.clone());
-        config.mode = mode.parse().expect("Invalid mode");
-        config.run_lib_path = format!("{}/lib/rustlib/{}/lib", sysroot, target);
-        config.rustc_path = "target/debug/miri".into();
-        config.src_base = PathBuf::from(format!("tests/{}", mode));
-        config.target = target.to_owned();
-        config.target_rustcflags = Some(flags.clone());
-        compiletest::run_tests(&config);
-    }
-}
-
-#[test]
-fn compile_test() {
-    run_mode("compile-fail");
-    run_mode("run-pass");
+        writeln!(stderr.lock(), "").unwrap();
+    })
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -20,7 +20,7 @@ fn run_mode(dir: &'static str, mode: &'static str, sysroot: &str) {
     });
 }
 
-fn for_all_targets<F: Fn(String)>(sysroot: &str, f: F) {
+fn for_all_targets<F: FnMut(String)>(sysroot: &str, mut f: F) {
     for target in std::fs::read_dir(format!("{}/lib/rustlib/", sysroot)).unwrap() {
         let target = target.unwrap();
         if !target.metadata().unwrap().is_dir() {
@@ -63,7 +63,7 @@ fn compile_test() {
             cmd.arg(format!("--sysroot={}", sysroot));
             cmd.arg("-Dwarnings");
             cmd.arg(format!("--target={}", target));
-            cmd.env("RUST_SYSROOT", sysroot);
+            cmd.env("RUST_SYSROOT", &sysroot);
             let libs = Path::new(&sysroot).join("lib");
             let sysroot = libs.join("rustlib").join(&target).join("lib");
             let paths = std::env::join_paths(&[libs, sysroot]).unwrap();
@@ -84,7 +84,7 @@ fn compile_test() {
         }
         let stderr = std::io::stderr();
         writeln!(stderr.lock(), "").unwrap();
-    })
+    });
     if failed {
         panic!("some tests failed");
     }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -38,6 +38,7 @@ fn for_all_targets<F: Fn(String)>(sysroot: &str, f: F) {
 
 #[test]
 fn compile_test() {
+    let mut failed = false;
     // Taken from https://github.com/Manishearth/rust-clippy/pull/911.
     let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
     let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
@@ -69,14 +70,21 @@ fn compile_test() {
             match cmd.output() {
                 Ok(ref output) if output.status.success() => writeln!(stderr.lock(), "ok").unwrap(),
                 Ok(output) => {
+                    failed = true;
                     writeln!(stderr.lock(), "FAILED with exit code {}", output.status.code().unwrap_or(0)).unwrap();
                     writeln!(stderr.lock(), "stdout: \n {}", std::str::from_utf8(&output.stdout).unwrap()).unwrap();
                     writeln!(stderr.lock(), "stderr: \n {}", std::str::from_utf8(&output.stderr).unwrap()).unwrap();
                 }
-                Err(e) => writeln!(stderr.lock(), "FAILED: {}", e).unwrap(),
+                Err(e) => {
+                    failed = true;
+                    writeln!(stderr.lock(), "FAILED: {}", e).unwrap();
+                },
             }
         }
         let stderr = std::io::stderr();
         writeln!(stderr.lock(), "").unwrap();
     })
+    if failed {
+        panic!("some tests failed");
+    }
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -63,6 +63,7 @@ fn compile_test() {
             cmd.arg(format!("--sysroot={}", sysroot));
             cmd.arg("-Dwarnings");
             cmd.arg(format!("--target={}", target));
+            cmd.env("RUST_SYSROOT", sysroot);
             let libs = Path::new(&sysroot).join("lib");
             let sysroot = libs.join("rustlib").join(&target).join("lib");
             let paths = std::env::join_paths(&[libs, sysroot]).unwrap();

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -26,7 +26,7 @@ fn for_all_targets<F: Fn(String)>(sysroot: &str, f: F) {
         if !target.metadata().unwrap().is_dir() {
             continue;
         }
-        let target = target.path().iter().rev().next().unwrap().to_str().unwrap().to_owned();
+        let target = target.file_name().into_string().unwrap();
         if target == "etc" {
             continue;
         }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -60,7 +60,6 @@ fn compile_test() {
             write!(stderr.lock(), "test [miri-pass] {} ", file.to_str().unwrap()).unwrap();
             let mut cmd = std::process::Command::new("target/debug/miri");
             cmd.arg(file);
-            cmd.arg(format!("--sysroot={}", sysroot));
             cmd.arg("-Dwarnings");
             cmd.arg(format!("--target={}", target));
             let libs = Path::new(&sysroot).join("lib");

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -63,7 +63,6 @@ fn compile_test() {
             cmd.arg(format!("--sysroot={}", sysroot));
             cmd.arg("-Dwarnings");
             cmd.arg(format!("--target={}", target));
-            cmd.env("RUST_SYSROOT", &sysroot);
             let libs = Path::new(&sysroot).join("lib");
             let sysroot = libs.join("rustlib").join(&target).join("lib");
             let paths = std::env::join_paths(&[libs, sysroot]).unwrap();


### PR DESCRIPTION
compiletest doesn't give us this kind of pass, so I created one...

now I can miri-run windows-tests on linux:

```
running tests for target x86_64-pc-windows-gnu
test [miri-pass] tests/run-pass/loops.rs
test [miri-pass] tests/run-pass/arrays.rs
```

The test suite automatically checks for installed targets and runs miri on them.

Also I hope the travis changes now actually break the CI if the tests fail.

I needed compiletest 2.0 for `compiletest::procsrv::dylib_env_var()`