### PR TITLE
rustup to rustc 1.17.0-nightly (60a0edc6c 2017-02-26)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,15 +1,14 @@
 use std::error::Error;
 use std::fmt;
 use rustc::mir;
-use rustc::ty::{BareFnTy, Ty, FnSig, layout};
-use syntax::abi::Abi;
+use rustc::ty::{PolyFnSig, Ty, layout};
 use memory::{Pointer, Function};
 use rustc_const_math::ConstMathErr;
 use syntax::codemap::Span;
 
 #[derive(Clone, Debug)]
 pub enum EvalError<'tcx> {
-    FunctionPointerTyMismatch(Abi, &'tcx FnSig<'tcx>, &'tcx BareFnTy<'tcx>),
+    FunctionPointerTyMismatch(PolyFnSig<'tcx>, PolyFnSig<'tcx>),
     NoMirFor(String),
     UnterminatedCString(Pointer),
     DanglingPointerDeref,
@@ -151,8 +150,8 @@ impl<'tcx> fmt::Display for EvalError<'tcx> {
                        ptr.offset, ptr.offset + size, ptr.alloc_id, allocation_size)
             },
             EvalError::NoMirFor(ref func) => write!(f, "no mir for `{}`", func),
-            EvalError::FunctionPointerTyMismatch(abi, sig, got) =>
-                write!(f, "tried to call a function with abi {:?} and sig {:?} through a function pointer of type {:?}", abi, sig, got),
+            EvalError::FunctionPointerTyMismatch(sig, got) =>
+                write!(f, "tried to call a function with sig {} through a function pointer of type {}", sig.skip_binder(), got.skip_binder()),
             EvalError::ArrayIndexOutOfBounds(span, len, index) =>
                 write!(f, "index out of bounds: the len is {} but the index is {} at {:?}", len, index, span),
             EvalError::Math(span, ref err) =>

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,14 @@
 use std::error::Error;
 use std::fmt;
 use rustc::mir;
-use rustc::ty::{PolyFnSig, Ty, layout};
+use rustc::ty::{FnSig, Ty, layout};
 use memory::{Pointer, Function};
 use rustc_const_math::ConstMathErr;
 use syntax::codemap::Span;
 
 #[derive(Clone, Debug)]
 pub enum EvalError<'tcx> {
-    FunctionPointerTyMismatch(PolyFnSig<'tcx>, PolyFnSig<'tcx>),
+    FunctionPointerTyMismatch(FnSig<'tcx>, FnSig<'tcx>),
     NoMirFor(String),
     UnterminatedCString(Pointer),
     DanglingPointerDeref,
@@ -151,7 +151,7 @@ impl<'tcx> fmt::Display for EvalError<'tcx> {
             },
             EvalError::NoMirFor(ref func) => write!(f, "no mir for `{}`", func),
             EvalError::FunctionPointerTyMismatch(sig, got) =>
-                write!(f, "tried to call a function with sig {} through a function pointer of type {}", sig.skip_binder(), got.skip_binder()),
+                write!(f, "tried to call a function with sig {} through a function pointer of type {}", sig, got),
             EvalError::ArrayIndexOutOfBounds(span, len, index) =>
                 write!(f, "index out of bounds: the len is {} but the index is {} at {:?}", len, index, span),
             EvalError::Math(span, ref err) =>

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -649,15 +649,20 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     },
 
                     UnsafeFnPointer => match dest_ty.sty {
-                        ty::TyFnPtr(unsafe_fn_ty) => {
+                        ty::TyFnPtr(_) => {
                             let src = self.eval_operand(operand)?;
-                            let ptr = src.read_ptr(&self.memory)?;
-                            let fn_def = self.memory.get_fn(ptr.alloc_id)?.expect_concrete()?;
-                            let unsafe_fn_ty = self.tcx.erase_regions(&unsafe_fn_ty);
-                            let fn_ptr = self.memory.create_fn_ptr(self.tcx, fn_def.def_id, fn_def.substs, unsafe_fn_ty);
-                            self.write_value(Value::ByVal(PrimVal::Ptr(fn_ptr)), dest, dest_ty)?;
+                            self.write_value(src, dest, dest_ty)?;
                         },
                         ref other => bug!("fn to unsafe fn cast on {:?}", other),
+                    },
+
+                    ClosureFnPointer => match self.operand_ty(operand).sty {
+                        ty::TyClosure(def_id, substs) => {
+                            let fn_ty = self.tcx.closure_type(def_id, substs);
+                            let fn_ptr = self.memory.create_fn_ptr_from_noncapture_closure(self.tcx, def_id, substs, fn_ty);
+                            self.write_value(Value::ByVal(PrimVal::Ptr(fn_ptr)), dest, dest_ty)?;
+                        },
+                        ref other => bug!("reify fn pointer on {:?}", other),
                     },
                 }
             }

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -9,7 +9,7 @@ use rustc::mir;
 use rustc::traits::Reveal;
 use rustc::ty::layout::{self, Layout, Size};
 use rustc::ty::subst::{self, Subst, Substs};
-use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
+use rustc::ty::{self, Ty, TyCtxt, TypeFoldable, Binder};
 use rustc_data_structures::indexed_vec::Idx;
 use syntax::codemap::{self, DUMMY_SP};
 
@@ -223,6 +223,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let without_lifetimes = self.tcx.erase_regions(&ty);
         let substituted = without_lifetimes.subst(self.tcx, substs);
         self.tcx.normalize_associated_type(&substituted)
+    }
+
+    pub fn erase_lifetimes<T>(&self, value: &Binder<T>) -> T
+        where T : TypeFoldable<'tcx>
+    {
+        let value = self.tcx.erase_late_bound_regions(value);
+        self.tcx.erase_regions(&value)
     }
 
     pub(super) fn type_size(&self, ty: Ty<'tcx>) -> EvalResult<'tcx, Option<u64>> {

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -137,9 +137,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             Local(mir::RETURN_POINTER) => self.frame().return_lvalue,
             Local(local) => Lvalue::Local { frame: self.stack.len() - 1, local, field: None },
 
-            Static(ref statik) => {
+            Static(ref static_) => {
                 let substs = self.tcx.intern_substs(&[]);
-                Lvalue::Global(GlobalId { def_id: statik.def_id, substs, promoted: None })
+                Lvalue::Global(GlobalId { def_id: static_.def_id, substs, promoted: None })
             }
 
             Projection(ref proj) => return self.eval_lvalue_projection(proj),

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -137,9 +137,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             Local(mir::RETURN_POINTER) => self.frame().return_lvalue,
             Local(local) => Lvalue::Local { frame: self.stack.len() - 1, local, field: None },
 
-            Static(def_id) => {
+            Static(ref statik) => {
                 let substs = self.tcx.intern_substs(&[]);
-                Lvalue::Global(GlobalId { def_id, substs, promoted: None })
+                Lvalue::Global(GlobalId { def_id: statik.def_id, substs, promoted: None })
             }
 
             Projection(ref proj) => return self.eval_lvalue_projection(proj),

--- a/src/step.rs
+++ b/src/step.rs
@@ -242,7 +242,8 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for ConstantExtractor<'a, 'b, 'tcx> {
         location: mir::Location
     ) {
         self.super_lvalue(lvalue, context, location);
-        if let mir::Lvalue::Static(def_id) = *lvalue {
+        if let mir::Lvalue::Static(ref statik) = *lvalue {
+            let def_id = statik.def_id;
             let substs = self.ecx.tcx.intern_substs(&[]);
             let span = self.span;
             if let Some(node_item) = self.ecx.tcx.hir.get_if_local(def_id) {

--- a/src/step.rs
+++ b/src/step.rs
@@ -242,8 +242,8 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for ConstantExtractor<'a, 'b, 'tcx> {
         location: mir::Location
     ) {
         self.super_lvalue(lvalue, context, location);
-        if let mir::Lvalue::Static(ref statik) = *lvalue {
-            let def_id = statik.def_id;
+        if let mir::Lvalue::Static(ref static_) = *lvalue {
+            let def_id = static_.def_id;
             let substs = self.ecx.tcx.intern_substs(&[]);
             let span = self.span;
             if let Some(node_item) = self.ecx.tcx.hir.get_if_local(def_id) {

--- a/src/terminator/drop.rs
+++ b/src/terminator/drop.rs
@@ -97,7 +97,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let (adt_ptr, extra) = lval.to_ptr_and_extra();
 
                 // run drop impl before the fields' drop impls
-                if let Some(drop_def_id) = adt_def.destructor() {
+                if let Some(drop_def_id) = adt_def.destructor(self.tcx) {
                     let trait_ref = ty::Binder(ty::TraitRef {
                         def_id: self.tcx.lang_items.drop_trait().unwrap(),
                         substs: self.tcx.mk_substs_trait(ty, &[]),
@@ -121,7 +121,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     Layout::General { .. } => {
                         let discr_val = self.read_discriminant_value(adt_ptr, ty)? as u128;
                         let ptr = self.force_allocation(lval)?.to_ptr();
-                        match adt_def.variants.iter().position(|v| discr_val == v.disr_val) {
+                        match adt_def.discriminants(self.tcx).position(|v| discr_val == v.to_u128_unchecked()) {
                             Some(i) => {
                                 lval = Lvalue::Ptr {
                                     ptr,

--- a/src/terminator/drop.rs
+++ b/src/terminator/drop.rs
@@ -97,7 +97,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let (adt_ptr, extra) = lval.to_ptr_and_extra();
 
                 // run drop impl before the fields' drop impls
-                if let Some(drop_def_id) = adt_def.destructor(self.tcx) {
+                if let Some(destructor) = adt_def.destructor(self.tcx) {
                     let trait_ref = ty::Binder(ty::TraitRef {
                         def_id: self.tcx.lang_items.drop_trait().unwrap(),
                         substs: self.tcx.mk_substs_trait(ty, &[]),
@@ -112,7 +112,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         LvalueExtra::Length(n) => Value::ByValPair(PrimVal::Ptr(adt_ptr), PrimVal::from_u128(n as u128)),
                         LvalueExtra::Vtable(vtable) => Value::ByValPair(PrimVal::Ptr(adt_ptr), PrimVal::Ptr(vtable)),
                     };
-                    drop.push((drop_def_id, val, vtable.substs));
+                    drop.push((destructor.did, val, vtable.substs));
                 }
 
                 let layout = self.type_layout(ty)?;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -275,8 +275,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         // in case there is no drop function to be called, this still needs to be initialized
         self.memory.write_usize(vtable, 0)?;
         if let ty::TyAdt(adt_def, substs) = trait_ref.self_ty().sty {
-            if let Some(drop_def_id) = adt_def.destructor(self.tcx) {
-                let fn_ty = match self.tcx.item_type(drop_def_id).sty {
+            if let Some(destructor) = adt_def.destructor(self.tcx) {
+                let fn_ty = match self.tcx.item_type(destructor.did).sty {
                     ty::TyFnDef(_, _, fn_ty) => self.tcx.erase_regions(&fn_ty),
                     _ => bug!("drop method is not a TyFnDef"),
                 };

--- a/tests/compile-fail/cast_fn_ptr.rs
+++ b/tests/compile-fail/cast_fn_ptr.rs
@@ -5,5 +5,5 @@ fn main() {
         std::mem::transmute::<fn(), fn(i32)>(f)
     };
 
-    g(42) //~ ERROR tried to call a function with abi Rust and sig
+    g(42) //~ ERROR tried to call a function with sig fn() through a function pointer of type fn(i32)
 }

--- a/tests/run-pass/non_capture_closure_to_fn_ptr.rs
+++ b/tests/run-pass/non_capture_closure_to_fn_ptr.rs
@@ -1,0 +1,16 @@
+#![feature(closure_to_fn_coercion)]
+
+// allow(const_err) to work around a bug in warnings
+#[allow(const_err)]
+static FOO: fn() = || { assert_ne!(42, 43) };
+#[allow(const_err)]
+static BAR: fn(i32, i32) = |a, b| { assert_ne!(a, b) };
+
+fn main() {
+    FOO();
+    BAR(44, 45);
+    let bar: unsafe fn(i32, i32) = BAR;
+    unsafe { bar(46, 47) };
+    let boo: &Fn(i32, i32) = &BAR;
+    boo(48, 49);
+}

--- a/tests/run-pass/recursive_static.rs
+++ b/tests/run-pass/recursive_static.rs
@@ -1,5 +1,3 @@
-#![feature(static_recursion)]
-
 struct S(&'static S);
 static S1: S = S(&S2);
 static S2: S = S(&S1);

--- a/tests/run-pass/rfc1623.rs
+++ b/tests/run-pass/rfc1623.rs
@@ -1,0 +1,81 @@
+// Copyright 2012 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(dead_code)]
+
+// very simple test for a 'static static with default lifetime
+static STATIC_STR: &str = "&'static str";
+const CONST_STR: &str = "&'static str";
+
+// this should be the same as without default:
+static EXPLICIT_STATIC_STR: &'static str = "&'static str";
+const EXPLICIT_CONST_STR: &'static str = "&'static str";
+
+// a function that elides to an unbound lifetime for both in- and output
+fn id_u8_slice(arg: &[u8]) -> &[u8] {
+    arg
+}
+
+// one with a function, argument elided
+static STATIC_SIMPLE_FN: &fn(&[u8]) -> &[u8] = &(id_u8_slice as fn(&[u8]) -> &[u8]);
+const CONST_SIMPLE_FN: &fn(&[u8]) -> &[u8] = &(id_u8_slice as fn(&[u8]) -> &[u8]);
+
+// this should be the same as without elision
+static STATIC_NON_ELIDED_fN: &for<'a> fn(&'a [u8]) -> &'a [u8] =
+    &(id_u8_slice as for<'a> fn(&'a [u8]) -> &'a [u8]);
+const CONST_NON_ELIDED_fN: &for<'a> fn(&'a [u8]) -> &'a [u8] =
+    &(id_u8_slice as for<'a> fn(&'a [u8]) -> &'a [u8]);
+
+// another function that elides, each to a different unbound lifetime
+fn multi_args(a: &u8, b: &u8, c: &u8) {}
+
+static STATIC_MULTI_FN: &fn(&u8, &u8, &u8) = &(multi_args as fn(&u8, &u8, &u8));
+const CONST_MULTI_FN: &fn(&u8, &u8, &u8) = &(multi_args as fn(&u8, &u8, &u8));
+
+struct Foo<'a> {
+    bools: &'a [bool],
+}
+
+static STATIC_FOO: Foo = Foo { bools: &[true, false] };
+const CONST_FOO: Foo = Foo { bools: &[true, false] };
+
+type Bar<'a> = Foo<'a>;
+
+static STATIC_BAR: Bar = Bar { bools: &[true, false] };
+const CONST_BAR: Bar = Bar { bools: &[true, false] };
+
+type Baz<'a> = fn(&'a [u8]) -> Option<u8>;
+
+fn baz(e: &[u8]) -> Option<u8> {
+    e.first().map(|x| *x)
+}
+
+static STATIC_BAZ: &Baz = &(baz as Baz);
+const CONST_BAZ: &Baz = &(baz as Baz);
+
+static BYTES: &[u8] = &[1, 2, 3];
+
+fn main() {
+    // make sure that the lifetime is actually elided (and not defaulted)
+    let x = &[1u8, 2, 3];
+    STATIC_SIMPLE_FN(x);
+    CONST_SIMPLE_FN(x);
+
+    STATIC_BAZ(BYTES); // neees static lifetime
+    CONST_BAZ(BYTES);
+
+    // make sure this works with different lifetimes
+    let a = &1;
+    {
+        let b = &2;
+        let c = &3;
+        CONST_MULTI_FN(a, b, c);
+    }
+}

--- a/tests/run-pass/rfc1623.rs
+++ b/tests/run-pass/rfc1623.rs
@@ -28,13 +28,13 @@ static STATIC_SIMPLE_FN: &fn(&[u8]) -> &[u8] = &(id_u8_slice as fn(&[u8]) -> &[u
 const CONST_SIMPLE_FN: &fn(&[u8]) -> &[u8] = &(id_u8_slice as fn(&[u8]) -> &[u8]);
 
 // this should be the same as without elision
-static STATIC_NON_ELIDED_fN: &for<'a> fn(&'a [u8]) -> &'a [u8] =
+static STATIC_NON_ELIDED_FN: &for<'a> fn(&'a [u8]) -> &'a [u8] =
     &(id_u8_slice as for<'a> fn(&'a [u8]) -> &'a [u8]);
-const CONST_NON_ELIDED_fN: &for<'a> fn(&'a [u8]) -> &'a [u8] =
+const CONST_NON_ELIDED_FN: &for<'a> fn(&'a [u8]) -> &'a [u8] =
     &(id_u8_slice as for<'a> fn(&'a [u8]) -> &'a [u8]);
 
 // another function that elides, each to a different unbound lifetime
-fn multi_args(a: &u8, b: &u8, c: &u8) {}
+fn multi_args(_a: &u8, _b: &u8, _c: &u8) {}
 
 static STATIC_MULTI_FN: &fn(&u8, &u8, &u8) = &(multi_args as fn(&u8, &u8, &u8));
 const CONST_MULTI_FN: &fn(&u8, &u8, &u8) = &(multi_args as fn(&u8, &u8, &u8));


### PR DESCRIPTION
We can now turn non-capturing closures into function pointers (and then back into `Fn` trait objects)

Diff best viewed [without whitespace changes](https://github.com/solson/miri/pull/147/files?w=1)