### PR TITLE
prevent more deallocations of statics

### DIFF
--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -329,6 +329,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         }
                     },
                 }
+                // see comment on `initialized` field
+                assert!(!global_value.initialized);
+                global_value.initialized = true;
                 assert!(global_value.mutable);
                 global_value.mutable = mutable;
             } else {
@@ -868,7 +871,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     _ => {
                         let ptr = self.alloc_ptr_with_substs(global_val.ty, cid.substs)?;
                         self.write_value_to_ptr(global_val.value, ptr, global_val.ty)?;
-                        self.memory.mark_static(ptr.alloc_id, global_val.mutable)?;
+                        // see comment on `initialized` field
+                        if global_val.initialized {
+                            self.memory.mark_static(ptr.alloc_id, global_val.mutable)?;
+                        }
                         let lval = self.globals.get_mut(&cid).expect("already checked");
                         *lval = Global {
                             value: Value::ByRef(ptr),

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -172,7 +172,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         // FIXME: cache these allocs
         let ptr = self.memory.allocate(s.len() as u64, 1)?;
         self.memory.write_bytes(ptr, s.as_bytes())?;
-        self.memory.mark_static(ptr.alloc_id, false)?;
+        self.memory.mark_static_initalized(ptr.alloc_id, false)?;
         Ok(Value::ByValPair(PrimVal::Ptr(ptr), PrimVal::from_u128(s.len() as u128)))
     }
 
@@ -194,9 +194,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             Str(ref s) => return self.str_to_value(s),
 
             ByteStr(ref bs) => {
+                // FIXME: cache these allocs
                 let ptr = self.memory.allocate(bs.len() as u64, 1)?;
                 self.memory.write_bytes(ptr, bs)?;
-                self.memory.mark_static(ptr.alloc_id, false)?;
+                self.memory.mark_static_initalized(ptr.alloc_id, false)?;
                 PrimVal::Ptr(ptr)
             }
 
@@ -316,16 +317,16 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let global_value = self.globals.get_mut(&id)
                     .expect("global should have been cached (static)");
                 match global_value.value {
-                    Value::ByRef(ptr) => self.memory.mark_static(ptr.alloc_id, mutable)?,
+                    Value::ByRef(ptr) => self.memory.mark_static_initalized(ptr.alloc_id, mutable)?,
                     Value::ByVal(val) => if let PrimVal::Ptr(ptr) = val {
-                        self.memory.mark_static(ptr.alloc_id, mutable)?;
+                        self.memory.mark_static_initalized(ptr.alloc_id, mutable)?;
                     },
                     Value::ByValPair(val1, val2) => {
                         if let PrimVal::Ptr(ptr) = val1 {
-                            self.memory.mark_static(ptr.alloc_id, mutable)?;
+                            self.memory.mark_static_initalized(ptr.alloc_id, mutable)?;
                         }
                         if let PrimVal::Ptr(ptr) = val2 {
-                            self.memory.mark_static(ptr.alloc_id, mutable)?;
+                            self.memory.mark_static_initalized(ptr.alloc_id, mutable)?;
                         }
                     },
                 }
@@ -870,10 +871,11 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     Value::ByRef(ptr) => Lvalue::from_ptr(ptr),
                     _ => {
                         let ptr = self.alloc_ptr_with_substs(global_val.ty, cid.substs)?;
+                        self.memory.mark_static(ptr.alloc_id);
                         self.write_value_to_ptr(global_val.value, ptr, global_val.ty)?;
                         // see comment on `initialized` field
                         if global_val.initialized {
-                            self.memory.mark_static(ptr.alloc_id, global_val.mutable)?;
+                            self.memory.mark_static_initalized(ptr.alloc_id, global_val.mutable)?;
                         }
                         let lval = self.globals.get_mut(&cid).expect("already checked");
                         *lval = Global {

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -57,6 +57,11 @@ pub struct GlobalId<'tcx> {
 #[derive(Copy, Clone, Debug)]
 pub struct Global<'tcx> {
     pub(super) value: Value,
+    /// Only used in `force_allocation` to ensure we don't mark the memory
+    /// before the static is initialized. It is possible to convert a
+    /// global which initially is `Value::ByVal(PrimVal::Undef)` and gets
+    /// lifted to an allocation before the static is fully initialized
+    pub(super) initialized: bool,
     pub(super) mutable: bool,
     pub(super) ty: Ty<'tcx>,
 }
@@ -102,6 +107,7 @@ impl<'tcx> Global<'tcx> {
             value: Value::ByVal(PrimVal::Undef),
             mutable: true,
             ty,
+            initialized: false,
         }
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -632,7 +632,7 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
 impl<'a, 'tcx> Memory<'a, 'tcx> {
     /// mark an allocation as being the entry point to a static (see `static_alloc` field)
     pub fn mark_static(&mut self, alloc_id: AllocId) {
-        if !self.static_alloc.insert(alloc_id) {
+        if alloc_id != NEVER_ALLOC_ID && alloc_id != ZST_ALLOC_ID && !self.static_alloc.insert(alloc_id) {
             bug!("tried to mark an allocation ({:?}) as static twice", alloc_id);
         }
     }

--- a/src/vtable.rs
+++ b/src/vtable.rs
@@ -112,7 +112,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
         }
 
-        self.memory.mark_static(vtable.alloc_id, false)?;
+        self.memory.mark_static_initalized(vtable.alloc_id, false)?;
 
         Ok(vtable)
     }

--- a/tests/run-pass/issue-31267-additional.rs
+++ b/tests/run-pass/issue-31267-additional.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(unused_variables)]
+
+#![feature(associated_consts)]
+
+#[derive(Clone, Copy, Debug)]
+struct Bar;
+
+const BAZ: Bar = Bar;
+
+#[derive(Debug)]
+struct Foo([Bar; 1]);
+
+struct Biz;
+
+impl Biz {
+    const BAZ: Foo = Foo([BAZ; 1]);
+}
+
+fn main() {
+    let foo = Biz::BAZ;
+}

--- a/tests/run-pass/issue-5917.rs
+++ b/tests/run-pass/issue-5917.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+struct T (&'static [isize]);
+static t : T = T (&[5, 4, 3]);
+pub fn main () {
+    let T(ref v) = t;
+    assert_eq!(v[0], 5);
+}

--- a/tests/run-pass/issue-5917.rs
+++ b/tests/run-pass/issue-5917.rs
@@ -10,8 +10,8 @@
 
 
 struct T (&'static [isize]);
-static t : T = T (&[5, 4, 3]);
+static STATIC : T = T (&[5, 4, 3]);
 pub fn main () {
-    let T(ref v) = t;
+    let T(ref v) = STATIC;
     assert_eq!(v[0], 5);
 }


### PR DESCRIPTION
We can probably expect a static to always be initialized at some point, and thus simply remove the field and test the value for `PrimVal::Undef`, but I wanted to be on the safe side and add a field that has no interaction with other code.