### PR TITLE
change the block and stmt position after a function call returns

### DIFF
--- a/src/interpreter/step.rs
+++ b/src/interpreter/step.rs
@@ -87,8 +87,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     }
 
     fn terminator(&mut self, terminator: &mir::Terminator<'tcx>) -> EvalResult<'tcx, ()> {
-        // after a terminator we go to a new block
-        self.frame_mut().stmt = 0;
         trace!("{:?}", terminator.kind);
         self.eval_terminator(terminator)?;
         if !self.stack.is_empty() {
@@ -125,7 +123,7 @@ impl<'a, 'b, 'tcx> ConstantExtractor<'a, 'b, 'tcx> {
         self.try(|this| {
             let ptr = this.ecx.alloc_ret_ptr(mir.return_ty, substs)?;
             this.ecx.statics.insert(cid.clone(), ptr);
-            this.ecx.push_stack_frame(def_id, span, mir, substs, Some(ptr))
+            this.ecx.push_stack_frame(def_id, span, mir, substs, Some(ptr), None)
         });
     }
     fn try<F: FnOnce(&mut Self) -> EvalResult<'tcx, ()>>(&mut self, f: F) {
@@ -170,7 +168,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for ConstantExtractor<'a, 'b, 'tcx> {
                     let return_ptr = this.ecx.alloc_ret_ptr(return_ty, cid.substs)?;
                     let mir = CachedMir::Owned(Rc::new(mir));
                     this.ecx.statics.insert(cid.clone(), return_ptr);
-                    this.ecx.push_stack_frame(this.def_id, constant.span, mir, this.substs, Some(return_ptr))
+                    this.ecx.push_stack_frame(this.def_id, constant.span, mir, this.substs, Some(return_ptr), None)
                 });
             }
         }

--- a/tests/compile-fail/cast_fn_ptr.rs
+++ b/tests/compile-fail/cast_fn_ptr.rs
@@ -1,9 +1,9 @@
 fn main() {
     fn f() {}
 
-    let g = unsafe { //~ ERROR tried to call a function of type
+    let g = unsafe {
         std::mem::transmute::<fn(), fn(i32)>(f)
     };
 
-    g(42)
+    g(42) //~ ERROR tried to call a function of type
 }

--- a/tests/compile-fail/execute_memory.rs
+++ b/tests/compile-fail/execute_memory.rs
@@ -4,7 +4,6 @@ fn main() {
     let x = box 42;
     unsafe {
         let f = std::mem::transmute::<Box<i32>, fn()>(x);
-        //~^ ERROR: tried to treat a memory pointer as a function pointer
-        f()
+        f() //~ ERROR: tried to treat a memory pointer as a function pointer
     }
 }

--- a/tests/compile-fail/oom.rs
+++ b/tests/compile-fail/oom.rs
@@ -6,6 +6,6 @@ fn bar() {
     assert_eq!(x, 6);
 }
 
-fn main() { //~ ERROR tried to allocate 4 more bytes, but only 0 bytes are free of the 0 byte memory
-    bar();
+fn main() {
+    bar(); //~ ERROR tried to allocate 4 more bytes, but only 0 bytes are free of the 0 byte memory
 }


### PR DESCRIPTION
previously we moved to the target block *before* calling a function, so when inspecting
the stack, it appeared as if we were in the first statement of the next block.

this also improves the error spans for some errors