### PR TITLE
update for upstream changes with ty::ParamEnv

### DIFF
--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -377,7 +377,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(super) fn type_is_sized(&self, ty: Ty<'tcx>) -> bool {
         // generics are weird, don't run this function on a generic
         assert!(!ty.needs_subst());
-        ty.is_sized(self.tcx, &self.tcx.empty_parameter_environment(), DUMMY_SP)
+        ty.is_sized(self.tcx, ty::ParamEnv::empty(), DUMMY_SP)
     }
 
     pub fn load_mir(&self, instance: ty::InstanceDef<'tcx>) -> EvalResult<'tcx, &'tcx mir::Mir<'tcx>> {
@@ -1914,14 +1914,14 @@ pub fn needs_drop_glue<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, t: Ty<'tcx>) -> bo
     // returned `false` does not appear unsound. The impact on
     // code quality is unknown at this time.)
 
-    let env = tcx.empty_parameter_environment();
-    if !t.needs_drop(tcx, &env) {
+    let env = ty::ParamEnv::empty();
+    if !t.needs_drop(tcx, env) {
         return false;
     }
     match t.sty {
         ty::TyAdt(def, _) if def.is_box() => {
             let typ = t.boxed_ty();
-            if !typ.needs_drop(tcx, &env) && type_is_sized(tcx, typ) {
+            if !typ.needs_drop(tcx, env) && type_is_sized(tcx, typ) {
                 tcx.infer_ctxt((), traits::Reveal::All).enter(|infcx| {
                     let layout = t.layout(&infcx).unwrap();
                     // `Box<ZeroSizeType>` does not allocate.
@@ -2038,7 +2038,7 @@ impl<'a, 'tcx> ::rustc::ty::fold::TypeFolder<'tcx, 'tcx> for AssociatedTypeNorma
 fn type_is_sized<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> bool {
     // generics are weird, don't run this function on a generic
     assert!(!ty.needs_subst());
-    ty.is_sized(tcx, &tcx.empty_parameter_environment(), DUMMY_SP)
+    ty.is_sized(tcx, ty::ParamEnv::empty(), DUMMY_SP)
 }
 
 /// Attempts to resolve an obligation. The result is a shallow vtable resolution -- meaning that we

--- a/src/step.rs
+++ b/src/step.rs
@@ -164,7 +164,7 @@ impl<'a, 'b, 'tcx> ConstantExtractor<'a, 'b, 'tcx> {
             let mutable = !shared ||
                 !mir.return_ty.is_freeze(
                     this.ecx.tcx,
-                    &this.ecx.tcx.empty_parameter_environment(),
+                    ty::ParamEnv::empty(),
                     span);
             let cleanup = StackPopCleanup::MarkStatic(mutable);
             let name = ty::tls::with(|tcx| tcx.item_path_str(def_id));

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -291,8 +291,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "needs_drop" => {
                 let ty = substs.type_at(0);
-                let env = self.tcx.empty_parameter_environment();
-                let needs_drop = ty.needs_drop(self.tcx, &env);
+                let env = ty::ParamEnv::empty();
+                let needs_drop = ty.needs_drop(self.tcx, env);
                 self.write_primval(dest, PrimVal::from_bool(needs_drop), dest_ty)?;
             }
 


### PR DESCRIPTION
Fixes breakage from https://github.com/rust-lang/rust/pull/42015.