### PR TITLE
lvalue references into fields of ValPair locals

### DIFF
--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -1367,12 +1367,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         if let Lvalue::Local { frame, local, field } = lvalue {
             let mut allocs = Vec::new();
             let mut msg = format!("{:?}", local);
+            if let Some(field) = field {
+                write!(msg, ".{}", field).unwrap();
+            }
             let last_frame = self.stack.len() - 1;
             if frame != last_frame {
                 write!(msg, " ({} frames up)", last_frame - frame).unwrap();
-            }
-            if let Some(field) = field {
-                write!(msg, " (field {:?})", field).unwrap();
             }
             write!(msg, ":").unwrap();
 

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -1367,7 +1367,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         if let Lvalue::Local { frame, local, field } = lvalue {
             let mut allocs = Vec::new();
             let mut msg = format!("{:?}", local);
-            if let Some(field) = field {
+            if let Some((field, _)) = field {
                 write!(msg, ".{}", field).unwrap();
             }
             let last_frame = self.stack.len() - 1;

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -116,16 +116,6 @@ impl<'tcx> Global<'tcx> {
 
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(super) fn eval_and_read_lvalue(&mut self, lvalue: &mir::Lvalue<'tcx>) -> EvalResult<'tcx, Value> {
-        if let mir::Lvalue::Projection(ref proj) = *lvalue {
-            if let mir::Lvalue::Local(index) = proj.base {
-                if let Value::ByValPair(a, b) = self.frame().get_local(index, None) {
-                    if let mir::ProjectionElem::Field(ref field, _) = proj.elem {
-                        let val = [a, b][field.index()];
-                        return Ok(Value::ByVal(val));
-                    }
-                }
-            }
-        }
         let lvalue = self.eval_lvalue(lvalue)?;
         Ok(self.read_lvalue(lvalue))
     }

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -254,7 +254,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     Ok(zero_val)
                 };
                 match dest {
-                    Lvalue::Local { frame, local } => self.modify_local(frame, local, init)?,
+                    Lvalue::Local { frame, local, field } => self.modify_local(frame, local, field.map(|(i, _)| i), init)?,
                     Lvalue::Ptr { ptr, extra: LvalueExtra::None } => self.memory.write_repeat(ptr, 0, size)?,
                     Lvalue::Ptr { .. } => bug!("init intrinsic tried to write to fat ptr target"),
                     Lvalue::Global(cid) => self.modify_global(cid, init)?,
@@ -386,7 +386,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     }
                 };
                 match dest {
-                    Lvalue::Local { frame, local } => self.modify_local(frame, local, uninit)?,
+                    Lvalue::Local { frame, local, field } => self.modify_local(frame, local, field.map(|(i, _)| i), uninit)?,
                     Lvalue::Ptr { ptr, extra: LvalueExtra::None } =>
                         self.memory.mark_definedness(ptr, size, false)?,
                     Lvalue::Ptr { .. } => bug!("uninit intrinsic tried to write to fat ptr target"),


### PR DESCRIPTION
I ran this on the rustc test suite and found no regressions, but your changes also came in there (and reduced the number of errors significantly), so maybe I don't see something.

more groundwork towards

> src/value.rs:99: expected ptr and vtable, got ByVal(Ptr(Pointer { alloc_id: AllocId(6), offset: 0 }))