### PR TITLE
implement __rust_allocate_zeroed C ABI function

### DIFF
--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -493,6 +493,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 self.write_primval(dest, PrimVal::Ptr(ptr), dest_ty)?;
             }
 
+            "__rust_allocate_zeroed" => {
+                let size = self.value_to_primval(args[0], usize)?.to_u64()?;
+                let align = self.value_to_primval(args[1], usize)?.to_u64()?;
+                let ptr = self.memory.allocate(size, align)?;
+                self.memory.write_repeat(ptr, 0, size)?;
+                self.write_primval(dest, PrimVal::Ptr(ptr), dest_ty)?;
+            }
+
             "__rust_deallocate" => {
                 let ptr = args[0].read_ptr(&self.memory)?;
                 // FIXME: insert sanity check for size and align?

--- a/tests/run-pass/vecs.rs
+++ b/tests/run-pass/vecs.rs
@@ -13,6 +13,10 @@ fn make_vec_macro_repeat() -> Vec<u8> {
     vec![42; 5]
 }
 
+fn make_vec_macro_repeat_zeroed() -> Vec<u8> {
+    vec![0; 7]
+}
+
 fn vec_into_iter() -> u8 {
     vec![1, 2, 3, 4]
         .into_iter()
@@ -34,4 +38,5 @@ fn main() {
     assert_eq!(make_vec().capacity(), 4);
     assert_eq!(make_vec_macro(), [1, 2]);
     assert_eq!(make_vec_macro_repeat(), [42; 5]);
+    assert_eq!(make_vec_macro_repeat_zeroed(), [0; 7]);
 }


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/40409, we need to implement `__rust_allocate_zeroed()` in order to support vectors constructed like `vec![0; 10]`.