### PR TITLE
implement packed struct field access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "miri"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.0.0 (git+https://github.com/quininer/byteorder.git?branch=i128)",
- "cargo_metadata 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "compiletest_rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -25,12 +25,12 @@ source = "git+https://github.com/quininer/byteorder.git?branch=i128#ef51df297aa8
 
 [[package]]
 name = "cargo_metadata"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 0.9.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.0-rc2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -39,12 +39,12 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "dtoa"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -53,12 +53,12 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -72,12 +72,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.16"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -90,7 +90,7 @@ name = "log_settings"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -98,7 +98,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -113,75 +113,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.9.0-rc3"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "serde_codegen"
-version = "0.9.0-rc3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen_internals 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "serde_codegen_internals"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "syn 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "0.9.0-rc3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.9.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen_internals 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "0.9.0-rc2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dtoa 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.10.6"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -190,7 +182,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -203,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -224,31 +216,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum byteorder 1.0.0 (git+https://github.com/quininer/byteorder.git?branch=i128)" = "<none>"
-"checksum cargo_metadata 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb382367db7c8eb427e622e46b99eff500fb63d8cf22dc2df6bcc5587112a993"
+"checksum cargo_metadata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "84e3b2d1646a740bb5aae05f7c0a7afd8ae40ea244f78bc36ac25fc8043a54a5"
 "checksum compiletest_rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f3f344389765ad7bec166f64c1b39ed6dd2b54d81c4c5dd8af789169351d380c"
-"checksum dtoa 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80e5dc7a4b2bbf348fb0afe68b3994daf1126223d2d9770221b8213c5e4565af"
+"checksum dtoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87a527ff375a9761c677bb24a677ce48af8035ba260e01e831e4e4b04f945d2a"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
-"checksum itoa 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8f9e7653c775f2ef8016f4181eb3ad62fe8a710e5dd73d4060a5903a58022f"
+"checksum itoa 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5537accdedeaa51526addad01e989bdaeb690e8e5fcca8dce893350912778636"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
-"checksum libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "408014cace30ee0f767b1c4517980646a573ec61a57957aeeabcac8ac0a02e8d"
+"checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
+"checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum log_settings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3d382732ea0fbc09790c4899db3255bdea0fc78b54bf234bd18a63bb603915b6"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
 "checksum quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e7b44fd83db28b83c1c58187159934906e5e955c812e211df413b76b03c909a5"
-"checksum regex 0.1.77 (registry+https://github.com/rust-lang/crates.io-index)" = "64b03446c466d35b42f2a8b203c8e03ed8b91c0f17b56e1f84f7210a257aa665"
-"checksum regex-syntax 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279401017ae31cf4e15344aa3f085d0e2e5c1e70067289ef906906fdbe92c8fd"
-"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
-"checksum serde 0.9.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)" = "bfeedfddd5db4465d96959431d7f3d8d618a6052cdaf3fddb2e981e86a7ad04c"
-"checksum serde_codegen 0.9.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)" = "c89a070576ea7af4c609e72fcdd3d283e9c4c77946bd3fd7a07c43ee15b9c144"
-"checksum serde_codegen_internals 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "afad7924a009f859f380e4a2e3a509a845c2ac66435fcead74a4d983b21ae806"
-"checksum serde_derive 0.9.0-rc3 (registry+https://github.com/rust-lang/crates.io-index)" = "1651978181e36fc90e1faaf91ae21fe74ffba77bc4ce4baf18b20fbb00e24cd4"
-"checksum serde_json 0.9.0-rc2 (registry+https://github.com/rust-lang/crates.io-index)" = "6efad3dc934e5032a92ea163adb13c8414359da950a0f304c1897214f28d9444"
-"checksum syn 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)" = "17134635792e6a2361f53efbee798701796d8b5842c1c21b7cdb875e2950c8fc"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
+"checksum serde 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ff246881a798936bb630947e77add6c4b031fbf28312aca8e3d7c8949429e5f0"
+"checksum serde_codegen_internals 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbca5cba592a2874e48fb67a61479f5b86c0b84a86cf82fa81f947ea538e1449"
+"checksum serde_derive 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7278d46eaf402b063c25288d0e4232029e9fb2f20e272a932b2c15a9fed7f32d"
+"checksum serde_json 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d30dd31e5b6b2752ba87da4bb34edc01391bbab71563fc1e95cdd1e30dce16b8"
+"checksum syn 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f94368aae82bb29656c98443a7026ca931a659e8d19dcdc41d6e273054e820"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
-"checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
     i128_type,
     pub_restricted,
     rustc_private,
-    collections_bound,
 )]
 
 // From rustc.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
     i128_type,
     pub_restricted,
     rustc_private,
+    collections_bound,
 )]
 
 // From rustc.

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -208,12 +208,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     _ => bug!("field access on non-product type: {:?}", base_layout),
                 };
 
+                let ptr = base_ptr.offset(offset.bytes());
+
                 if packed {
                     let size = self.type_size(field_ty)?.expect("packed struct must be sized");
-                    self.memory.mark_packed(base_ptr, size);
+                    self.memory.mark_packed(ptr, size);
                 }
 
-                let ptr = base_ptr.offset(offset.bytes());
                 let extra = if self.type_is_sized(field_ty) {
                     LvalueExtra::None
                 } else {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -510,7 +510,6 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
         if size == 0 {
             return Ok(&[]);
         }
-        self.check_align(ptr, align, size)?;
         if self.relocations(ptr, size)?.count() != 0 {
             return Err(EvalError::ReadPointerAsBytes);
         }
@@ -522,7 +521,6 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
         if size == 0 {
             return Ok(&mut []);
         }
-        self.check_align(ptr, align, size)?;
         self.clear_relocations(ptr, size)?;
         self.mark_definedness(ptr, size, true)?;
         self.get_bytes_unchecked_mut(ptr, size, align)

--- a/src/step.rs
+++ b/src/step.rs
@@ -28,6 +28,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
     /// Returns true as long as there are more things to do.
     pub fn step(&mut self) -> EvalResult<'tcx, bool> {
+        // see docs on the `Memory::packed` field for why we do this
         self.memory.clear_packed();
         self.inc_step_counter_and_check_limit(1)?;
         if self.stack.is_empty() {

--- a/src/step.rs
+++ b/src/step.rs
@@ -28,6 +28,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
     /// Returns true as long as there are more things to do.
     pub fn step(&mut self) -> EvalResult<'tcx, bool> {
+        self.memory.clear_packed();
         self.inc_step_counter_and_check_limit(1)?;
         if self.stack.is_empty() {
             return Ok(false);

--- a/tests/compile-fail/reference_to_packed.rs
+++ b/tests/compile-fail/reference_to_packed.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code, unused_variables)]
+
+#[repr(packed)]
+struct Foo {
+    x: i32,
+    y: i32,
+}
+
+fn main() {
+    let foo = Foo {
+        x: 42,
+        y: 99,
+    };
+    let p = &foo.x;
+    let i = *p; //~ ERROR tried to access memory with alignment 1, but alignment 4 is required
+}

--- a/tests/compile-fail/reference_to_packed_unsafe.rs
+++ b/tests/compile-fail/reference_to_packed_unsafe.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code, unused_variables)]
+
+#[repr(packed)]
+struct Foo {
+    x: i32,
+    y: i32,
+}
+
+fn main() {
+    let foo = Foo {
+        x: 42,
+        y: 99,
+    };
+    let p: *const i32 = &foo.x;
+    let x = unsafe { *p + foo.x }; //~ ERROR tried to access memory with alignment 1, but alignment 4 is required
+}

--- a/tests/run-pass/packed_struct.rs
+++ b/tests/run-pass/packed_struct.rs
@@ -9,6 +9,11 @@ fn main() {
         a: 42,
         b: 99,
     };
-    assert_eq!(x.a, 42);
-    assert_eq!(x.b, 99);
+    let a = x.a;
+    let b = x.b;
+    assert_eq!(a, 42);
+    assert_eq!(b, 99);
+    // can't do `assert_eq!(x.a, 42)`, because `assert_eq!` takes a reference
+    assert_eq!({x.a}, 42);
+    assert_eq!({x.b}, 99);
 }

--- a/tests/run-pass/packed_struct.rs
+++ b/tests/run-pass/packed_struct.rs
@@ -1,0 +1,14 @@
+#[repr(packed)]
+struct S {
+    a: i32,
+    b: i64,
+}
+
+fn main() {
+    let x = S {
+        a: 42,
+        b: 99,
+    };
+    assert_eq!(x.a, 42);
+    assert_eq!(x.b, 99);
+}


### PR DESCRIPTION
This is a little roundabout. We mark memory as "packed" or "unaligned" for a single statement, and clear the marking afterwards. This has the advantage over the below mentioned solution, that in the case where no packed structs are present, it's just a single emptyness check of a set instead of heavily influencing all memory access code.

Not sure how to do this better.

We could add some flag to the `Lvalue` type that is set when we encounter some packed struct. But for reading from a packed struct, I'm not sure how to do that properly. Also that would require us to modify all the code related to writing and reading from memory, modifying the alignment checks...

One disadvantage of this solution is the fact that you can cast a pointer to a packed struct to a pointer to a normal struct and if you access a field of both in the same MIR statement, the normal struct access will succeed even though it shouldn't. But even with mir optimizations, I'm not sure if that situation is even producible.