### PR TITLE
Read discriminant as a signed integer.

### DIFF
--- a/src/interpreter/terminator/mod.rs
+++ b/src/interpreter/terminator/mod.rs
@@ -252,9 +252,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let adt_layout = self.type_layout(adt_ty);
 
         let discr_val = match *adt_layout {
-            General { discr, .. } | CEnum { discr, .. } => {
+            General { discr, .. } | CEnum { discr, signed: false, .. } => {
                 let discr_size = discr.size().bytes();
                 self.memory.read_uint(adt_ptr, discr_size as usize)?
+            }
+
+            CEnum { discr, signed: true, .. } => {
+                let discr_size = discr.size().bytes();
+                self.memory.read_int(adt_ptr, discr_size as usize)? as u64
             }
 
             RawNullablePointer { nndiscr, .. } => {

--- a/tests/run-pass/negative_discriminant.rs
+++ b/tests/run-pass/negative_discriminant.rs
@@ -1,0 +1,13 @@
+enum AB { A = -1, B = 1 }
+
+fn main() {
+    match AB::A {
+        AB::A => (),
+        AB::B => panic!(),
+    }
+
+    match AB::B {
+        AB::A => panic!(),
+        AB::B => (),
+    }
+}


### PR DESCRIPTION
This ensures it gets sign extended correctly.

Fixes #78