### PR TITLE
fix 'cargo run' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ rustup update nightly
 
 You should also make `nightly` the default version for your Miri directory by
 running the following command while you're in it. If you don't do this, you can
-run the later `cargo` commands by prefixing them with `rustup run nightly`.
+run the later `cargo` commands by using `cargo +nightly` instead.
 
 ```sh
 rustup override add nightly

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ how to fix it, you could send a PR. :smile:
 ## Running tests
 
 ```sh
-cargo run tests/run-pass/vecs.rs # Or whatever test you like.
+cargo run --bin miri tests/run-pass/vecs.rs # Or whatever test you like.
 ```
 
 ## Debugging


### PR DESCRIPTION
The command as given in the README fails with cargo complaining that there are two binaries and it does not know which one to run.