### PR TITLE
fix argument order on check_align()

### DIFF
--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -410,7 +410,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let size = self.type_size(ty)?.expect("write_bytes() type must be sized");
                 let ptr = arg_vals[0].read_ptr(&self.memory)?;
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
-                self.memory.check_align(ptr, size * count, ty_align)?;
+                self.memory.check_align(ptr, ty_align, size * count)?;
                 self.memory.write_repeat(ptr, val_byte, size * count)?;
             }
 


### PR DESCRIPTION
Oops... I copied-and-pasted from [this comment](https://github.com/solson/miri/pull/148#discussion_r105805697) and apparently did not run the full test suite before pushing.