### PR TITLE
fix drop impls for clike enums

### DIFF
--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -776,6 +776,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                             return Ok(()); // nothing to do, this is zero sized (e.g. `None`)
                         }
                     },
+                    Layout::CEnum { .. } => return Ok(()),
                     _ => bug!("{:?} is not an adt layout", layout),
                 };
                 let tcx = self.tcx;

--- a/tests/run-pass/issue-15063.rs
+++ b/tests/run-pass/issue-15063.rs
@@ -1,0 +1,20 @@
+// Copyright 2014 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+enum Two { A, B }
+impl Drop for Two {
+    fn drop(&mut self) {
+    }
+}
+fn main() {
+    let _k = Two::A;
+}


### PR DESCRIPTION
clike enums can't have any fields, so nothing to do here.