### PR TITLE
deallocate all locals on function exit and transitively freeze constants through pointers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use memory::Pointer;
 use rustc_const_math::ConstMathErr;
 use syntax::codemap::Span;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EvalError<'tcx> {
     FunctionPointerTyMismatch(Abi, &'tcx FnSig<'tcx>, &'tcx BareFnTy<'tcx>),
     NoMirFor(String),
@@ -48,6 +48,8 @@ pub enum EvalError<'tcx> {
     AssumptionNotHeld,
     InlineAsm,
     TypeNotPrimitive(Ty<'tcx>),
+    ReallocatedFrozenMemory,
+    DeallocatedFrozenMemory,
 }
 
 pub type EvalResult<'tcx, T> = Result<T, EvalError<'tcx>>;
@@ -110,6 +112,10 @@ impl<'tcx> Error for EvalError<'tcx> {
                 "cannot evaluate inline assembly",
             EvalError::TypeNotPrimitive(_) =>
                 "expected primitive type, got nonprimitive",
+            EvalError::ReallocatedFrozenMemory =>
+                "tried to reallocate frozen memory",
+            EvalError::DeallocatedFrozenMemory =>
+                "tried to deallocate frozen memory",
         }
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -364,6 +364,20 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let global_value = self.globals
                                        .get_mut(&id)
                                        .expect("global should have been cached (freeze)");
+                match global_value.data.expect("global should have been initialized") {
+                    Value::ByRef(ptr) => self.memory.freeze(ptr.alloc_id)?,
+                    Value::ByVal(val) => if let Some(alloc_id) = val.relocation {
+                        self.memory.freeze(alloc_id)?;
+                    },
+                    Value::ByValPair(a, b) => {
+                        if let Some(alloc_id) = a.relocation {
+                            self.memory.freeze(alloc_id)?;
+                        }
+                        if let Some(alloc_id) = b.relocation {
+                            self.memory.freeze(alloc_id)?;
+                        }
+                    },
+                }
                 if let Value::ByRef(ptr) = global_value.data.expect("global should have been initialized") {
                     self.memory.freeze(ptr.alloc_id)?;
                 }
@@ -375,7 +389,17 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             StackPopCleanup::Goto(target) => self.goto_block(target),
             StackPopCleanup::None => {},
         }
-        // TODO(solson): Deallocate local variables.
+        // check that all locals have been deallocated through StorageDead
+        for (i, local) in frame.locals.into_iter().enumerate() {
+            if let Some(Value::ByRef(ptr)) = local {
+                trace!("deallocating local {}: {:?}", i + 1, ptr);
+                self.memory.dump(ptr.alloc_id);
+                match self.memory.deallocate(ptr) {
+                    Ok(()) | Err(EvalError::DeallocatedFrozenMemory) => {},
+                    other => return other,
+                }
+            }
+        }
         Ok(())
     }
 
@@ -729,6 +753,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         // Skip the initial 0 intended for LLVM GEP.
         for field_index in path {
             let field_offset = self.get_field_offset(ty, field_index)?;
+            trace!("field_path_offset_and_ty: {}, {}, {:?}, {:?}", field_index, ty, field_offset, offset);
             ty = self.get_field_ty(ty, field_index)?;
             offset = offset.checked_add(field_offset, &self.tcx.data_layout).unwrap();
         }
@@ -1595,8 +1620,20 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     ) -> EvalResult<'tcx, ()> {
         let val = self.stack[frame].get_local(local);
         let val = f(self, val)?;
-        // can't use `set_local` here, because that's only meant for going to an initialized value
-        self.stack[frame].locals[local.index() - 1] = val;
+        if let Some(val) = val {
+            self.stack[frame].set_local(local, val);
+        } else {
+            self.deallocate_local(frame, local)?;
+        }
+        Ok(())
+    }
+
+    pub fn deallocate_local(&mut self, frame: usize, local: mir::Local) -> EvalResult<'tcx, ()> {
+        if let Some(Value::ByRef(ptr)) = self.stack[frame].get_local(local) {
+            self.memory.deallocate(ptr)?;
+        }
+        // Subtract 1 because we don't store a value for the ReturnPointer, the local with index 0.
+        self.stack[frame].locals[local.index() - 1] = None;
         Ok(())
     }
 }

--- a/src/interpreter/step.rs
+++ b/src/interpreter/step.rs
@@ -81,8 +81,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             Assign(ref lvalue, ref rvalue) => self.eval_rvalue_into_lvalue(rvalue, lvalue)?,
             SetDiscriminant { .. } => unimplemented!(),
 
-            // Miri can safely ignore these. Only translation needs them.
-            StorageLive(_) | StorageDead(_) => {}
+            // Miri can safely ignore these. Only translation needs it.
+            StorageLive(_) |
+            StorageDead(_) => {}
 
             // Defined to do nothing. These are added by optimization passes, to avoid changing the
             // size of MIR constantly.

--- a/tests/compile-fail/modifying_constants.rs
+++ b/tests/compile-fail/modifying_constants.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let x = &1; // the `&1` is promoted to a constant, but it used to be that only the pointer is frozen, not the pointee
+    let y = unsafe { &mut *(x as *const i32 as *mut i32) };
+    *y = 42; //~ ERROR tried to modify constant memory
+    assert_eq!(*x, 42);
+}

--- a/tests/run-pass/move-arg-3-unique.rs
+++ b/tests/run-pass/move-arg-3-unique.rs
@@ -1,0 +1,18 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unused_features, unused_variables)]
+#![feature(box_syntax)]
+
+pub fn main() {
+    let x = box 10;
+    let y = x;
+    assert_eq!(*y, 10);
+}


### PR DESCRIPTION
This should be pretty cool for const eval, since at the end all one has to do is traverse the allocation list and create llvm allocs for all frozen allocations. As long as something is reachable, it gets frozen, everything else is gone.

fixes #83