### PR TITLE
fix size of dst in size_of_val intrinsic

### DIFF
--- a/tests/run-pass/issue-35815.rs
+++ b/tests/run-pass/issue-35815.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::mem;
+
+struct Foo<T: ?Sized> {
+    a: i64,
+    b: bool,
+    c: T,
+}
+
+fn main() {
+    let foo: &Foo<i32> = &Foo { a: 1, b: false, c: 2i32 };
+    let foo_unsized: &Foo<Send> = foo;
+    assert_eq!(mem::size_of_val(foo), mem::size_of_val(foo_unsized));
+}

--- a/tests/run-pass/issue-35815.rs
+++ b/tests/run-pass/issue-35815.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(dead_code)]
+
 use std::mem;
 
 struct Foo<T: ?Sized> {


### PR DESCRIPTION
I synced the code with

https://github.com/rust-lang/rust/blob/9c8cdb2923a69177017165a4cdb0e1ea673fc49f/src/librustc_trans/glue.rs#L296

but it wasn't any functional change. Instead, my size calculation was wrong.