### PR TITLE
use the item path printer that prints user friendly textual paths

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -236,7 +236,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     }
 
     fn load_mir(&self, def_id: DefId) -> CachedMir<'a, 'tcx> {
-        use rustc_trans::back::symbol_names::def_id_to_string;
         match self.tcx.map.as_local_node_id(def_id) {
             Some(node_id) => CachedMir::Ref(self.mir_map.map.get(&node_id).unwrap()),
             None => {
@@ -247,7 +246,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
                 let cs = &self.tcx.sess.cstore;
                 let mir = cs.maybe_get_item_mir(self.tcx, def_id).unwrap_or_else(|| {
-                    panic!("no mir for `{}`", def_id_to_string(self.tcx, def_id));
+                    panic!("no mir for `{}`", self.tcx.item_path_str(def_id));
                 });
                 let cached = Rc::new(mir);
                 mir_cache.insert(def_id, cached.clone());

--- a/tests/compile-fail/env_args.rs
+++ b/tests/compile-fail/env_args.rs
@@ -1,4 +1,4 @@
-//error-pattern: no mir for `std
+//error-pattern: no mir for `std::env::args`
 
 fn main() {
     let x = std::env::args();


### PR DESCRIPTION
previously we had something like `std::$insert_mangle_garbage_here$::env::vars`