### PR TITLE
partially update for latest rustc nightly

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -82,7 +82,7 @@ fn after_analysis<'a, 'tcx>(state: &mut CompileState<'a, 'tcx>) {
         impl<'a, 'tcx: 'a, 'hir> itemlikevisit::ItemLikeVisitor<'hir> for Visitor<'a, 'tcx> {
             fn visit_item(&mut self, i: &'hir hir::Item) {
                 if let hir::Item_::ItemFn(_, _, _, _, _, body_id) = i.node {
-                    if i.attrs.iter().any(|attr| attr.value.name == "test") {
+                    if i.attrs.iter().any(|attr| attr.name().map_or(false, |n| n == "test")) {
                         let did = self.1.hir.body_owner_def_id(body_id);
                         println!("running test: {}", self.1.hir.def_path(did).to_string(self.1));
                         miri::eval_main(self.1, did, self.0);
@@ -117,8 +117,8 @@ fn resource_limits_from_attributes(state: &CompileState) -> miri::ResourceLimits
         }
     };
 
-    for attr in krate.attrs.iter().filter(|a| a.name() == "miri") {
-        if let MetaItemKind::List(ref items) = attr.value.node {
+    for attr in krate.attrs.iter().filter(|a| a.name().map_or(false, |n| n == "miri")) {
+        if let Some(items) = attr.meta_item_list() {
             for item in items {
                 if let NestedMetaItemKind::MetaItem(ref inner) = item.node {
                     if let MetaItemKind::NameValue(ref value) = inner.node {


### PR DESCRIPTION
This takes care of the breakage introduced by https://github.com/rust-lang/rust/pull/40346.

It does not take care of new test failures due to https://github.com/rust-lang/rust/pull/39628,
which is causing infinite `drop_in_place()` recursion.

