### PR TITLE
replace all `unreachable!` and `panic!` calls with `bug!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.75 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -82,19 +82,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.1.73"
+version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -145,8 +145,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum log_settings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3d382732ea0fbc09790c4899db3255bdea0fc78b54bf234bd18a63bb603915b6"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)" = "56b7ee9f764ecf412c6e2fff779bca4b22980517ae335a21aeaf4e32625a5df2"
-"checksum regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31040aad7470ad9d8c46302dcffba337bb4289ca5da2e3cd6e37b64109a85199"
+"checksum regex 0.1.75 (registry+https://github.com/rust-lang/crates.io-index)" = "f62414f9d3b0f53e827ac46d6f8ce2ff6a91afd724225a5986e54e81e170693c"
+"checksum regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279401017ae31cf4e15344aa3f085d0e2e5c1e70067289ef906906fdbe92c8fd"
 "checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "55dd963dbaeadc08aa7266bf7f91c3154a7805e32bb94b820b769d2ef3b4744d"

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -41,12 +41,12 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
             let mut memory_size = 100*1024*1024; // 100MB
             let mut step_limit = 1000_000;
             let mut stack_limit = 100;
-            fn extract_str(lit: &syntax::ast::Lit) -> syntax::parse::token::InternedString {
+            let extract_int = |lit: &syntax::ast::Lit| -> u64 {
                 match lit.node {
-                    syntax::ast::LitKind::Str(ref s, _) => s.clone(),
-                    _ => bug!("attribute values need to be strings"),
+                    syntax::ast::LitKind::Int(i, _) => i,
+                    _ => state.session.span_fatal(lit.span, "expected an integer literal"),
                 }
-            }
+            };
             for attr in krate.attrs.iter() {
                 match attr.node.value.node {
                     MetaItemKind::List(ref name, _) if name != "miri" => {}
@@ -55,9 +55,9 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
                             NestedMetaItemKind::MetaItem(ref inner) => match inner.node {
                                 MetaItemKind::NameValue(ref name, ref value) => {
                                     match &**name {
-                                        "memory_size" => memory_size = extract_str(value).parse().expect("not a number"),
-                                        "step_limit" => step_limit = extract_str(value).parse().expect("not a number"),
-                                        "stack_limit" => stack_limit = extract_str(value).parse().expect("not a number"),
+                                        "memory_size" => memory_size = extract_int(value) as usize,
+                                        "step_limit" => step_limit = extract_int(value),
+                                        "stack_limit" => stack_limit = extract_int(value) as usize,
                                         _ => state.session.span_err(item.span, "unknown miri attribute"),
                                     }
                                 }

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -44,7 +44,7 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
             fn extract_str(lit: &syntax::ast::Lit) -> syntax::parse::token::InternedString {
                 match lit.node {
                     syntax::ast::LitKind::Str(ref s, _) => s.clone(),
-                    _ => panic!("attribute values need to be strings"),
+                    _ => bug!("attribute values need to be strings"),
                 }
             }
             for attr in krate.attrs.iter() {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -255,7 +255,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             let cs = &self.tcx.sess.cstore;
             let mir = cs.maybe_get_item_mir(self.tcx, def_id).unwrap_or_else(|| {
-                bug!("no mir for `{}`", self.tcx.item_path_str(def_id));
+                panic!("no mir for `{}`", self.tcx.item_path_str(def_id));
             });
             let cached = Rc::new(mir);
             mir_cache.insert(def_id, cached.clone());

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -292,7 +292,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         // TODO(solson): Is this inefficient? Needs investigation.
         let ty = self.monomorphize(ty, substs);
 
-        self.tcx.normalizing_infer_ctxt(Reveal::All).enter(|infcx| {
+        self.tcx.infer_ctxt(None, None, Reveal::All).enter(|infcx| {
             // TODO(solson): Report this error properly.
             ty.layout(&infcx).unwrap()
         })
@@ -454,7 +454,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     }
 
                     General { discr, ref variants, .. } => {
-                        if let mir::AggregateKind::Adt(adt_def, variant, _) = *kind {
+                        if let mir::AggregateKind::Adt(adt_def, variant, _, _) = *kind {
                             let discr_val = adt_def.variants[variant].disr_val.to_u64_unchecked();
                             let discr_size = discr.size().bytes() as usize;
                             self.memory.write_uint(dest, discr_val, discr_size)?;
@@ -468,7 +468,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     }
 
                     RawNullablePointer { nndiscr, .. } => {
-                        if let mir::AggregateKind::Adt(_, variant, _) = *kind {
+                        if let mir::AggregateKind::Adt(_, variant, _, _) = *kind {
                             if nndiscr == variant as u64 {
                                 assert_eq!(operands.len(), 1);
                                 let operand = &operands[0];
@@ -485,7 +485,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     }
 
                     StructWrappedNullablePointer { nndiscr, ref nonnull, ref discrfield } => {
-                        if let mir::AggregateKind::Adt(_, variant, _) = *kind {
+                        if let mir::AggregateKind::Adt(_, variant, _, _) = *kind {
                             if nndiscr == variant as u64 {
                                 let offsets = iter::once(0)
                                     .chain(nonnull.offset_after_field.iter().map(|s| s.bytes()));
@@ -503,7 +503,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
                     CEnum { discr, signed, .. } => {
                         assert_eq!(operands.len(), 0);
-                        if let mir::AggregateKind::Adt(adt_def, variant, _) = *kind {
+                        if let mir::AggregateKind::Adt(adt_def, variant, _, _) = *kind {
                             let val = adt_def.variants[variant].disr_val.to_u64_unchecked();
                             let size = discr.size().bytes() as usize;
 

--- a/src/interpreter/terminator.rs
+++ b/src/interpreter/terminator.rs
@@ -240,6 +240,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             // The discriminant_value intrinsic returns 0 for non-sum types.
             Array { .. } | FatPointer { .. } | Scalar { .. } | Univariant { .. } |
             Vector { .. } => 0,
+            UntaggedUnion { .. } => unimplemented!(),
         };
 
         Ok(discr_val)
@@ -278,7 +279,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "assume" => {}
 
             "copy_nonoverlapping" => {
-                let elem_ty = substs.types[0];
+                let elem_ty = substs.types().next().expect("should at least have one type argument");
                 let elem_size = self.type_size(elem_ty);
                 let elem_align = self.type_align(elem_ty);
                 let src = self.memory.read_ptr(args_ptrs[0])?;
@@ -288,7 +289,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "discriminant_value" => {
-                let ty = substs.types[0];
+                let ty = substs.types().next().expect("should have at least one type argument");
                 let adt_ptr = self.memory.read_ptr(args_ptrs[0])?;
                 let discr_val = self.read_discriminant_value(adt_ptr, ty)?;
                 self.memory.write_uint(dest, discr_val, 8)?;
@@ -299,19 +300,19 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "init" => self.memory.write_repeat(dest, 0, dest_layout.size(&self.tcx.data_layout).bytes() as usize)?,
 
             "min_align_of" => {
-                let elem_ty = substs.types[0];
+                let elem_ty = substs.types().next().expect("should have at least one type argument");
                 let elem_align = self.type_align(elem_ty);
                 self.memory.write_uint(dest, elem_align as u64, pointer_size)?;
             }
 
             "move_val_init" => {
-                let ty = substs.types[0];
+                let ty = substs.types().next().expect("should have at least one type argument");
                 let ptr = self.memory.read_ptr(args_ptrs[0])?;
                 self.move_(args_ptrs[1], ptr, ty)?;
             }
 
             "offset" => {
-                let pointee_ty = substs.types[0];
+                let pointee_ty = substs.types().next().expect("should have at least one type argument");
                 let pointee_size = self.type_size(pointee_ty) as isize;
                 let ptr_arg = args_ptrs[0];
                 let offset = self.memory.read_isize(args_ptrs[1])?;
@@ -343,13 +344,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "size_of" => {
-                let ty = substs.types[0];
+                let ty = substs.types().next().expect("should have at least one type argument");
                 let size = self.type_size(ty) as u64;
                 self.memory.write_uint(dest, size, pointer_size)?;
             }
 
             "size_of_val" => {
-                let ty = substs.types[0];
+                let ty = substs.types().next().expect("should have at least one type argument");
                 if self.type_is_sized(ty) {
                     let size = self.type_size(ty) as u64;
                     self.memory.write_uint(dest, size, pointer_size)?;
@@ -369,7 +370,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "transmute" => {
-                let ty = substs.types[0];
+                let ty = substs.types().next().expect("should have at least one type argument");
                 self.move_(args_ptrs[0], dest, ty)?;
             }
             "uninit" => self.memory.mark_definedness(dest, dest_layout.size(&self.tcx.data_layout).bytes() as usize, false)?,
@@ -457,7 +458,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     fn fulfill_obligation(&self, trait_ref: ty::PolyTraitRef<'tcx>) -> traits::Vtable<'tcx, ()> {
         // Do the initial selection for the obligation. This yields the shallow result we are
         // looking for -- that is, what specific impl.
-        self.tcx.normalizing_infer_ctxt(Reveal::All).enter(|infcx| {
+        self.tcx.infer_ctxt(None, None, Reveal::All).enter(|infcx| {
             let mut selcx = traits::SelectionContext::new(&infcx);
 
             let obligation = traits::Obligation::new(
@@ -570,14 +571,14 @@ fn get_impl_method<'a, 'tcx>(
     impl_substs: &'tcx Substs<'tcx>,
     name: ast::Name,
 ) -> ImplMethod<'tcx> {
-    assert!(!substs.types.needs_infer());
+    assert!(!substs.types().any(|ty| ty.needs_infer()));
 
     let trait_def_id = tcx.trait_id_of_impl(impl_def_id).unwrap();
     let trait_def = tcx.lookup_trait_def(trait_def_id);
 
     match trait_def.ancestors(impl_def_id).fn_defs(tcx, name).next() {
         Some(node_item) => {
-            let substs = tcx.normalizing_infer_ctxt(Reveal::All).enter(|infcx| {
+            let substs = tcx.infer_ctxt(None, None, Reveal::All).enter(|infcx| {
                 let substs = substs.rebase_onto(tcx, trait_def_id, impl_substs);
                 let substs = traits::translate_substs(&infcx, impl_def_id,
                                                       substs, node_item.node);

--- a/src/interpreter/terminator.rs
+++ b/src/interpreter/terminator.rs
@@ -198,7 +198,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                 arg_srcs.push((src, ty));
                             }
                         }
-                        ty => panic!("expected tuple as last argument in function with 'rust-call' ABI, got {:?}", ty),
+                        ty => bug!("expected tuple as last argument in function with 'rust-call' ABI, got {:?}", ty),
                     }
                 }
 
@@ -523,7 +523,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 //                   ty: def_ty(tcx, def_id, substs)
                 // }
             }
-            vtable => unreachable!("resolved vtable bad vtable {:?} in trans", vtable),
+            vtable => bug!("resolved vtable bad vtable {:?} in trans", vtable),
         }
     }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -303,7 +303,7 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
                     println!("(deallocated)");
                     continue;
                 },
-                (Some(_), Some(_)) => unreachable!(),
+                (Some(_), Some(_)) => bug!("miri invariant broken: an allocation id exists that points to both a function and a memory location"),
             };
 
             for i in 0..alloc.bytes.len() {
@@ -481,7 +481,7 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
             2 => Ok(self.layout.i16_align.abi() as usize),
             4 => Ok(self.layout.i32_align.abi() as usize),
             8 => Ok(self.layout.i64_align.abi() as usize),
-            _ => panic!("bad integer size"),
+            _ => bug!("bad integer size"),
         }
     }
 

--- a/src/primval.rs
+++ b/src/primval.rs
@@ -49,7 +49,7 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 BitOr  => $v($l | $r),
 
                 // these have already been handled
-                Shl | Shr => bug!("`bin_op` operation should already have been handled", bin_op.to_hir_binop().as_str()),
+                Shl | Shr => bug!("`{}` operation should already have been handled", bin_op.to_hir_binop().as_str()),
 
                 Eq => Bool($l == $r),
                 Ne => Bool($l != $r),

--- a/src/primval.rs
+++ b/src/primval.rs
@@ -49,8 +49,8 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 BitOr  => $v($l | $r),
 
                 // these have already been handled
-                Shl => unreachable!(),
-                Shr => unreachable!(),
+                Shl => bug!("`<<` operation should already have been handled"),
+                Shr => bug!("`>>` operation should already have been handled"),
 
                 Eq => Bool($l == $r),
                 Ne => Bool($l != $r),
@@ -72,11 +72,11 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 Rem    => $v($l % $r),
 
                 // invalid float ops
-                BitXor => unreachable!(),
-                BitAnd => unreachable!(),
-                BitOr  => unreachable!(),
-                Shl => unreachable!(),
-                Shr => unreachable!(),
+                BitXor => bug!("`^` is not a valid operation on floats"),
+                BitAnd => bug!("`&` is not a valid operation on floats"),
+                BitOr  => bug!("`|` is not a valid operation on floats"),
+                Shl => bug!("`<<` is not a valid operation on floats"),
+                Shr => bug!("`>>` is not a valid operation on floats"),
 
                 Eq => Bool($l == $r),
                 Ne => Bool($l != $r),
@@ -108,7 +108,7 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 I16(_) | U16(_) => 16,
                 I32(_) | U32(_) => 32,
                 I64(_) | U64(_) => 64,
-                _ => unreachable!(),
+                _ => bug!("bad MIR: bitshift lhs is not integral"),
             };
             assert!(type_bits.is_power_of_two());
             // turn into `u32` because `overflowing_sh{l,r}` only take `u32`
@@ -121,7 +121,7 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 U16(i) => i as u32,
                 U32(i) => i as u32,
                 U64(i) => i as u32,
-                _ => panic!("bad MIR: bitshift rhs is not integral"),
+                _ => bug!("bad MIR: bitshift rhs is not integral"),
             };
             // apply mask
             let r = r & (type_bits - 1);
@@ -130,7 +130,7 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                     match bin_op {
                         Shl => overflow!($v, U32, $l, overflowing_shl, $r),
                         Shr => overflow!($v, U32, $l, overflowing_shr, $r),
-                        _ => unreachable!(),
+                        _ => bug!("it has already been checked that this is a shift op"),
                     }
                 })
             }
@@ -143,7 +143,7 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 U16(l) => shift!(U16, l, r),
                 U32(l) => shift!(U32, l, r),
                 U64(l) => shift!(U64, l, r),
-                _ => unreachable!(),
+                _ => bug!("bad MIR: bitshift lhs is not integral (should already have been checked)"),
             };
             return Ok((val, false));
         },
@@ -168,7 +168,7 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
             Le => Bool(l <= r),
             Gt => Bool(l > r),
             Ge => Bool(l >= r),
-            _ => panic!("invalid char op: {:?}", bin_op),
+            _ => bug!("invalid char op: {:?}", bin_op),
         },
 
         (Bool(l), Bool(r)) => {

--- a/src/primval.rs
+++ b/src/primval.rs
@@ -49,8 +49,7 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 BitOr  => $v($l | $r),
 
                 // these have already been handled
-                Shl => bug!("`<<` operation should already have been handled"),
-                Shr => bug!("`>>` operation should already have been handled"),
+                Shl | Shr => bug!("`bin_op` operation should already have been handled", bin_op.to_hir_binop().as_str()),
 
                 Eq => Bool($l == $r),
                 Ne => Bool($l != $r),
@@ -72,11 +71,8 @@ pub fn binary_op<'tcx>(bin_op: mir::BinOp, left: PrimVal, right: PrimVal) -> Eva
                 Rem    => $v($l % $r),
 
                 // invalid float ops
-                BitXor => bug!("`^` is not a valid operation on floats"),
-                BitAnd => bug!("`&` is not a valid operation on floats"),
-                BitOr  => bug!("`|` is not a valid operation on floats"),
-                Shl => bug!("`<<` is not a valid operation on floats"),
-                Shr => bug!("`>>` is not a valid operation on floats"),
+                BitXor | BitAnd | BitOr |
+                Shl | Shr => bug!("`{}` is not a valid operation on floats", bin_op.to_hir_binop().as_str()),
 
                 Eq => Bool($l == $r),
                 Ne => Bool($l != $r),

--- a/tests/compile-fail/oom.rs
+++ b/tests/compile-fail/oom.rs
@@ -1,5 +1,5 @@
-#![feature(custom_attribute)]
-#![miri(memory_size="0")]
+#![feature(custom_attribute, attr_literals)]
+#![miri(memory_size=0)]
 
 fn bar() {
     let x = 5;

--- a/tests/compile-fail/oom2.rs
+++ b/tests/compile-fail/oom2.rs
@@ -1,5 +1,5 @@
-#![feature(custom_attribute)]
-#![miri(memory_size="1000")]
+#![feature(custom_attribute, attr_literals)]
+#![miri(memory_size=1000)]
 
 fn bar(i: i32) {
     if i < 1000 {

--- a/tests/compile-fail/stack_limit.rs
+++ b/tests/compile-fail/stack_limit.rs
@@ -1,5 +1,5 @@
-#![feature(custom_attribute)]
-#![miri(stack_limit="2")]
+#![feature(custom_attribute, attr_literals)]
+#![miri(stack_limit=2)]
 
 fn bar() {
     foo();

--- a/tests/compile-fail/timeout.rs
+++ b/tests/compile-fail/timeout.rs
@@ -1,6 +1,6 @@
 //error-pattern: reached the configured maximum execution time
-#![feature(custom_attribute)]
-#![miri(step_limit="1000")]
+#![feature(custom_attribute, attr_literals)]
+#![miri(step_limit=1000)]
 
 fn main() {
     for i in 0..1000000 {


### PR DESCRIPTION
fixes #32 

I didn't touch the `unimplemented!`, since these probably need to go away by being implememented before moving miri into rustc.