### PR TITLE
ignore `print!`, turn `panic!` into a EvalError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,7 @@ pub enum EvalError<'tcx> {
     ExpectedConcreteFunction(Function<'tcx>),
     ExpectedDropGlue(Function<'tcx>),
     ManuallyCalledDropGlue,
+    Panic,
 }
 
 pub type EvalResult<'tcx, T = ()> = Result<T, EvalError<'tcx>>;
@@ -134,6 +135,8 @@ impl<'tcx> Error for EvalError<'tcx> {
                 "tried to use non-drop-glue function as drop glue",
             EvalError::ManuallyCalledDropGlue =>
                 "tried to manually invoke drop glue",
+            EvalError::Panic =>
+                "the evaluated program panicked",
         }
     }
 

--- a/tests/compile-fail/env_args.rs
+++ b/tests/compile-fail/env_args.rs
@@ -1,6 +1,4 @@
-//error-pattern: no mir for `std::env::args`
-
 fn main() {
-    let x = std::env::args();
+    let x = std::env::args(); //~ ERROR miri does not support program arguments
     assert_eq!(x.count(), 1);
 }

--- a/tests/compile-fail/panic.rs
+++ b/tests/compile-fail/panic.rs
@@ -1,0 +1,5 @@
+//error-pattern: the evaluated program panicked
+
+fn main() {
+    assert_eq!(5, 6);
+}

--- a/tests/compile-fail/unimplemented.rs
+++ b/tests/compile-fail/unimplemented.rs
@@ -1,5 +1,0 @@
-//error-pattern:begin_panic_fmt
-
-fn main() {
-    assert_eq!(5, 6);
-}


### PR DESCRIPTION
This solution is a hack of course, but it allows better testing until we get a handle on generating libstd with full MIR.

~~1638 success, 554 mir not found, 205 crate not found, 141 failed~~
1863 success, 211 mir not found, 205 crate not found, 259 failed

The failures are

```
     67 error: miri does not support threading
     31 error: miri does not support program arguments
     16 error: the evaluated program panicked
     14 error: main function not found
     10 error: cannot evaluate inline assembly
     10 error: a raw memory access tried to access part of a pointer value as raw bytes
      8 error: reached the configured maximum execution time
      6 error: tried to access memory through an invalid pointer
      6 error: can't handle function with PlatformIntrinsic ABI
      4 error: can't call C ABI function: __rust_maybe_catch_panic
      3 error: tried to access memory with alignment 1, but alignment 8 is required
      3 error: dangling pointer was dereferenced
      3 error: can't call C ABI function: foo
      2 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/subst.rs:476: Type parameter `T/#0` (T/0) out of range when substituting (root type=Some(std::option::Option<T>)) substs=[]
      2 error: can't call C ABI function: rust_interesting_average
      2 error: can't call C ABI function: rust_get_test_int
      2 error: can't call C ABI function: rust_dbg_call
      2 error: attempted to do math or a comparison on pointers into different allocations
      1 test [miri-pass] ../rust/src/test/run-pass/issue-24533.rs ... NO MIR FOR `std::error::<impl std::convert::From<&'b str> for std::boxed::Box<std::error::Error + std::marker::Sync + std::marker::Send + 'a>>::from`
      1 error: unused import: `std::option`
      1 error: unimplemented intrinsic: atomic_or
      1 error: unimplemented intrinsic: atomic_cxchg_acq_failrelaxed
      1 error: unimplemented intrinsic: atomic_cxchg_acq
      1 error: tried to access memory with alignment 2, but alignment 8 is required
      1 error: test failed
      1 error: reached the configured maximum number of stack frames
      1 error: Overflow(Neg) at /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/libcore/ops.rs:758:43: 758:45
      1 error: Overflow(Add) at /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/libcore/ops.rs:263:45: 263:57
      1 error: internal compiler error: src/value.rs:99: expected ptr and vtable, got ByVal(Ptr(Pointer { alloc_id: AllocId(6), offset: 0 }))
      1 error: internal compiler error: src/step.rs:238: static def id doesn't point to item
      1 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1860: No def'n found for DefId { krate: CrateNum(0), node: DefIndex(9) => associated_const_resolution_order/4089d7c8b778d88cec885baf7b69e6df-exe::MyTrait[0]::IMPL_IS_INHERENT[0] } in tcx.mir_map
      1 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1860: No def'n found for DefId { krate: CrateNum(0), node: DefIndex(4) => issue_23808/4089d7c8b778d88cec885baf7b69e6df-exe::Const[0]::C[0] } in tcx.mir_map
      1 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1860: No def'n found for DefId { krate: CrateNum(0), node: DefIndex(4) => associated_const_use_impl_of_same_trait/4089d7c8b778d88cec885baf7b69e6df-exe::Foo[0]::BAR[0] } in tcx.mir_map
      1 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1860: No def'n found for DefId { krate: CrateNum(0), node: DefIndex(4) => associated_const_ufcs_infer_trait/4089d7c8b778d88cec885baf7b69e6df-exe::Foo[0]::ID[0] } in tcx.mir_map
      1 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1860: No def'n found for DefId { krate: CrateNum(0), node: DefIndex(4) => associated_const_type_parameters/4089d7c8b778d88cec885baf7b69e6df-exe::Foo[0]::X[0] } in tcx.mir_map
      1 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1860: No def'n found for DefId { krate: CrateNum(0), node: DefIndex(4) => associated_const_self_type/4089d7c8b778d88cec885baf7b69e6df-exe::MyInt[0]::ONE[0] } in tcx.mir_map
      1 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1860: No def'n found for DefId { krate: CrateNum(0), node: DefIndex(4) => associated_const_const_eval/4089d7c8b778d88cec885baf7b69e6df-exe::Foo[0]::NUM[0] } in tcx.mir_map
      1 error: internal compiler error: /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1860: No def'n found for DefId { krate: CrateNum(0), node: DefIndex(4) => associated_const/4089d7c8b778d88cec885baf7b69e6df-exe::Foo[0]::ID[0] } in tcx.mir_map
      1 error: can't handle function with Vectorcall ABI
      1 error: can't handle function with SysV64 ABI
      1 error: can't handle function with Fastcall ABI
      1 error: can't call C ABI function: tuple2
      1 error: can't call C ABI function: test
      1 error: can't call C ABI function: simple_extern
      1 error: can't call C ABI function: sigaction
      1 error: can't call C ABI function: rust_int8_to_int32
      1 error: can't call C ABI function: rust_dbg_extern_return_TwoU8s
      1 error: can't call C ABI function: rust_dbg_extern_return_TwoU64s
      1 error: can't call C ABI function: rust_dbg_extern_return_TwoU32s
      1 error: can't call C ABI function: rust_dbg_extern_return_TwoU16s
      1 error: can't call C ABI function: rust_dbg_extern_identity_u8
      1 error: can't call C ABI function: rust_dbg_extern_identity_u64
      1 error: can't call C ABI function: rust_dbg_extern_identity_u32
      1 error: can't call C ABI function: rust_dbg_extern_identity_TwoU8s
      1 error: can't call C ABI function: rust_dbg_extern_identity_TwoU64s
      1 error: can't call C ABI function: rust_dbg_extern_identity_TwoU32s
      1 error: can't call C ABI function: rust_dbg_extern_identity_TwoU16s
      1 error: can't call C ABI function: rust_dbg_extern_identity_double
      1 error: can't call C ABI function: rust_dbg_extern_empty_struct
      1 error: can't call C ABI function: rust_dbg_abi_1
      1 error: can't call C ABI function: puts
      1 error: can't call C ABI function: malloc
      1 error: can't call C ABI function: lgamma_r
      1 error: can't call C ABI function: issue_28983
      1 error: can't call C ABI function: identity
      1 error: can't call C ABI function: good
      1 error: can't call C ABI function: get_x
      1 error: can't call C ABI function: get_c_many_params
      1 error: can't call C ABI function: free
      1 error: can't call C ABI function: f
      1 error: can't call C ABI function: close
      1 error: attempted to read undefined bytes
```

leftover mir not found:

```
    101 NO MIR FOR `<std::string::String as std::convert::From<&'a str>>::from`
     35 NO MIR FOR `std::fmt::format`
     16 NO MIR FOR `std::collections::hash_map::RandomState::new::KEYS`
      9 NO MIR FOR `std::panicking::panicking`
      8 NO MIR FOR `<T as std::string::ToString>::to_string::__STATIC_FMTSTR`
      5 NO MIR FOR `std::ffi::os_str::<impl std::convert::AsRef<std::ffi::OsStr> for str>::as_ref`
      3 NO MIR FOR `std::str::pattern::StrSearcher::new`
      3 NO MIR FOR `std::str::<impl std::borrow::ToOwned for str>::to_owned`
      3 NO MIR FOR `std::panic::set_hook`
      3 NO MIR FOR `std::ops::Add::add`
      3 NO MIR FOR `std::io::stdout`
      3 NO MIR FOR `core::num::<impl std::str::FromStr for i32>::from_str`
      2 NO MIR FOR `std::__rand::thread_rng`
      1 NO MIR FOR `<[u8] as std::ascii::AsciiExt>::make_ascii_lowercase`
      1 NO MIR FOR `std::thread::yield_now`
      1 NO MIR FOR `std::thread::sleep_ms`
      1 NO MIR FOR `std::str::<impl str>::escape_debug`
      1 NO MIR FOR `std::str::from_utf8`
      1 NO MIR FOR `std::net::lookup_host`
      1 NO MIR FOR `std::io::stdin`
      1 NO MIR FOR `std::io::sink`
      1 NO MIR FOR `std::fs::OpenOptions::new`
      1 NO MIR FOR `std::fmt::write`
      1 NO MIR FOR `std::error::<impl std::convert::From<&'b str> for std::boxed::Box<std::error::Error + std::marker::Sync + std::marker::Send + 'a>>::from`
      1 NO MIR FOR `std::env::vars_os`
      1 NO MIR FOR `std::env::args_os`
      1 NO MIR FOR `getopts::optopt`
      1 NO MIR FOR `core::num::<impl std::str::FromStr for usize>::from_str`
      1 NO MIR FOR `core::num::dec2flt::extract_sign`
      1 NO MIR FOR `collections::fmt::format`
```

miri panics:

```
      4 thread 'main' panicked at 'index out of bounds: the len is 1 but the index is 2', /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/libcollections/vec.rs:1392
      4 thread 'main' panicked at 'assertion failed: !self.is_enum()', /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc/ty/mod.rs:1484
      2 thread 'main' panicked at 'Box<Any>', /buildslave/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/librustc_errors/lib.rs:376
      2 thread 'main' panicked at 'assertion failed: `(left == right)` (left: `1`, right: `8`)', src/memory.rs:743
      1 thread 'main' panicked at 'assertion failed: `(left == right)` (left: `Length(2)`, right: `None`)', src/lvalue.rs:128
      1 thread 'main' panicked at 'assertion failed: `(left == right)` (left: `Length(1)`, right: `None`)', src/lvalue.rs:128
```