### PR TITLE
deduplicate field access logic

### DIFF
--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -11,7 +11,6 @@ use rustc::ty::layout::{self, Layout, Size};
 use rustc::ty::subst::{self, Subst, Substs};
 use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
 use rustc_data_structures::indexed_vec::Idx;
-use rustc_data_structures::fx::FxHashSet;
 use syntax::codemap::{self, DUMMY_SP};
 
 use error::{EvalError, EvalResult};
@@ -1588,7 +1587,7 @@ pub fn monomorphize_field_ty<'a, 'tcx:'a >(tcx: TyCtxt<'a, 'tcx, 'tcx>, f: &ty::
 }
 
 pub fn is_inhabited<'a, 'tcx: 'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> bool {
-    ty.uninhabited_from(&mut FxHashSet::default(), tcx).is_empty()
+    ty.uninhabited_from(&mut HashMap::default(), tcx).is_empty()
 }
 
 pub trait IntoValTyPair<'tcx> {

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -436,6 +436,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 self.write_primval(dest, operator::unary_op(un_op, val, kind)?, dest_ty)?;
             }
 
+            // Skip everything for zsts
+            Aggregate(..) if self.type_size(dest_ty)? == Some(0) => {}
+
             Aggregate(ref kind, ref operands) => {
                 self.inc_step_counter_and_check_limit(operands.len() as u64)?;
                 use rustc::ty::layout::Layout::*;


### PR DESCRIPTION
no regressions on rustc test suite detected

We treat arrays like structures with homogeneous fields.