### PR TITLE
implement floats by running the ops on the host architecture

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -169,7 +169,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     // TODO(solson): Try making const_to_primval instead.
     fn const_to_ptr(&mut self, const_val: &const_val::ConstVal) -> EvalResult<'tcx, Pointer> {
         use rustc::middle::const_val::ConstVal::*;
-        use rustc_const_math::{ConstInt, ConstIsize, ConstUsize};
+        use rustc_const_math::{ConstInt, ConstIsize, ConstUsize, ConstFloat};
+        use std::mem::transmute;
         macro_rules! i2p {
             ($i:ident, $n:expr) => {{
                 let ptr = self.memory.allocate($n);
@@ -178,7 +179,15 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }}
         }
         match *const_val {
-            Float(_f) => unimplemented!(),
+            Float(ConstFloat::F32(f)) => {
+                let i = unsafe { transmute::<_, u32>(f) };
+                i2p!(i, 4)
+            },
+            Float(ConstFloat::F64(f)) => {
+                let i = unsafe { transmute::<_, u64>(f) };
+                i2p!(i, 8)
+            },
+            Float(ConstFloat::FInfer{..}) => unreachable!(),
             Integral(ConstInt::Infer(_)) => unreachable!(),
             Integral(ConstInt::InferSigned(_)) => unreachable!(),
             Integral(ConstInt::I8(i)) => i2p!(i, 1),
@@ -824,7 +833,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     }
 
     pub fn read_primval(&mut self, ptr: Pointer, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
-        use syntax::ast::{IntTy, UintTy};
+        use syntax::ast::{IntTy, UintTy, FloatTy};
+        use std::mem::transmute;
         let val = match (self.memory.pointer_size(), &ty.sty) {
             (_, &ty::TyBool)              => PrimVal::Bool(self.memory.read_bool(ptr)?),
             (_, &ty::TyChar)              => {
@@ -848,6 +858,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             (_, &ty::TyUint(UintTy::U32)) => PrimVal::U32(self.memory.read_uint(ptr, 4)? as u32),
             (8, &ty::TyUint(UintTy::Us)) |
             (_, &ty::TyUint(UintTy::U64)) => PrimVal::U64(self.memory.read_uint(ptr, 8)? as u64),
+            (_, &ty::TyFloat(FloatTy::F32)) => {
+                let i = self.memory.read_uint(ptr, 4)? as u32;
+                PrimVal::F32(unsafe { transmute(i) })
+            },
+            (_, &ty::TyFloat(FloatTy::F64)) => {
+                let i = self.memory.read_uint(ptr, 8)?;
+                PrimVal::F64(unsafe { transmute(i) })
+            },
 
             (_, &ty::TyFnDef(def_id, substs, fn_ty)) => {
                 PrimVal::FnPtr(self.memory.create_fn_ptr(def_id, substs, fn_ty))

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -394,6 +394,7 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
     }
 
     pub fn write_primval(&mut self, ptr: Pointer, val: PrimVal) -> EvalResult<'tcx, ()> {
+        use std::mem::transmute;
         let pointer_size = self.pointer_size();
         match val {
             PrimVal::Bool(b) => self.write_bool(ptr, b),
@@ -407,6 +408,8 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
             PrimVal::U64(n)  => self.write_uint(ptr, n as u64, 8),
             PrimVal::Char(c) => self.write_uint(ptr, c as u64, 4),
             PrimVal::IntegerPtr(n) => self.write_uint(ptr, n as u64, pointer_size),
+            PrimVal::F32(f) => self.write_uint(ptr, unsafe { transmute::<_, u32>(f) } as u64, 4),
+            PrimVal::F64(f) => self.write_uint(ptr, unsafe { transmute::<_, u64>(f) }, 8),
             PrimVal::FnPtr(_p) |
             PrimVal::AbstractPtr(_p) => unimplemented!(),
         }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -394,7 +394,6 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
     }
 
     pub fn write_primval(&mut self, ptr: Pointer, val: PrimVal) -> EvalResult<'tcx, ()> {
-        use std::mem::transmute;
         let pointer_size = self.pointer_size();
         match val {
             PrimVal::Bool(b) => self.write_bool(ptr, b),
@@ -408,8 +407,8 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
             PrimVal::U64(n)  => self.write_uint(ptr, n as u64, 8),
             PrimVal::Char(c) => self.write_uint(ptr, c as u64, 4),
             PrimVal::IntegerPtr(n) => self.write_uint(ptr, n as u64, pointer_size),
-            PrimVal::F32(f) => self.write_uint(ptr, unsafe { transmute::<_, u32>(f) } as u64, 4),
-            PrimVal::F64(f) => self.write_uint(ptr, unsafe { transmute::<_, u64>(f) }, 8),
+            PrimVal::F32(f) => self.write_f32(ptr, f),
+            PrimVal::F64(f) => self.write_f64(ptr, f),
             PrimVal::FnPtr(_p) |
             PrimVal::AbstractPtr(_p) => unimplemented!(),
         }
@@ -466,6 +465,28 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
     pub fn write_usize(&mut self, ptr: Pointer, n: u64) -> EvalResult<'tcx, ()> {
         let size = self.pointer_size();
         self.write_uint(ptr, n, size)
+    }
+
+    pub fn write_f32(&mut self, ptr: Pointer, f: f32) -> EvalResult<'tcx, ()> {
+        let endianess = self.endianess();
+        let b = self.get_bytes_mut(ptr, 4)?;
+        write_target_f32(endianess, b, f).unwrap();
+        Ok(())
+    }
+
+    pub fn write_f64(&mut self, ptr: Pointer, f: f64) -> EvalResult<'tcx, ()> {
+        let endianess = self.endianess();
+        let b = self.get_bytes_mut(ptr, 8)?;
+        write_target_f64(endianess, b, f).unwrap();
+        Ok(())
+    }
+
+    pub fn read_f32(&self, ptr: Pointer) -> EvalResult<'tcx, f32> {
+        self.get_bytes(ptr, 4).map(|b| read_target_f32(self.endianess(), b).unwrap())
+    }
+
+    pub fn read_f64(&self, ptr: Pointer) -> EvalResult<'tcx, f64> {
+        self.get_bytes(ptr, 8).map(|b| read_target_f64(self.endianess(), b).unwrap())
     }
 }
 
@@ -586,6 +607,36 @@ fn read_target_int(endianess: layout::Endian, mut source: &[u8]) -> Result<i64, 
     match endianess {
         layout::Endian::Little => source.read_int::<LittleEndian>(source.len()),
         layout::Endian::Big => source.read_int::<BigEndian>(source.len()),
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Methods to access floats in the target endianess
+////////////////////////////////////////////////////////////////////////////////
+
+fn write_target_f32(endianess: layout::Endian, mut target: &mut [u8], data: f32) -> Result<(), byteorder::Error> {
+    match endianess {
+        layout::Endian::Little => target.write_f32::<LittleEndian>(data),
+        layout::Endian::Big => target.write_f32::<BigEndian>(data),
+    }
+}
+fn write_target_f64(endianess: layout::Endian, mut target: &mut [u8], data: f64) -> Result<(), byteorder::Error> {
+    match endianess {
+        layout::Endian::Little => target.write_f64::<LittleEndian>(data),
+        layout::Endian::Big => target.write_f64::<BigEndian>(data),
+    }
+}
+
+fn read_target_f32(endianess: layout::Endian, mut source: &[u8]) -> Result<f32, byteorder::Error> {
+    match endianess {
+        layout::Endian::Little => source.read_f32::<LittleEndian>(),
+        layout::Endian::Big => source.read_f32::<BigEndian>(),
+    }
+}
+fn read_target_f64(endianess: layout::Endian, mut source: &[u8]) -> Result<f64, byteorder::Error> {
+    match endianess {
+        layout::Endian::Little => source.read_f64::<LittleEndian>(),
+        layout::Endian::Big => source.read_f64::<BigEndian>(),
     }
 }
 

--- a/src/primval.rs
+++ b/src/primval.rs
@@ -75,8 +75,6 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 Shl => unreachable!(),
                 Shr => unreachable!(),
 
-                // directly comparing floats is questionable
-                // miri could forbid it, or at least miri as rust const eval should forbid it
                 Eq => Bool($l == $r),
                 Ne => Bool($l != $r),
                 Lt => Bool($l < $r),

--- a/tests/run-pass/floats.rs
+++ b/tests/run-pass/floats.rs
@@ -5,4 +5,7 @@ fn main() {
     assert_eq!(-{5.0_f32}, -5.0_f32);
     assert!((5.0_f32/0.0).is_infinite());
     assert!((-5.0_f32).sqrt().is_nan());
+    let x: u64 = unsafe { std::mem::transmute(42.0_f64) };
+    let y: f64 = unsafe { std::mem::transmute(x) };
+    assert_eq!(y, 42.0_f64);
 }

--- a/tests/run-pass/floats.rs
+++ b/tests/run-pass/floats.rs
@@ -1,0 +1,8 @@
+
+fn main() {
+    assert_eq!(6.0_f32*6.0_f32, 36.0_f32);
+    assert_eq!(6.0_f64*6.0_f64, 36.0_f64);
+    assert_eq!(-{5.0_f32}, -5.0_f32);
+    assert!((5.0_f32/0.0).is_infinite());
+    assert!((-5.0_f32).sqrt().is_nan());
+}


### PR DESCRIPTION
We can't possibly hope to emulate all target architectures' float quirks. Let's just assert that anyone depending on the minuscule differences between architectures deserves their code to be broken when run through miri.

Instead of running on the host architecture, we can also use one of the following crates for deterministic behaviour not depending on the host architecture

* [exact-float](https://crates.io/crates/exact-float) (a fraction of bignums)
* [accurate](https://crates.io/crates/accurate) (some software based float algorithms)
* [decimal](https://crates.io/crates/decimal) (128 bit soft floats)

Only `accurate` will emulate the computation closely. The other two are much more precise and will thus differ from running the code on the target.

fixes #35 
