### PR TITLE
remove feature opt-ins that are no longer needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![feature(
-    btree_range,
-    collections,
     i128_type,
-    pub_restricted,
     rustc_private,
 )]
 


### PR DESCRIPTION
On `rustc 1.17.0-nightly (cab4bff3d 2017-03-21)` I see these warnings:

```
warning: this feature has been stable since 1.17.0. Attribute no longer needed
 --> src/lib.rs:5:5
  |
5 |     pub_restricted,
  |     ^^^^^^^^^^^^^^
  |
  = note: #[warn(stable_features)] on by default

warning: this feature has been stable since 1.17.0. Attribute no longer needed
 --> src/lib.rs:2:5
  |
2 |     btree_range,
  |     ^^^^^^^^^^^
  |
  = note: #[warn(stable_features)] on by default

warning: unused or unknown feature
 --> src/lib.rs:3:5
  |
3 |     collections,
  |     ^^^^^^^^^^^
  |
  = note: #[warn(unused_features)] on by default
```
