### PR TITLE
Remove PrimValKind field from PrimVal.

### DIFF
--- a/src/interpreter/cast.rs
+++ b/src/interpreter/cast.rs
@@ -97,8 +97,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     fn cast_ptr(&self, ptr: Pointer, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
         use rustc::ty::TypeVariants::*;
         match ty.sty {
-            TyRef(..) | TyRawPtr(_) | TyFnPtr(_) => Ok(PrimVal::from_ptr(ptr)),
-            TyInt(_) | TyUint(_) => self.transmute_primval(PrimVal::from_ptr(ptr), ty),
+            TyRef(..) | TyRawPtr(_) | TyFnPtr(_) | TyInt(_) | TyUint(_) =>
+                Ok(PrimVal::from_ptr(ptr)),
             _ => Err(EvalError::Unimplemented(format!("ptr to {:?} cast", ty))),
         }
     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1165,18 +1165,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             Value::ByRef(_) => bug!("follow_by_ref_value can't result in `ByRef`"),
 
             Value::ByVal(primval) => {
-                let new_primval = self.transmute_primval(primval, ty)?;
-                self.ensure_valid_value(new_primval, ty)?;
-                Ok(new_primval)
+                self.ensure_valid_value(primval, ty)?;
+                Ok(primval)
             }
 
             Value::ByValPair(..) => bug!("value_to_primval can't work with fat pointers"),
         }
-    }
-
-    // FIXME(solson): Delete this.
-    fn transmute_primval(&self, val: PrimVal, _ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
-        Ok(val)
     }
 
     fn write_primval(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -282,8 +282,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
     pub fn monomorphize(&self, ty: Ty<'tcx>, substs: &'tcx Substs<'tcx>) -> Ty<'tcx> {
         let substituted = ty.subst(self.tcx, substs);
-        let new = self.tcx.normalize_associated_type(&substituted);
-        new
+        self.tcx.normalize_associated_type(&substituted)
     }
 
     fn type_size(&self, ty: Ty<'tcx>) -> EvalResult<'tcx, Option<u64>> {

--- a/src/interpreter/terminator/intrinsics.rs
+++ b/src/interpreter/terminator/intrinsics.rs
@@ -221,7 +221,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "forget" => {}
 
             "init" => {
-                let size = self.type_size(dest_ty)?.expect("cannot init unsized value");;
+                let size = self.type_size(dest_ty)?.expect("cannot zero unsized value");;
                 let init = |this: &mut Self, val: Option<Value>| {
                     let zero_val = match val {
                         Some(Value::ByRef(ptr)) => {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -11,7 +11,7 @@ use rustc::ty::layout::{self, TargetDataLayout};
 use syntax::abi::Abi;
 
 use error::{EvalError, EvalResult};
-use primval::PrimVal;
+use primval::{PrimVal, PrimValKind};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Allocations and pointers
@@ -559,13 +559,18 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
         Ok(())
     }
 
-    pub fn write_primval(&mut self, dest: Pointer, val: PrimVal) -> EvalResult<'tcx, ()> {
+    pub fn write_primval(
+        &mut self,
+        dest: Pointer,
+        val: PrimVal,
+        kind: PrimValKind,
+    ) -> EvalResult<'tcx, ()> {
         if let Some(alloc_id) = val.relocation {
             return self.write_ptr(dest, Pointer::new(alloc_id, val.bits));
         }
 
         use primval::PrimValKind::*;
-        let (size, bits) = match val.kind {
+        let (size, bits) = match kind {
             I8 | U8 | Bool         => (1, val.bits as u8  as u64),
             I16 | U16              => (2, val.bits as u16 as u64),
             I32 | U32 | F32 | Char => (4, val.bits as u32 as u64),

--- a/src/primval.rs
+++ b/src/primval.rs
@@ -135,7 +135,7 @@ impl PrimVal {
     }
 
     pub fn try_as_uint<'tcx>(self) -> EvalResult<'tcx, u64> {
-        self.to_ptr().to_int().map(|val| val)
+        self.to_ptr().to_int()
     }
 
     pub fn to_u64(self) -> u64 {

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -61,8 +61,6 @@ fn compile_test() {
         let files: Box<Iterator<Item=_>> = if let Ok(path) = std::env::var("MIRI_RUSTC_TEST") {
             Box::new(files.chain(std::fs::read_dir(path).unwrap()))
         } else {
-            // print traces only when not running on the rust run-pass test suite (since tracing is slow)
-            std::env::set_var("MIRI_LOG", "trace");
             Box::new(files)
         };
         let mut mir_not_found = 0;


### PR DESCRIPTION
@oli-obk @eddyb I wrote this code a month ago, but just today rebased it over @oli-obk's many changes (:heart:). All the tests are passing, but the code is not fresh in my mind and some nonsense might have crept in with the rebase, so I'd like some external code review before merging.

----

This is a refactoring we've wanted to do for quite a while, ever since @eddyb suggested the current `PrimVal` representation to me. In a future PR I think we will want to go further and remove `PrimValKind` entirely, making all choices based on `Ty`s instead.

I think there are also some more simplifications this refactoring enables that I haven't done yet, e.g. in the casting code.