### PR TITLE
only split the Fn* arguments in case of closures and function pointers

### DIFF
--- a/tests/run-pass/function_pointers.rs
+++ b/tests/run-pass/function_pointers.rs
@@ -6,6 +6,10 @@ fn g(i: i32) -> i32 {
     i*42
 }
 
+fn h(i: i32, j: i32) -> i32 {
+    j * i * 7
+}
+
 fn return_fn_ptr() -> fn() -> i32 {
     f
 }
@@ -22,6 +26,10 @@ fn indirect2<F: Fn(i32) -> i32>(f: F) -> i32 { f(10) }
 fn indirect_mut2<F: FnMut(i32) -> i32>(mut f: F) -> i32 { f(10) }
 fn indirect_once2<F: FnOnce(i32) -> i32>(f: F) -> i32 { f(10) }
 
+fn indirect3<F: Fn(i32, i32) -> i32>(f: F) -> i32 { f(10, 3) }
+fn indirect_mut3<F: FnMut(i32, i32) -> i32>(mut f: F) -> i32 { f(10, 3) }
+fn indirect_once3<F: FnOnce(i32, i32) -> i32>(f: F) -> i32 { f(10, 3) }
+
 fn main() {
     assert_eq!(call_fn_ptr(), 42);
     assert_eq!(indirect(f), 42);
@@ -30,6 +38,9 @@ fn main() {
     assert_eq!(indirect2(g), 420);
     assert_eq!(indirect_mut2(g), 420);
     assert_eq!(indirect_once2(g), 420);
+    assert_eq!(indirect3(h), 210);
+    assert_eq!(indirect_mut3(h), 210);
+    assert_eq!(indirect_once3(h), 210);
     assert!(return_fn_ptr() == f);
     assert!(return_fn_ptr() as unsafe fn() -> i32 == f as fn() -> i32 as unsafe fn() -> i32);
 }

--- a/tests/run-pass/overloaded-calls-simple.rs
+++ b/tests/run-pass/overloaded-calls-simple.rs
@@ -1,0 +1,33 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+#![feature(lang_items, unboxed_closures, fn_traits)]
+
+struct S3 {
+    x: i32,
+    y: i32,
+}
+
+impl FnOnce<(i32,i32)> for S3 {
+    type Output = i32;
+    extern "rust-call" fn call_once(self, (z,zz): (i32,i32)) -> i32 {
+        self.x * self.y * z * zz
+    }
+}
+
+fn main() {
+    let s = S3 {
+        x: 3,
+        y: 3,
+    };
+    let ans = s(3, 1);
+    assert_eq!(ans, 27);
+}


### PR DESCRIPTION
running on rustc run-pass right now to detect regressions