### PR TITLE
don't freeze globals twice

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -383,9 +383,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         }
                     },
                 }
-                if let Value::ByRef(ptr) = global_value.data.expect("global should have been initialized") {
-                    self.memory.freeze(ptr.alloc_id)?;
-                }
                 assert!(global_value.mutable);
                 global_value.mutable = false;
             } else {


### PR DESCRIPTION
Just a leftover piece of code. Right above it we already freeze that memory location