### PR TITLE
Update to rustc 1.19.0-nightly (777ee2079 2017-05-01)

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -248,7 +248,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for ConstantExtractor<'a, 'b, 'tcx> {
                     bug!("static def id doesn't point to item");
                 }
             } else {
-                let def = self.ecx.tcx.sess.cstore.describe_def(def_id).expect("static not found");
+                let def = self.ecx.tcx.describe_def(def_id).expect("static not found");
                 if let hir::def::Def::Static(_, mutable) = def {
                     self.global_item(def_id, substs, span, !mutable);
                 } else {


### PR DESCRIPTION
Failing a test because of https://github.com/rust-lang/rust/issues/41697

Manually running miri without `-Z dump-mir=all` works fine.