### PR TITLE
don't execute the first statement of a constant/static/promoted right away

### DIFF
--- a/src/interpreter/step.rs
+++ b/src/interpreter/step.rs
@@ -39,11 +39,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }.visit_statement(block, stmt);
             if current_stack == self.stack.len() {
                 self.statement(stmt)?;
-            } else {
-                // ConstantExtractor added some new frames for statics/constants/promoteds
-                // self.step() can't be "done", so it can't return false
-                assert!(self.step()?);
             }
+            // if ConstantExtractor added new frames, we don't execute anything here
+            // but await the next call to step
             return Ok(true);
         }
 
@@ -58,11 +56,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }.visit_terminator(block, terminator);
         if current_stack == self.stack.len() {
             self.terminator(terminator)?;
-        } else {
-            // ConstantExtractor added some new frames for statics/constants/promoteds
-            // self.step() can't be "done", so it can't return false
-            assert!(self.step()?);
         }
+        // if ConstantExtractor added new frames, we don't execute anything here
+        // but await the next call to step
         Ok(true)
     }
 


### PR DESCRIPTION
This might create confusion, because attempting to execute a statement can cause
arbitrary stackframes to be added for the constants/statics/promoteds required by that
statement. Before this commit, the first statement of the last added stackframe was
executed immediately. Thus there was no way to inspect the state before that first
statement.