### PR TITLE
tuple struct constructors and uninitialized fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tex/*/out
 *.dot
 *.mir
+*.rs.bk

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
+- rustup target add i686-unknown-linux-gnu
+- rustup target add i686-pc-windows-gnu
+- rustup target add i686-pc-windows-msvc
 script:
 - |
   env RUST_SYSROOT=$HOME/rust travis-cargo build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
-- rustup target add i686-unknown-linux-gnu
-- rustup target add i686-pc-windows-gnu
-- rustup target add i686-pc-windows-msvc
+- ls -lh ~/rust
+- ~/rust/rustup target add i686-unknown-linux-gnu
+- ~/rust/rustup target add i686-pc-windows-gnu
+- ~/rust/rustup target add i686-pc-windows-msvc
 script:
 - |
   env RUST_SYSROOT=$HOME/rust travis-cargo build &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&
   export PATH=$HOME/.local/bin:$PATH
-- ls -lh ~/rust
-- ~/rust/rustup target add i686-unknown-linux-gnu
-- ~/rust/rustup target add i686-pc-windows-gnu
-- ~/rust/rustup target add i686-pc-windows-msvc
+- sh ~/rust-installer/rustup.sh --add-target=i686-unknown-linux-gnu --prefix=/home/travis/rust -y --disable-sudo
+- sh ~/rust-installer/rustup.sh --add-target=i686-pc-windows-gnu --prefix=/home/travis/rust -y --disable-sudo
+- sh ~/rust-installer/rustup.sh --add-target=i686-pc-windows-msvc --prefix=/home/travis/rust p-y --disable-sudo
 script:
 - |
   env RUST_SYSROOT=$HOME/rust travis-cargo build &&

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "miri"
 version = "0.1.0"
 dependencies = [
- "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.0.0 (git+https://github.com/quininer/byteorder.git?branch=i128)",
  "compiletest_rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -19,8 +19,8 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.0"
+source = "git+https://github.com/quininer/byteorder.git?branch=i128#ef51df297aa833d0b6639aae328a95597fc07d75"
 
 [[package]]
 name = "compiletest_rs"
@@ -136,7 +136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-"checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
+"checksum byteorder 1.0.0 (git+https://github.com/quininer/byteorder.git?branch=i128)" = "<none>"
 "checksum compiletest_rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f3f344389765ad7bec166f64c1b39ed6dd2b54d81c4c5dd8af789169351d380c"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -51,12 +51,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -69,7 +69,7 @@ name = "log_settings"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -77,29 +77,29 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -108,7 +108,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -140,14 +140,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum compiletest_rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f3f344389765ad7bec166f64c1b39ed6dd2b54d81c4c5dd8af789169351d380c"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
-"checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
+"checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
+"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum log_settings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3d382732ea0fbc09790c4899db3255bdea0fc78b54bf234bd18a63bb603915b6"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-"checksum regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)" = "64b03446c466d35b42f2a8b203c8e03ed8b91c0f17b56e1f84f7210a257aa665"
-"checksum regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279401017ae31cf4e15344aa3f085d0e2e5c1e70067289ef906906fdbe92c8fd"
-"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ test = false
 test = false
 
 [dependencies]
-byteorder = "0.4.2"
+#byteorder = "0.4.2"
+byteorder = { git = "https://github.com/quininer/byteorder.git", branch = "i128", features = ["i128"]}
 env_logger = "0.3.3"
 log = "0.3.6"
 log_settings = "0.1.1"

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_private)]
+#![feature(rustc_private, i128_type)]
 
 extern crate getopts;
 extern crate miri;
@@ -54,7 +54,7 @@ fn resource_limits_from_attributes(state: &CompileState) -> miri::ResourceLimits
     let mut limits = miri::ResourceLimits::default();
     let krate = state.hir_crate.as_ref().unwrap();
     let err_msg = "miri attributes need to be in the form `miri(key = value)`";
-    let extract_int = |lit: &syntax::ast::Lit| -> u64 {
+    let extract_int = |lit: &syntax::ast::Lit| -> u128 {
         match lit.node {
             syntax::ast::LitKind::Int(i, _) => i,
             _ => state.session.span_fatal(lit.span, "expected an integer literal"),
@@ -67,8 +67,8 @@ fn resource_limits_from_attributes(state: &CompileState) -> miri::ResourceLimits
                 if let NestedMetaItemKind::MetaItem(ref inner) = item.node {
                     if let MetaItemKind::NameValue(ref value) = inner.node {
                         match &inner.name().as_str()[..] {
-                            "memory_size" => limits.memory_size = extract_int(value),
-                            "step_limit" => limits.step_limit = extract_int(value),
+                            "memory_size" => limits.memory_size = extract_int(value) as u64,
+                            "step_limit" => limits.step_limit = extract_int(value) as u64,
                             "stack_limit" => limits.stack_limit = extract_int(value) as usize,
                             _ => state.session.span_err(item.span, "unknown miri attribute"),
                         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ pub enum EvalError<'tcx> {
     ExecuteMemory,
     ArrayIndexOutOfBounds(Span, u64, u64),
     Math(Span, ConstMathErr),
-    InvalidChar(u64),
+    InvalidChar(u128),
     OutOfMemory {
         allocation_size: u64,
         memory_size: u64,

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,11 @@ pub enum EvalError<'tcx> {
     ReallocatedFrozenMemory,
     DeallocatedFrozenMemory,
     Layout(layout::LayoutError<'tcx>),
+    Abort,
+    Panic {
+        file: String,
+        line: u32,
+    },
 }
 
 pub type EvalResult<'tcx, T> = Result<T, EvalError<'tcx>>;
@@ -122,6 +127,10 @@ impl<'tcx> Error for EvalError<'tcx> {
                 "rustc layout computation failed",
             EvalError::UnterminatedCString(_) =>
                 "attempted to get length of a null terminated string, but no null found before end of allocation",
+            EvalError::Abort =>
+                "`abort` intrinsic reached",
+            EvalError::Panic { .. } =>
+                "panic!",
         }
     }
 
@@ -154,6 +163,8 @@ impl<'tcx> fmt::Display for EvalError<'tcx> {
                 write!(f, "expected primitive type, got {}", ty),
             EvalError::Layout(ref err) =>
                 write!(f, "rustc layout computation failed: {:?}", err),
+            EvalError::Panic { ref file, line } =>
+                write!(f, "panicked at {}:{}", file, line),
             _ => write!(f, "{}", self.description()),
         }
     }

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -43,6 +43,10 @@ pub struct EvalContext<'a, 'tcx: 'a> {
     /// This prevents infinite loops and huge computations from freezing up const eval.
     /// Remove once halting problem is solved.
     pub(super) steps_remaining: u64,
+
+    // FIXME: also add destructors
+    pub(super) pthread: HashMap<i32, Pointer>,
+    pub(super) next_pthread_key: i32,
 }
 
 /// A stack frame.
@@ -137,6 +141,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             stack: Vec::new(),
             stack_limit: limits.stack_limit,
             steps_remaining: limits.step_limit,
+            pthread: HashMap::new(),
+            next_pthread_key: 0,
         }
     }
 

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -364,18 +364,44 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         Ok(())
     }
 
-    fn assign_fields<I: IntoIterator<Item = u64>>(
+    pub fn assign_discr_and_fields<
+        I: IntoIterator<Item = u64>,
+        V: IntoValTyPair<'tcx>,
+        J: IntoIterator<Item = V>,
+    >(
         &mut self,
         dest: Lvalue<'tcx>,
         offsets: I,
-        operands: &[mir::Operand<'tcx>],
+        operands: J,
+        discr_val: u64,
+        discr_size: u64,
+    ) -> EvalResult<'tcx, ()> {
+        // FIXME(solson)
+        let dest_ptr = self.force_allocation(dest)?.to_ptr();
+
+        let mut offsets = offsets.into_iter();
+        let discr_offset = offsets.next().unwrap();
+        let discr_dest = dest_ptr.offset(discr_offset);
+        self.memory.write_uint(discr_dest, discr_val, discr_size)?;
+
+        self.assign_fields(dest, offsets, operands)
+    }
+
+    pub fn assign_fields<
+        I: IntoIterator<Item = u64>,
+        V: IntoValTyPair<'tcx>,
+        J: IntoIterator<Item = V>,
+    >(
+        &mut self,
+        dest: Lvalue<'tcx>,
+        offsets: I,
+        operands: J,
     ) -> EvalResult<'tcx, ()> {
         // FIXME(solson)
         let dest = self.force_allocation(dest)?.to_ptr();
 
         for (offset, operand) in offsets.into_iter().zip(operands) {
-            let value = self.eval_operand(operand)?;
-            let value_ty = self.operand_ty(operand);
+            let (value, value_ty) = operand.into_val_ty_pair(self)?;
             let field_dest = dest.offset(offset);
             self.write_value_to_ptr(value, field_dest, value_ty)?;
         }
@@ -440,18 +466,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         if let mir::AggregateKind::Adt(adt_def, variant, _, _) = *kind {
                             let discr_val = adt_def.variants[variant].disr_val.to_u64_unchecked();
                             let discr_size = discr.size().bytes();
-                            let discr_offset = variants[variant].offsets[0].bytes();
 
-                            // FIXME(solson)
-                            let dest = self.force_allocation(dest)?;
-                            let discr_dest = (dest.to_ptr()).offset(discr_offset);
-
-                            self.memory.write_uint(discr_dest, discr_val, discr_size)?;
-
-                            // Don't include the first offset; it's for the discriminant.
-                            let field_offsets = variants[variant].offsets.iter().skip(1)
-                                .map(|s| s.bytes());
-                            self.assign_fields(dest, field_offsets, operands)?;
+                            self.assign_discr_and_fields(
+                                dest,
+                                variants[variant].offsets.iter().cloned().map(Size::bytes),
+                                operands,
+                                discr_val,
+                                discr_size,
+                            )?;
                         } else {
                             bug!("tried to assign {:?} to Layout::General", kind);
                         }
@@ -1471,4 +1493,22 @@ impl IntegerExt for layout::Integer {
 pub fn monomorphize_field_ty<'a, 'tcx:'a >(tcx: TyCtxt<'a, 'tcx, 'tcx>, f: &ty::FieldDef, substs: &'tcx Substs<'tcx>) -> Ty<'tcx> {
     let substituted = &f.ty(tcx, substs);
     tcx.normalize_associated_type(&substituted)
+}
+
+pub trait IntoValTyPair<'tcx> {
+    fn into_val_ty_pair<'a>(self, ecx: &mut EvalContext<'a, 'tcx>) -> EvalResult<'tcx, (Value, Ty<'tcx>)> where 'tcx: 'a;
+}
+
+impl<'tcx> IntoValTyPair<'tcx> for (Value, Ty<'tcx>) {
+    fn into_val_ty_pair<'a>(self, _: &mut EvalContext<'a, 'tcx>) -> EvalResult<'tcx, (Value, Ty<'tcx>)> where 'tcx: 'a {
+        Ok(self)
+    }
+}
+
+impl<'b, 'tcx: 'b> IntoValTyPair<'tcx> for &'b mir::Operand<'tcx> {
+    fn into_val_ty_pair<'a>(self, ecx: &mut EvalContext<'a, 'tcx>) -> EvalResult<'tcx, (Value, Ty<'tcx>)> where 'tcx: 'a {
+        let value = ecx.eval_operand(self)?;
+        let value_ty = ecx.operand_ty(self);
+        Ok((value, value_ty))
+    }
 }

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -715,7 +715,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         Ok((offset, ty))
     }
 
-    fn get_field_ty(&self, ty: Ty<'tcx>, field_index: usize) -> EvalResult<'tcx, Ty<'tcx>> {
+    pub fn get_field_ty(&self, ty: Ty<'tcx>, field_index: usize) -> EvalResult<'tcx, Ty<'tcx>> {
         match ty.sty {
             ty::TyAdt(adt_def, substs) => {
                 Ok(adt_def.struct_variant().fields[field_index].ty(self.tcx, substs))
@@ -1038,7 +1038,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         Ok(())
     }
 
-    pub(super) fn ty_to_primval_kind(&self, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimValKind> {
+    pub fn ty_to_primval_kind(&self, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimValKind> {
         use syntax::ast::FloatTy;
 
         let kind = match ty.sty {

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -175,7 +175,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let ptr = self.memory.allocate(s.len() as u64, 1)?;
         self.memory.write_bytes(ptr, s.as_bytes())?;
         self.memory.freeze(ptr.alloc_id)?;
-        Ok(Value::ByValPair(PrimVal::Ptr(ptr), PrimVal::from_u64(s.len() as u64)))
+        Ok(Value::ByValPair(PrimVal::Ptr(ptr), PrimVal::from_u128(s.len() as u128)))
     }
 
     pub(super) fn const_to_value(&mut self, const_val: &ConstVal) -> EvalResult<'tcx, Value> {
@@ -183,7 +183,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         use rustc_const_math::ConstFloat;
 
         let primval = match *const_val {
-            Integral(const_int) => PrimVal::Bytes(const_int.to_u64_unchecked()),
+            Integral(const_int) => PrimVal::Bytes(const_int.to_u128_unchecked()),
 
             Float(ConstFloat::F32(f)) => PrimVal::from_f32(f),
             Float(ConstFloat::F64(f)) => PrimVal::from_f64(f),
@@ -370,7 +370,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         dest: Lvalue<'tcx>,
         offsets: I,
         operands: J,
-        discr_val: u64,
+        discr_val: u128,
         discr_size: u64,
     ) -> EvalResult<'tcx, ()> {
         // FIXME(solson)
@@ -461,7 +461,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
                     General { discr, ref variants, .. } => {
                         if let mir::AggregateKind::Adt(adt_def, variant, _, _) = *kind {
-                            let discr_val = adt_def.variants[variant].disr_val.to_u64_unchecked();
+                            let discr_val = adt_def.variants[variant].disr_val.to_u128_unchecked();
                             let discr_size = discr.size().bytes();
 
                             self.assign_discr_and_fields(
@@ -525,7 +525,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     CEnum { .. } => {
                         assert_eq!(operands.len(), 0);
                         if let mir::AggregateKind::Adt(adt_def, variant, _, _) = *kind {
-                            let n = adt_def.variants[variant].disr_val.to_u64_unchecked();
+                            let n = adt_def.variants[variant].disr_val.to_u128_unchecked();
                             self.write_primval(dest, PrimVal::Bytes(n), dest_ty)?;
                         } else {
                             bug!("tried to assign {:?} to Layout::CEnum", kind);
@@ -580,7 +580,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let src = self.eval_lvalue(lvalue)?;
                 let ty = self.lvalue_ty(lvalue);
                 let (_, len) = src.elem_ty_and_len(ty);
-                self.write_primval(dest, PrimVal::from_u64(len), dest_ty)?;
+                self.write_primval(dest, PrimVal::from_u128(len as u128), dest_ty)?;
             }
 
             Ref(_, _, ref lvalue) => {
@@ -590,7 +590,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
                 let val = match extra {
                     LvalueExtra::None => Value::ByVal(ptr),
-                    LvalueExtra::Length(len) => Value::ByValPair(ptr, PrimVal::from_u64(len)),
+                    LvalueExtra::Length(len) => Value::ByValPair(ptr, PrimVal::from_u128(len as u128)),
                     LvalueExtra::Vtable(vtable) => Value::ByValPair(ptr, PrimVal::Ptr(vtable)),
                     LvalueExtra::DowncastVariant(..) =>
                         bug!("attempted to take a reference to an enum downcast lvalue"),
@@ -1052,6 +1052,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     I16 => 2,
                     I32 => 4,
                     I64 => 8,
+                    I128 => 16,
                     Is => self.memory.pointer_size(),
                 };
                 PrimValKind::from_int_size(size)
@@ -1064,6 +1065,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     U16 => 2,
                     U32 => 4,
                     U64 => 8,
+                    U128 => 16,
                     Us => self.memory.pointer_size(),
                 };
                 PrimValKind::from_uint_size(size)
@@ -1116,7 +1118,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             ty::TyBool if val.to_bytes()? > 1 => Err(EvalError::InvalidBool),
 
             ty::TyChar if ::std::char::from_u32(val.to_bytes()? as u32).is_none()
-                => Err(EvalError::InvalidChar(val.to_bytes()? as u32 as u64)),
+                => Err(EvalError::InvalidChar(val.to_bytes()? as u32 as u128)),
 
             _ => Ok(()),
         }
@@ -1139,7 +1141,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let c = self.memory.read_uint(ptr, 4)? as u32;
                 match ::std::char::from_u32(c) {
                     Some(ch) => PrimVal::from_char(ch),
-                    None => return Err(EvalError::InvalidChar(c as u64)),
+                    None => return Err(EvalError::InvalidChar(c as u128)),
                 }
             }
 
@@ -1150,9 +1152,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     I16 => 2,
                     I32 => 4,
                     I64 => 8,
+                    I128 => 16,
                     Is => self.memory.pointer_size(),
                 };
-                PrimVal::from_i64(self.memory.read_int(ptr, size)?)
+                PrimVal::from_i128(self.memory.read_int(ptr, size)?)
             }
 
             ty::TyUint(uint_ty) => {
@@ -1162,9 +1165,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     U16 => 2,
                     U32 => 4,
                     U64 => 8,
+                    U128 => 16,
                     Us => self.memory.pointer_size(),
                 };
-                PrimVal::from_u64(self.memory.read_uint(ptr, size)?)
+                PrimVal::from_u128(self.memory.read_uint(ptr, size)?)
             }
 
             ty::TyFloat(FloatTy::F32) => PrimVal::from_f32(self.memory.read_f32(ptr)?),
@@ -1183,7 +1187,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     let extra = match self.tcx.struct_tail(ty).sty {
                         ty::TyDynamic(..) => PrimVal::Ptr(self.memory.read_ptr(extra)?),
                         ty::TySlice(..) |
-                        ty::TyStr => PrimVal::from_u64(self.memory.read_usize(extra)?),
+                        ty::TyStr => PrimVal::from_u128(self.memory.read_usize(extra)? as u128),
                         _ => bug!("unsized primval ptr read from {:?}", ty),
                     };
                     return Ok(Some(Value::ByValPair(PrimVal::Ptr(p), extra)));
@@ -1195,9 +1199,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 if let CEnum { discr, signed, .. } = *self.type_layout(ty)? {
                     let size = discr.size().bytes();
                     if signed {
-                        PrimVal::from_i64(self.memory.read_int(ptr, size)?)
+                        PrimVal::from_i128(self.memory.read_int(ptr, size)?)
                     } else {
-                        PrimVal::from_u64(self.memory.read_uint(ptr, size)?)
+                        PrimVal::from_u128(self.memory.read_uint(ptr, size)?)
                     }
                 } else {
                     return Ok(None);
@@ -1244,7 +1248,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 match (&src_pointee_ty.sty, &dest_pointee_ty.sty) {
                     (&ty::TyArray(_, length), &ty::TySlice(_)) => {
                         let ptr = src.read_ptr(&self.memory)?;
-                        let len = PrimVal::from_u64(length as u64);
+                        let len = PrimVal::from_u128(length as u128);
                         let ptr = PrimVal::Ptr(ptr);
                         self.write_value(Value::ByValPair(ptr, len), dest, dest_ty)?;
                     }
@@ -1478,6 +1482,7 @@ impl IntegerExt for layout::Integer {
             I16 => Size::from_bits(16),
             I32 => Size::from_bits(32),
             I64 => Size::from_bits(64),
+            I128 => Size::from_bits(128),
         }
     }
 }

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -500,7 +500,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         }
                     }
 
-                    StructWrappedNullablePointer { nndiscr, ref nonnull, ref discrfield } => {
+                    StructWrappedNullablePointer { nndiscr, ref nonnull, ref discrfield, .. } => {
                         if let mir::AggregateKind::Adt(_, variant, _, _) = *kind {
                             if nndiscr == variant as u64 {
                                 let offsets = nonnull.offsets.iter().map(|s| s.bytes());

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -547,10 +547,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         let operand = &operands[0];
                         let value = self.eval_operand(operand)?;
                         let value_ty = self.operand_ty(operand);
-
-                        // FIXME(solson)
-                        let dest = self.force_allocation(dest)?;
-
                         self.write_value(value, dest, value_ty)?;
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
     collections_bound,
     pub_restricted,
     rustc_private,
+    i128_type,
 )]
 
 // From rustc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(
     btree_range,
-    cell_extras,
     collections,
     collections_bound,
     pub_restricted,

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -282,7 +282,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized");
                 let n_ptr = self.eval_operand(operand)?;
                 let usize = self.tcx.types.usize;
-                let n = self.value_to_primval(n_ptr, usize)?.to_u64()?;
+                let n = self.value_to_primval(n_ptr, usize)?.to_u128()?;
+                // we read a target usize, it can't be 128 bits
+                assert_eq!(n as u64 as u128, n);
+                let n = n as u64;
                 assert!(n < len);
                 let ptr = base_ptr.offset(n * elem_size);
                 (ptr, LvalueExtra::None)

--- a/src/step.rs
+++ b/src/step.rs
@@ -175,7 +175,7 @@ impl<'a, 'b, 'tcx> ConstantExtractor<'a, 'b, 'tcx> {
         self.try(|this| {
             if this.weak_linkage(def_id) {
                 let data = match this.ecx.type_size(ty)?.expect("statics/consts can't be unsized") {
-                    0...8 => Value::ByVal(PrimVal::new(0)),
+                    0...8 => Value::ByVal(PrimVal::from_u64(0)),
                     n => {
                         let ptr = this.ecx.memory.allocate(n, 1)?;
                         this.ecx.memory.write_repeat(ptr, 0, n)?;
@@ -183,7 +183,7 @@ impl<'a, 'b, 'tcx> ConstantExtractor<'a, 'b, 'tcx> {
                     },
                 };
                 this.ecx.globals.insert(cid, Global {
-                    data: Some(data),
+                    value: data,
                     mutable: !immutable,
                     ty: ty,
                 });

--- a/src/step.rs
+++ b/src/step.rs
@@ -103,7 +103,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         let dest = self.force_allocation(dest)?;
                         let discr_dest = (dest.to_ptr()).offset(discr_offset);
 
-                        self.memory.write_uint(discr_dest, variant_index as u64, discr_size)?;
+                        self.memory.write_uint(discr_dest, variant_index as u128, discr_size)?;
                     }
 
                     Layout::RawNullablePointer { nndiscr, .. } => {
@@ -175,7 +175,7 @@ impl<'a, 'b, 'tcx> ConstantExtractor<'a, 'b, 'tcx> {
         self.try(|this| {
             if this.weak_linkage(def_id) {
                 let data = match this.ecx.type_size(ty)?.expect("statics/consts can't be unsized") {
-                    0...8 => Value::ByVal(PrimVal::from_u64(0)),
+                    0...8 => Value::ByVal(PrimVal::from_u128(0)),
                     n => {
                         let ptr = this.ecx.memory.allocate(n, 1)?;
                         this.ecx.memory.write_repeat(ptr, 0, n)?;

--- a/src/step.rs
+++ b/src/step.rs
@@ -15,6 +15,8 @@ use error::{EvalResult, EvalError};
 use eval_context::{EvalContext, StackPopCleanup, MirRef};
 use lvalue::{Global, GlobalId, Lvalue};
 use syntax::codemap::Span;
+use syntax::attr;
+use value::{Value, PrimVal};
 
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub fn inc_step_counter_and_check_limit(&mut self, n: u64) -> EvalResult<'tcx, ()> {
@@ -152,6 +154,13 @@ struct ConstantExtractor<'a, 'b: 'a, 'tcx: 'b> {
 }
 
 impl<'a, 'b, 'tcx> ConstantExtractor<'a, 'b, 'tcx> {
+    fn weak_linkage(&self, def_id: DefId) -> bool {
+        let attributes = self.ecx.tcx.get_attrs(def_id);
+        let attr = attr::first_attr_value_str_by_name(&attributes, "linkage");
+        trace!("linkage: {:?}", attr);
+        attr.map_or(false, |name| &*name.as_str() == "weak" || &*name.as_str() == "extern_weak")
+    }
+
     fn global_item(&mut self, def_id: DefId, substs: &'tcx subst::Substs<'tcx>, span: Span, immutable: bool) {
         let cid = GlobalId {
             def_id: def_id,
@@ -161,15 +170,34 @@ impl<'a, 'b, 'tcx> ConstantExtractor<'a, 'b, 'tcx> {
         if self.ecx.globals.contains_key(&cid) {
             return;
         }
+        let ty = self.ecx.tcx.item_type(def_id);
+        let immutable = immutable && !ty.type_contents(self.ecx.tcx).interior_unsafe();
         self.try(|this| {
-            let mir = this.ecx.load_mir(def_id)?;
-            this.ecx.globals.insert(cid, Global::uninitialized(mir.return_ty));
-            let cleanup = if immutable && !mir.return_ty.type_contents(this.ecx.tcx).interior_unsafe() {
-                StackPopCleanup::Freeze
+            if this.weak_linkage(def_id) {
+                let data = match this.ecx.type_size(ty)?.expect("statics/consts can't be unsized") {
+                    0...8 => Value::ByVal(PrimVal::new(0)),
+                    n => {
+                        let ptr = this.ecx.memory.allocate(n, 1)?;
+                        this.ecx.memory.write_repeat(ptr, 0, n)?;
+                        Value::ByRef(ptr)
+                    },
+                };
+                this.ecx.globals.insert(cid, Global {
+                    data: Some(data),
+                    mutable: !immutable,
+                    ty: ty,
+                });
+                Ok(())
             } else {
-                StackPopCleanup::None
-            };
-            this.ecx.push_stack_frame(def_id, span, mir, substs, Lvalue::Global(cid), cleanup, Vec::new())
+                this.ecx.globals.insert(cid, Global::uninitialized(ty));
+                let cleanup = if immutable {
+                    StackPopCleanup::Freeze
+                } else {
+                    StackPopCleanup::None
+                };
+                let mir = this.ecx.load_mir(def_id)?;
+                this.ecx.push_stack_frame(def_id, span, mir, substs, Lvalue::Global(cid), cleanup, Vec::new())
+            }
         });
     }
     fn try<F: FnOnce(&mut Self) -> EvalResult<'tcx, ()>>(&mut self, f: F) {

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -66,6 +66,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "atomic_store" |
+            "atomic_store_relaxed" |
+            "atomic_store_rel" |
             "volatile_store" => {
                 let ty = substs.type_at(0);
                 let dest = arg_vals[0].read_ptr(&self.memory)?;
@@ -90,6 +92,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 self.write_primval(Lvalue::from_ptr(ptr), change, ty)?;
             }
 
+            "atomic_cxchg_relaxed" |
             "atomic_cxchg" => {
                 let ty = substs.type_at(0);
                 let ptr = arg_vals[0].read_ptr(&self.memory)?;
@@ -108,6 +111,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 self.write_primval(Lvalue::from_ptr(ptr), change, ty)?;
             }
 
+            "atomic_xadd" |
             "atomic_xadd_relaxed" => {
                 let ty = substs.type_at(0);
                 let ptr = arg_vals[0].read_ptr(&self.memory)?;

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -156,7 +156,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let elem_align = self.type_align(elem_ty)?;
                 let src = arg_vals[0].read_ptr(&self.memory)?;
                 let dest = arg_vals[1].read_ptr(&self.memory)?;
-                let count = self.value_to_primval(arg_vals[2], usize)?.to_u128()? as u64;
+                let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                 self.memory.copy(src, dest, count * elem_size, elem_align)?;
             }
 
@@ -189,7 +189,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         ptr: ptr.to_ptr()?,
                         extra: match self.tcx.struct_tail(ty).sty {
                             ty::TyDynamic(..) => LvalueExtra::Vtable(extra.to_ptr()?),
-                            ty::TyStr | ty::TySlice(_) => LvalueExtra::Length(extra.to_u128()? as u64),
+                            ty::TyStr | ty::TySlice(_) => LvalueExtra::Length(extra.to_u64()?),
                             _ => bug!("invalid fat pointer type: {}", ptr_ty),
                         },
                     },

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -45,8 +45,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "arith_offset" => {
                 let ptr = arg_vals[0].read_ptr(&self.memory)?;
-                let offset = self.value_to_primval(arg_vals[1], isize)?.to_i64()?;
-                let new_ptr = ptr.signed_offset(offset);
+                let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()?;
+                let new_ptr = ptr.signed_offset(offset as i64);
                 self.write_primval(dest, PrimVal::Ptr(new_ptr), dest_ty)?;
             }
 
@@ -156,7 +156,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let elem_align = self.type_align(elem_ty)?;
                 let src = arg_vals[0].read_ptr(&self.memory)?;
                 let dest = arg_vals[1].read_ptr(&self.memory)?;
-                let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
+                let count = self.value_to_primval(arg_vals[2], usize)?.to_u128()? as u64;
                 self.memory.copy(src, dest, count * elem_size, elem_align)?;
             }
 
@@ -189,7 +189,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         ptr: ptr.to_ptr()?,
                         extra: match self.tcx.struct_tail(ty).sty {
                             ty::TyDynamic(..) => LvalueExtra::Vtable(extra.to_ptr()?),
-                            ty::TyStr | ty::TySlice(_) => LvalueExtra::Length(extra.to_u64()?),
+                            ty::TyStr | ty::TySlice(_) => LvalueExtra::Length(extra.to_u128()? as u64),
                             _ => bug!("invalid fat pointer type: {}", ptr_ty),
                         },
                     },
@@ -264,7 +264,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "min_align_of" => {
                 let elem_ty = substs.type_at(0);
                 let elem_align = self.type_align(elem_ty)?;
-                let align_val = PrimVal::from_u64(elem_align as u64);
+                let align_val = PrimVal::from_u128(elem_align as u128);
                 self.write_primval(dest, align_val, dest_ty)?;
             }
 
@@ -272,7 +272,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let ty = substs.type_at(0);
                 let layout = self.type_layout(ty)?;
                 let align = layout.align(&self.tcx.data_layout).pref();
-                let align_val = PrimVal::from_u64(align);
+                let align_val = PrimVal::from_u128(align as u128);
                 self.write_primval(dest, align_val, dest_ty)?;
             }
 
@@ -293,7 +293,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let pointee_ty = substs.type_at(0);
                 // FIXME: assuming here that type size is < i64::max_value()
                 let pointee_size = self.type_size(pointee_ty)?.expect("cannot offset a pointer to an unsized type") as i64;
-                let offset = self.value_to_primval(arg_vals[1], isize)?.to_i64()?;
+                let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()? as i64;
 
                 let ptr = arg_vals[0].read_ptr(&self.memory)?;
                 let result_ptr = ptr.signed_offset(offset * pointee_size);
@@ -314,13 +314,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "powif32" => {
                 let f = self.value_to_primval(arg_vals[0], f32)?.to_f32()?;
-                let i = self.value_to_primval(arg_vals[1], i32)?.to_i64()?;
+                let i = self.value_to_primval(arg_vals[1], i32)?.to_i128()?;
                 self.write_primval(dest, PrimVal::from_f32(f.powi(i as i32)), dest_ty)?;
             }
 
             "powif64" => {
                 let f = self.value_to_primval(arg_vals[0], f64)?.to_f64()?;
-                let i = self.value_to_primval(arg_vals[1], i32)?.to_i64()?;
+                let i = self.value_to_primval(arg_vals[1], i32)?.to_i128()?;
                 self.write_primval(dest, PrimVal::from_f64(f.powi(i as i32)), dest_ty)?;
             }
 
@@ -340,21 +340,21 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 // `size_of_val` intrinsic, then change this back to
                 // .expect("size_of intrinsic called on unsized value")
                 // see https://github.com/rust-lang/rust/pull/37708
-                let size = self.type_size(ty)?.unwrap_or(!0) as u64;
-                self.write_primval(dest, PrimVal::from_u64(size), dest_ty)?;
+                let size = self.type_size(ty)?.unwrap_or(!0) as u128;
+                self.write_primval(dest, PrimVal::from_u128(size), dest_ty)?;
             }
 
             "size_of_val" => {
                 let ty = substs.type_at(0);
                 let (size, _) = self.size_and_align_of_dst(ty, arg_vals[0])?;
-                self.write_primval(dest, PrimVal::from_u64(size), dest_ty)?;
+                self.write_primval(dest, PrimVal::from_u128(size as u128), dest_ty)?;
             }
 
             "min_align_of_val" |
             "align_of_val" => {
                 let ty = substs.type_at(0);
                 let (_, align) = self.size_and_align_of_dst(ty, arg_vals[0])?;
-                self.write_primval(dest, PrimVal::from_u64(align), dest_ty)?;
+                self.write_primval(dest, PrimVal::from_u128(align as u128), dest_ty)?;
             }
 
             "type_name" => {
@@ -366,7 +366,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "type_id" => {
                 let ty = substs.type_at(0);
                 let n = self.tcx.type_id_hash(ty);
-                self.write_primval(dest, PrimVal::Bytes(n), dest_ty)?;
+                self.write_primval(dest, PrimVal::Bytes(n as u128), dest_ty)?;
             }
 
             "transmute" => {
@@ -518,14 +518,16 @@ fn numeric_intrinsic<'tcx>(
 
             use value::PrimValKind::*;
             let result_bytes = match $kind {
-                I8 => (bytes as i8).$method() as u64,
-                U8 => (bytes as u8).$method() as u64,
-                I16 => (bytes as i16).$method() as u64,
-                U16 => (bytes as u16).$method() as u64,
-                I32 => (bytes as i32).$method() as u64,
-                U32 => (bytes as u32).$method() as u64,
-                I64 => (bytes as i64).$method() as u64,
-                U64 => bytes.$method() as u64,
+                I8 => (bytes as i8).$method() as u128,
+                U8 => (bytes as u8).$method() as u128,
+                I16 => (bytes as i16).$method() as u128,
+                U16 => (bytes as u16).$method() as u128,
+                I32 => (bytes as i32).$method() as u128,
+                U32 => (bytes as u32).$method() as u128,
+                I64 => (bytes as i64).$method() as u128,
+                U64 => (bytes as u64).$method() as u128,
+                I128 => (bytes as i128).$method() as u128,
+                U128 => bytes.$method() as u128,
                 _ => bug!("invalid `{}` argument: {:?}", $name, val),
             };
 

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -229,6 +229,34 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         (def_id, substs, Vec::new())
                     };
 
+                // FIXME(eddyb) Detect ADT constructors more efficiently.
+                if let Some(adt_def) = fn_ty.sig.skip_binder().output().ty_adt_def() {
+                    if let Some(v) = adt_def.variants.iter().find(|v| resolved_def_id == v.did) {
+                        // technically they can diverge, but only if one of their arguments diverges, so it doesn't matter
+                        let (lvalue, target) = destination.expect("tuple struct constructors can't diverge");
+                        let dest_ty = self.tcx.item_type(adt_def.did);
+                        let dest_layout = self.type_layout(dest_ty)?;
+                        match *dest_layout {
+                            Layout::Univariant { ref variant, .. } => {
+                                assert_eq!(v.disr_val.to_u64_unchecked(), 0);
+                                let offsets = variant.offsets.iter().map(|s| s.bytes());
+
+                                // FIXME: don't allocate for single or dual field structs
+                                let dest = self.force_allocation(lvalue)?.to_ptr();
+
+                                for (offset, (value, value_ty)) in offsets.into_iter().zip(args) {
+                                    let field_dest = dest.offset(offset);
+                                    self.write_value_to_ptr(value, field_dest, value_ty)?;
+                                }
+                            },
+                            // FIXME: enum variant constructors
+                            _ => bug!("bad layout for tuple struct constructor: {:?}", dest_layout),
+                        }
+                        self.goto_block(target);
+                        return Ok(());
+                    }
+                }
+
                 let mir = self.load_mir(resolved_def_id)?;
                 let (return_lvalue, return_to_block) = match destination {
                     Some((lvalue, block)) => (lvalue, StackPopCleanup::Goto(block)),

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -2,7 +2,7 @@ use rustc::hir::def_id::DefId;
 use rustc::mir;
 use rustc::traits::{self, Reveal};
 use rustc::ty::fold::TypeFoldable;
-use rustc::ty::layout::Layout;
+use rustc::ty::layout::{Layout, Size};
 use rustc::ty::subst::{Substs, Kind};
 use rustc::ty::{self, Ty, TyCtxt, BareFnTy};
 use syntax::codemap::{DUMMY_SP, Span};
@@ -261,20 +261,27 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         let (lvalue, target) = destination.expect("tuple struct constructors can't diverge");
                         let dest_ty = self.tcx.item_type(adt_def.did);
                         let dest_layout = self.type_layout(dest_ty)?;
+                        let disr = v.disr_val.to_u64_unchecked();
                         match *dest_layout {
                             Layout::Univariant { ref variant, .. } => {
-                                assert_eq!(v.disr_val.to_u64_unchecked(), 0);
+                                assert_eq!(disr, 0);
                                 let offsets = variant.offsets.iter().map(|s| s.bytes());
 
-                                // FIXME: don't allocate for single or dual field structs
-                                let dest = self.force_allocation(lvalue)?.to_ptr();
-
-                                for (offset, (value, value_ty)) in offsets.into_iter().zip(args) {
-                                    let field_dest = dest.offset(offset);
-                                    self.write_value_to_ptr(value, field_dest, value_ty)?;
-                                }
+                                self.assign_fields(lvalue, offsets, args)?;
                             },
-                            // FIXME: enum variant constructors
+                            Layout::General { discr, ref variants, .. } => {
+                                // FIXME: report a proper error for invalid discriminants
+                                // right now we simply go into index out of bounds
+                                let discr_size = discr.size().bytes();
+                                self.assign_discr_and_fields(
+                                    lvalue,
+                                    variants[disr as usize].offsets.iter().cloned().map(Size::bytes),
+                                    args,
+                                    disr,
+                                    discr_size,
+                                )?;
+                            },
+                            // FIXME: raw nullable pointer constructors
                             _ => bug!("bad layout for tuple struct constructor: {:?}", dest_layout),
                         }
                         self.goto_block(target);

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -281,7 +281,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                     discr_size,
                                 )?;
                             },
-                            // FIXME: raw nullable pointer constructors
+                            Layout::StructWrappedNullablePointer { .. } |
+                            Layout::RawNullablePointer { .. } => {
+                                assert_eq!(args.len(), 1);
+                                let (val, ty) = args.pop().unwrap();
+                                self.write_value(val, lvalue, ty)?;
+                            },
                             _ => bug!("bad layout for tuple struct constructor: {:?}", dest_layout),
                         }
                         self.goto_block(target);

--- a/src/value.rs
+++ b/src/value.rs
@@ -163,8 +163,29 @@ impl<'tcx> PrimVal {
         self.to_bytes()
     }
 
+    pub fn to_u64(self) -> EvalResult<'tcx, u64> {
+        self.to_bytes().map(|b| {
+            assert_eq!(b as u64 as u128, b);
+            b as u64
+        })
+    }
+
+    pub fn to_i32(self) -> EvalResult<'tcx, i32> {
+        self.to_bytes().map(|b| {
+            assert_eq!(b as i32 as u128, b);
+            b as i32
+        })
+    }
+
     pub fn to_i128(self) -> EvalResult<'tcx, i128> {
         self.to_bytes().map(|b| b as i128)
+    }
+
+    pub fn to_i64(self) -> EvalResult<'tcx, i64> {
+        self.to_bytes().map(|b| {
+            assert_eq!(b as i64 as u128, b);
+            b as i64
+        })
     }
 
     pub fn to_f32(self) -> EvalResult<'tcx, f32> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,23 +6,23 @@ use std::mem::transmute;
 use error::{EvalError, EvalResult};
 use memory::{Memory, Pointer};
 
-pub(super) fn bytes_to_f32(bytes: u64) -> f32 {
+pub(super) fn bytes_to_f32(bytes: u128) -> f32 {
     unsafe { transmute::<u32, f32>(bytes as u32) }
 }
 
-pub(super) fn bytes_to_f64(bytes: u64) -> f64 {
-    unsafe { transmute::<u64, f64>(bytes) }
+pub(super) fn bytes_to_f64(bytes: u128) -> f64 {
+    unsafe { transmute::<u64, f64>(bytes as u64) }
 }
 
-pub(super) fn f32_to_bytes(f: f32) -> u64 {
-    unsafe { transmute::<f32, u32>(f) as u64 }
+pub(super) fn f32_to_bytes(f: f32) -> u128 {
+    unsafe { transmute::<f32, u32>(f) as u128 }
 }
 
-pub(super) fn f64_to_bytes(f: f64) -> u64 {
-    unsafe { transmute::<f64, u64>(f) }
+pub(super) fn f64_to_bytes(f: f64) -> u128 {
+    unsafe { transmute::<f64, u64>(f) as u128 }
 }
 
-pub(super) fn bytes_to_bool(n: u64) -> bool {
+pub(super) fn bytes_to_bool(n: u128) -> bool {
     // FIXME(solson): Can we reach here due to user error?
     debug_assert!(n == 0 || n == 1, "bytes interpreted as bool were {}", n);
     n & 1 == 1
@@ -50,7 +50,7 @@ pub enum Value {
 #[derive(Clone, Copy, Debug)]
 pub enum PrimVal {
     /// The raw bytes of a simple value.
-    Bytes(u64),
+    Bytes(u128),
 
     /// A pointer into an `Allocation`. An `Allocation` in the `memory` module has a list of
     /// relocations, but a `PrimVal` is only large enough to contain one, so we just represent the
@@ -64,8 +64,8 @@ pub enum PrimVal {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PrimValKind {
-    I8, I16, I32, I64,
-    U8, U16, U32, U64,
+    I8, I16, I32, I64, I128,
+    U8, U16, U32, U64, U128,
     F32, F64,
     Bool,
     Char,
@@ -109,7 +109,9 @@ impl<'a, 'tcx: 'a> Value {
                 Ok((ptr, len))
             },
             ByValPair(ptr, val) => {
-                Ok((ptr.to_ptr()?, val.to_u64()?))
+                let len = val.to_u128()?;
+                assert_eq!(len as u64 as u128, len);
+                Ok((ptr.to_ptr()?, len as u64))
             },
             _ => unimplemented!(),
         }
@@ -117,12 +119,12 @@ impl<'a, 'tcx: 'a> Value {
 }
 
 impl<'tcx> PrimVal {
-    pub fn from_u64(n: u64) -> Self {
+    pub fn from_u128(n: u128) -> Self {
         PrimVal::Bytes(n)
     }
 
-    pub fn from_i64(n: i64) -> Self {
-        PrimVal::Bytes(n as u64)
+    pub fn from_i128(n: i128) -> Self {
+        PrimVal::Bytes(n as u128)
     }
 
     pub fn from_f32(f: f32) -> Self {
@@ -134,35 +136,35 @@ impl<'tcx> PrimVal {
     }
 
     pub fn from_bool(b: bool) -> Self {
-        PrimVal::Bytes(b as u64)
+        PrimVal::Bytes(b as u128)
     }
 
     pub fn from_char(c: char) -> Self {
-        PrimVal::Bytes(c as u64)
+        PrimVal::Bytes(c as u128)
     }
 
-    pub fn to_bytes(self) -> EvalResult<'tcx, u64> {
+    pub fn to_bytes(self) -> EvalResult<'tcx, u128> {
         match self {
             PrimVal::Bytes(b) => Ok(b),
-            PrimVal::Ptr(p) => p.to_int(),
+            PrimVal::Ptr(p) => p.to_int().map(|b| b as u128),
             PrimVal::Undef => Err(EvalError::ReadUndefBytes),
         }
     }
 
     pub fn to_ptr(self) -> EvalResult<'tcx, Pointer> {
         match self {
-            PrimVal::Bytes(b) => Ok(Pointer::from_int(b)),
+            PrimVal::Bytes(b) => Ok(Pointer::from_int(b as u64)),
             PrimVal::Ptr(p) => Ok(p),
             PrimVal::Undef => Err(EvalError::ReadUndefBytes),
         }
     }
 
-    pub fn to_u64(self) -> EvalResult<'tcx, u64> {
+    pub fn to_u128(self) -> EvalResult<'tcx, u128> {
         self.to_bytes()
     }
 
-    pub fn to_i64(self) -> EvalResult<'tcx, i64> {
-        self.to_bytes().map(|b| b as i64)
+    pub fn to_i128(self) -> EvalResult<'tcx, i128> {
+        self.to_bytes().map(|b| b as i128)
     }
 
     pub fn to_f32(self) -> EvalResult<'tcx, f32> {
@@ -186,7 +188,7 @@ impl PrimValKind {
     pub fn is_int(self) -> bool {
         use self::PrimValKind::*;
         match self {
-            I8 | I16 | I32 | I64 | U8 | U16 | U32 | U64 => true,
+            I8 | I16 | I32 | I64 | I128 | U8 | U16 | U32 | U64 | U128 => true,
             _ => false,
         }
     }
@@ -197,6 +199,7 @@ impl PrimValKind {
             2 => PrimValKind::U16,
             4 => PrimValKind::U32,
             8 => PrimValKind::U64,
+            16 => PrimValKind::U128,
             _ => bug!("can't make uint with size {}", size),
         }
     }
@@ -207,6 +210,7 @@ impl PrimValKind {
             2 => PrimValKind::I16,
             4 => PrimValKind::I32,
             8 => PrimValKind::I64,
+            16 => PrimValKind::I128,
             _ => bug!("can't make int with size {}", size),
         }
     }

--- a/tests/compile-fail/send-is-not-static-par-for.rs
+++ b/tests/compile-fail/send-is-not-static-par-for.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//error-pattern: no mir for `std::panicking::panicking`
+//error-pattern: no mir for `std::
 
 use std::sync::Mutex;
 

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -72,7 +72,14 @@ fn compile_test() {
             .to_owned(),
     };
     run_pass();
-    let host = toolchain.unwrap().splitn(2, '-').skip(1).next().unwrap();
+    let host = Path::new(&sysroot).file_name()
+                                  .unwrap()
+                                  .to_str()
+                                  .unwrap()
+                                  .splitn(2, '-')
+                                  .skip(1)
+                                  .next()
+                                  .unwrap();
     for_all_targets(&sysroot, |target| {
         miri_pass("tests/run-pass", &target, host);
         if let Ok(path) = std::env::var("MIRI_RUSTC_TEST") {

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -73,13 +73,13 @@ fn compile_test() {
     };
     run_pass();
     let host = Path::new(&sysroot).file_name()
-                                  .unwrap()
+                                  .expect("sysroot has no last par")
                                   .to_str()
-                                  .unwrap()
+                                  .expect("sysroot contains non utf8")
                                   .splitn(2, '-')
                                   .skip(1)
                                   .next()
-                                  .unwrap();
+                                  .expect("target dir not prefixed");
     for_all_targets(&sysroot, |target| {
         miri_pass("tests/run-pass", &target, host);
         if let Ok(path) = std::env::var("MIRI_RUSTC_TEST") {

--- a/tests/run-pass/aux_test.rs
+++ b/tests/run-pass/aux_test.rs
@@ -1,9 +1,8 @@
 // aux-build:dep.rs
+// ignore-cross-compile
 
-// FIXME: Auxiliary builds are currently broken.
-// extern crate dep;
+extern crate dep;
 
 fn main() {
-    // FIXME: Auxiliary builds are currently broken.
-    // dep::foo();
+    dep::foo();
 }

--- a/tests/run-pass/tuple_like_enum_variant_constructor.rs
+++ b/tests/run-pass/tuple_like_enum_variant_constructor.rs
@@ -1,0 +1,3 @@
+fn main() {
+    assert_eq!(Some(42).map(Some), Some(Some(42)));
+}

--- a/tests/run-pass/tuple_like_enum_variant_constructor_pointer_opt.rs
+++ b/tests/run-pass/tuple_like_enum_variant_constructor_pointer_opt.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let x = 5;
+    assert_eq!(Some(&x).map(Some), Some(Some(&x)));
+}

--- a/tests/run-pass/tuple_like_enum_variant_constructor_struct_pointer_opt.rs
+++ b/tests/run-pass/tuple_like_enum_variant_constructor_struct_pointer_opt.rs
@@ -1,0 +1,11 @@
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct A<'a> {
+    x: i32,
+    y: &'a i32,
+}
+
+fn main() {
+    let x = 5;
+    let a = A { x: 99, y: &x };
+    assert_eq!(Some(a).map(Some), Some(Some(a)));
+}

--- a/tests/run-pass/tuple_like_struct_constructor.rs
+++ b/tests/run-pass/tuple_like_struct_constructor.rs
@@ -1,0 +1,5 @@
+fn main() {
+    #[derive(PartialEq, Eq, Debug)]
+    struct A(i32);
+    assert_eq!(Some(42).map(A), Some(A(42)));
+}

--- a/tests/run-pass/union.rs
+++ b/tests/run-pass/union.rs
@@ -1,0 +1,88 @@
+#![feature(untagged_unions)]
+#![allow(dead_code, unused_variables)]
+
+fn main() {
+    a();
+    b();
+    c();
+    d();
+}
+
+fn a() {
+    union U {
+        f1: u32,
+        f2: f32,
+    }
+    let mut u = U { f1: 1 };
+    unsafe {
+        let b1 = &mut u.f1;
+        *b1 = 5;
+    }
+    assert_eq!(unsafe { u.f1 }, 5);
+}
+
+fn b() {
+    struct S {
+        x: u32,
+        y: u32,
+    }
+
+    union U {
+        s: S,
+        both: u64,
+    }
+    let mut u = U { s: S { x: 1, y: 2 } };
+    unsafe {
+        let bx = &mut u.s.x;
+        let by = &mut u.s.y;
+        *bx = 5;
+        *by = 10;
+    }
+    assert_eq!(unsafe { u.s.x }, 5);
+    assert_eq!(unsafe { u.s.y }, 10);
+}
+
+fn c() {
+    #[repr(u32)]
+    enum Tag { I, F }
+
+    #[repr(C)]
+    union U {
+        i: i32,
+        f: f32,
+    }
+
+    #[repr(C)]
+    struct Value {
+        tag: Tag,
+        u: U,
+    }
+
+    fn is_zero(v: Value) -> bool {
+        unsafe {
+            match v {
+                Value { tag: Tag::I, u: U { i: 0 } } => true,
+                Value { tag: Tag::F, u: U { f: 0.0 } } => true,
+                _ => false,
+            }
+        }
+    }
+    assert!(is_zero(Value { tag: Tag::I, u: U { i: 0 }}));
+    assert!(is_zero(Value { tag: Tag::F, u: U { f: 0.0 }}));
+    assert!(!is_zero(Value { tag: Tag::I, u: U { i: 1 }}));
+    assert!(!is_zero(Value { tag: Tag::F, u: U { f: 42.0 }}));
+}
+
+fn d() {
+    union MyUnion {
+        f1: u32,
+        f2: f32,
+    }
+    let u = MyUnion { f1: 10 };
+    unsafe {
+        match u {
+            MyUnion { f1: 10 } => { }
+            MyUnion { f2 } => { panic!("foo"); }
+        }
+    }
+}


### PR DESCRIPTION
It might be easier to create a fourth variant to `Value`: `Undefined`, but that wouldn't allow for fat pointers where one part isn't defined yet. Having an undefined `Primval` might work.