### PR TITLE
don't force allocations for most casts

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -687,10 +687,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
                     ReifyFnPointer => match self.operand_ty(operand).sty {
                         ty::TyFnDef(def_id, substs, fn_ty) => {
-                            // FIXME(solson)
-                            let dest = self.force_allocation(dest)?.to_ptr();
                             let fn_ptr = self.memory.create_fn_ptr(def_id, substs, fn_ty);
-                            self.memory.write_ptr(dest, fn_ptr)?;
+                            self.write_value(Value::ByVal(PrimVal::from_fn_ptr(fn_ptr)), dest, dest_ty)?;
                         },
                         ref other => bug!("reify fn pointer on {:?}", other),
                     },

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -695,13 +695,11 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
                     UnsafeFnPointer => match dest_ty.sty {
                         ty::TyFnPtr(unsafe_fn_ty) => {
-                            // FIXME(solson)
-                            let dest = self.force_allocation(dest)?.to_ptr();
                             let src = self.eval_operand(operand)?;
                             let ptr = src.read_ptr(&self.memory)?;
                             let (def_id, substs, _) = self.memory.get_fn(ptr.alloc_id)?;
                             let fn_ptr = self.memory.create_fn_ptr(def_id, substs, unsafe_fn_ty);
-                            self.memory.write_ptr(dest, fn_ptr)?;
+                            self.write_value(Value::ByVal(PrimVal::from_fn_ptr(fn_ptr)), dest, dest_ty)?;
                         },
                         ref other => bug!("fn to unsafe fn cast on {:?}", other),
                     },


### PR DESCRIPTION
now only `Arc<T>` -> `Arc<Trait>` casts require an allocation, which is basically the same reason field accesses require allocations.