### PR TITLE
Work with MIR-libstd

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ rustup component add rust-src
 chmod +x -R ~/.rustup/toolchains/*/lib/rustlib/src/rust/src/jemalloc/include/jemalloc/
 cargo install xargo
 cd xargo/
-RUSTFLAGS='-Zalways-encode-mir' xargo build --target `rustc -vV | egrep '^host: ' | sed 's/^host: //'`
+RUSTFLAGS='-Zalways-encode-mir' xargo build
 ```
 
 Now you can run miri against the libstd compiled by xargo:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ miri hits a call to such a function, execution terminates.  To fix this, it is
 possible to compile libstd with full MIR:
 
 ```sh
+rustup component add rust-src
+chmod +x -R ~/.rustup/toolchains/*/lib/rustlib/src/rust/src/jemalloc/include/jemalloc/
 cargo install xargo
 cd xargo/
 RUSTFLAGS='-Zalways-encode-mir' xargo build --target `rustc -vV | egrep '^host: ' | sed 's/^host: //'`
@@ -73,8 +75,7 @@ cargo run --bin miri -- --sysroot ~/.xargo/HOST tests/run-pass/vecs.rs
 ```
 
 Notice that you will have to re-run the last step of the preparations above when
-your toolchain changes (e.g., when you update the nightly).  Also, xargo doesn't
-currently work with nightlies newer than 2017-04-23.
+your toolchain changes (e.g., when you update the nightly).
 
 ## Contributing and getting help
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ Then, inside your own project, use `cargo +nightly miri` to run your project, if
 a bin project, or run `cargo +nightly miri test` to run all tests in your project
 through miri.
 
+## Running miri with full libstd
+
+Per default libstd does not contain the MIR of non-polymorphic functions.  When
+miri hits a call to such a function, execution terminates.  To fix this, it is
+possible to compile libstd with full MIR:
+
+```sh
+cargo install xargo
+cd xargo/
+RUSTFLAGS='-Zalways-encode-mir' xargo build --target `rustc -vV | egrep '^host: ' | sed 's/^host: //'`
+```
+
+Now you can run miri against the libstd compiled by xargo:
+
+```sh
+cargo run --bin miri -- --sysroot ~/.xargo/HOST tests/run-pass/vecs.rs
+```
+
+Notice that you will have to re-run the last step of the preparations above when
+your toolchain changes (e.g., when you update the nightly).  Also, xargo doesn't
+currently work with nightlies newer than 2017-04-23.
+
 ## Contributing and getting help
 
 Check out the issues on this GitHub repository for some ideas. There's lots that

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -95,8 +95,8 @@ fn after_analysis<'a, 'tcx>(state: &mut CompileState<'a, 'tcx>) {
         state.hir_crate.unwrap().visit_all_item_likes(&mut Visitor(limits, tcx, state));
     } else if let Some((entry_node_id, _)) = *state.session.entry_fn.borrow() {
         let entry_def_id = tcx.hir.local_def_id(entry_node_id);
-        let start_wrapper = tcx.lang_items.start_fn()
-                                      .and_then(|start_fn| if tcx.is_mir_available(start_fn) { Some(start_fn) } else { None });
+        let start_wrapper = tcx.lang_items.start_fn().and_then(|start_fn|
+                                if tcx.is_mir_available(start_fn) { Some(start_fn) } else { None });
         miri::eval_main(tcx, entry_def_id, start_wrapper, limits);
 
         state.session.abort_if_errors();

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,8 @@ pub enum EvalError<'tcx> {
     },
     ExecutionTimeLimitReached,
     StackFrameLimitReached,
+    OutOfTls,
+    TlsOutOfBounds,
     AlignmentCheckFailed {
         required: u64,
         has: u64,
@@ -101,6 +103,10 @@ impl<'tcx> Error for EvalError<'tcx> {
                 "reached the configured maximum execution time",
             EvalError::StackFrameLimitReached =>
                 "reached the configured maximum number of stack frames",
+            EvalError::OutOfTls =>
+                "reached the maximum number of representable TLS keys",
+            EvalError::TlsOutOfBounds =>
+                "accessed an invalid (unallocated) TLS key",
             EvalError::AlignmentCheckFailed{..} =>
                 "tried to execute a misaligned read or write",
             EvalError::CalledClosureAsFunction =>

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,7 @@ pub enum EvalError<'tcx> {
     StackFrameLimitReached,
     OutOfTls,
     TlsOutOfBounds,
+    AbiViolation(String),
     AlignmentCheckFailed {
         required: u64,
         has: u64,
@@ -107,6 +108,7 @@ impl<'tcx> Error for EvalError<'tcx> {
                 "reached the maximum number of representable TLS keys",
             EvalError::TlsOutOfBounds =>
                 "accessed an invalid (unallocated) TLS key",
+            EvalError::AbiViolation(ref msg) => msg,
             EvalError::AlignmentCheckFailed{..} =>
                 "tried to execute a misaligned read or write",
             EvalError::CalledClosureAsFunction =>

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -1704,13 +1704,7 @@ pub fn eval_main<'a, 'tcx: 'a>(
             }
 
             // Return value
-            let ret_ptr = {
-                let ty = ecx.tcx.types.isize;
-                let layout = ecx.type_layout_with_substs(ty, Substs::empty())?;
-                let size = layout.size(&ecx.tcx.data_layout).bytes();
-                let align = layout.align(&ecx.tcx.data_layout).abi();
-                ecx.memory.allocate(size, align)?
-            };
+            let ret_ptr = ecx.memory.allocate(ecx.tcx.data_layout.pointer_size.bytes(), ecx.tcx.data_layout.pointer_align.abi())?;
             cleanup_ptr = Some(ret_ptr);
 
             // Push our stack frame

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -126,6 +126,7 @@ impl Default for ResourceLimits {
 
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub fn new(tcx: TyCtxt<'a, 'tcx, 'tcx>, limits: ResourceLimits) -> Self {
+        // Register array drop glue code
         let source_info = mir::SourceInfo {
             span: DUMMY_SP,
             scope: mir::ARGUMENT_VISIBILITY_SCOPE
@@ -852,7 +853,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                             let fn_ptr = self.memory.create_fn_alloc(instance);
                             self.write_value(Value::ByVal(PrimVal::Ptr(fn_ptr)), dest, dest_ty)?;
                         },
-                        ref other => bug!("reify fn pointer on {:?}", other),
+                        ref other => bug!("closure fn pointer on {:?}", other),
                     },
                 }
             }
@@ -1676,62 +1677,120 @@ impl<'tcx> Frame<'tcx> {
 
 pub fn eval_main<'a, 'tcx: 'a>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    def_id: DefId,
+    main_id: DefId,
+    start_wrapper: Option<DefId>,
     limits: ResourceLimits,
 ) {
-    let mut ecx = EvalContext::new(tcx, limits);
-    let instance = ty::Instance::mono(tcx, def_id);
-    let mir = ecx.load_mir(instance.def).expect("main function's MIR not found");
+    fn run_main<'a, 'tcx: 'a>(
+        ecx: &mut EvalContext<'a, 'tcx>,
+        main_id: DefId,
+        start_wrapper: Option<DefId>,
+    ) -> EvalResult<'tcx> {
+        let main_instance = ty::Instance::mono(ecx.tcx, main_id);
+        let main_mir = ecx.load_mir(main_instance.def)?;
 
-    if !mir.return_ty.is_nil() || mir.arg_count != 0 {
-        let msg = "miri does not support main functions without `fn()` type signatures";
-        tcx.sess.err(&EvalError::Unimplemented(String::from(msg)).to_string());
-        return;
+        if !main_mir.return_ty.is_nil() || main_mir.arg_count != 0 {
+            return Err(EvalError::Unimplemented("miri does not support main functions without `fn()` type signatures".to_owned()));
+        }
+
+        if let Some(start_id) = start_wrapper {
+            let start_instance = ty::Instance::mono(ecx.tcx, start_id);
+            let start_mir = ecx.load_mir(start_instance.def)?;
+
+            if start_mir.arg_count != 3 {
+                return Err(EvalError::AbiViolation(format!("'start' lang item should have three arguments, but has {}", start_mir.arg_count)));
+            }
+
+            // Push our stack frame
+            ecx.push_stack_frame(
+                start_instance,
+                start_mir.span,
+                start_mir,
+                Lvalue::from_ptr(Pointer::zst_ptr()), // we'll fix the return lvalue later
+                StackPopCleanup::None,
+            )?;
+
+            let mut args = ecx.frame().mir.args_iter();
+
+            // First argument: pointer to main()
+            let main_ptr = ecx.memory.create_fn_alloc(main_instance);
+            let dest = ecx.eval_lvalue(&mir::Lvalue::Local(args.next().unwrap()))?;
+            let main_ty = main_instance.def.def_ty(ecx.tcx);
+            let main_ptr_ty = ecx.tcx.mk_fn_ptr(main_ty.fn_sig());
+            ecx.write_value(Value::ByVal(PrimVal::Ptr(main_ptr)), dest, main_ptr_ty)?;
+
+            // Second argument (argc): 0
+            let dest = ecx.eval_lvalue(&mir::Lvalue::Local(args.next().unwrap()))?;
+            let ty = ecx.tcx.types.isize;
+            ecx.write_value(Value::ByVal(PrimVal::Bytes(0)), dest, ty)?;
+
+            // Third argument (argv): 0
+            let dest = ecx.eval_lvalue(&mir::Lvalue::Local(args.next().unwrap()))?;
+            let ty = ecx.tcx.mk_imm_ptr(ecx.tcx.mk_imm_ptr(ecx.tcx.types.u8));
+            ecx.write_value(Value::ByVal(PrimVal::Bytes(0)), dest, ty)?;
+        } else {
+            ecx.push_stack_frame(
+                main_instance,
+                main_mir.span,
+                main_mir,
+                Lvalue::from_ptr(Pointer::zst_ptr()),
+                StackPopCleanup::None,
+            )?;
+        }
+
+        // Allocate memory for the return value.  We have to do this when a stack frame was already pushed as the type code below
+        // calls EvalContext::substs, which needs a frame to be allocated (?!?)
+        let ret_ptr = {
+            let ty = ecx.tcx.types.isize;
+            let layout = ecx.type_layout(ty)?;
+            let size = layout.size(&ecx.tcx.data_layout).bytes();
+            let align = layout.align(&ecx.tcx.data_layout).pref(); // FIXME is this right?
+            ecx.memory.allocate(size, align)?
+        };
+        ecx.frame_mut().return_lvalue = Lvalue::from_ptr(ret_ptr);
+
+        loop {
+            if !ecx.step()? {
+                ecx.memory.deallocate(ret_ptr)?;
+                return Ok(());
+            }
+        }
     }
 
-    ecx.push_stack_frame(
-        instance,
-        DUMMY_SP,
-        mir,
-        Lvalue::from_ptr(Pointer::zst_ptr()),
-        StackPopCleanup::None,
-    ).expect("could not allocate first stack frame");
-
-    loop {
-        match ecx.step() {
-            Ok(true) => {}
-            Ok(false) => {
-                let leaks = ecx.memory.leak_report();
-                if leaks != 0 {
-                    tcx.sess.err("the evaluated program leaked memory");
-                }
-                return;
+    let mut ecx = EvalContext::new(tcx, limits);
+    match run_main(&mut ecx, main_id, start_wrapper) {
+        Ok(()) => {
+            let leaks = ecx.memory.leak_report();
+            if leaks != 0 {
+                tcx.sess.err("the evaluated program leaked memory");
             }
-            Err(e) => {
-                report(tcx, &ecx, e);
-                return;
-            }
+        }
+        Err(e) => {
+            report(tcx, &ecx, e);
         }
     }
 }
 
 fn report(tcx: TyCtxt, ecx: &EvalContext, e: EvalError) {
-    let frame = ecx.stack().last().expect("stackframe was empty");
-    let block = &frame.mir.basic_blocks()[frame.block];
-    let span = if frame.stmt < block.statements.len() {
-        block.statements[frame.stmt].source_info.span
-    } else {
-        block.terminator().source_info.span
-    };
-    let mut err = tcx.sess.struct_span_err(span, &e.to_string());
-    for &Frame { instance, span, .. } in ecx.stack().iter().rev() {
-        if tcx.def_key(instance.def_id()).disambiguated_data.data == DefPathData::ClosureExpr {
-            err.span_note(span, "inside call to closure");
-            continue;
+    if let Some(frame) = ecx.stack().last() {
+        let block = &frame.mir.basic_blocks()[frame.block];
+        let span = if frame.stmt < block.statements.len() {
+            block.statements[frame.stmt].source_info.span
+        } else {
+            block.terminator().source_info.span
+        };
+        let mut err = tcx.sess.struct_span_err(span, &e.to_string());
+        for &Frame { instance, span, .. } in ecx.stack().iter().rev() {
+            if tcx.def_key(instance.def_id()).disambiguated_data.data == DefPathData::ClosureExpr {
+                err.span_note(span, "inside call to closure");
+                continue;
+            }
+            err.span_note(span, &format!("inside call to {}", instance));
         }
-        err.span_note(span, &format!("inside call to {}", instance));
+        err.emit();
+    } else {
+        tcx.sess.err(&e.to_string());
     }
-    err.emit();
 }
 
 // TODO(solson): Upstream these methods into rustc::ty::layout.

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -104,6 +104,15 @@ impl<'tcx> Global<'tcx> {
             initialized: false,
         }
     }
+
+    pub(super) fn initialized(ty: Ty<'tcx>, value: Value, mutable: bool) -> Self {
+        Global {
+            value,
+            mutable,
+            ty,
+            initialized: true,
+        }
+    }
 }
 
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -100,7 +100,6 @@ impl Pointer {
     }
     
     pub fn is_null_ptr(&self) -> bool {
-        // FIXME: Is this the right way?
         return *self == Pointer::from_int(0)
     }
 }

--- a/src/step.rs
+++ b/src/step.rs
@@ -43,14 +43,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     Lvalue::from_ptr(Pointer::zst_ptr()),
                     StackPopCleanup::None,
                 )?;
-                if let Some(arg_local) = self.frame().mir.args_iter().next() {
-                    let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
-                    let ty = self.tcx.mk_mut_ptr(self.tcx.types.u8);
-                    self.write_value(Value::ByVal(PrimVal::Ptr(ptr)), dest, ty)?;
-                } else {
-                    return Err(EvalError::AbiViolation("TLS dtor does not take enough arguments.".to_owned()));
-                }
-
+                let arg_local = self.frame().mir.args_iter().next().ok_or(EvalError::AbiViolation("TLS dtor does not take enough arguments.".to_owned()))?;
+                let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
+                let ty = self.tcx.mk_mut_ptr(self.tcx.types.u8);
+                self.write_value(Value::ByVal(PrimVal::Ptr(ptr)), dest, ty)?;
                 return Ok(true);
             }
             return Ok(false);

--- a/src/step.rs
+++ b/src/step.rs
@@ -34,7 +34,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         if self.stack.is_empty() {
             if let Some((instance, ptr)) = self.memory.fetch_tls_dtor() {
                 trace!("Running TLS dtor {:?} on {:?}", instance, ptr);
-                // TODO: Potientiually, this has to support all the other possible instances? See eval_fn_call in terminator/mod.rs
+                // TODO: Potientially, this has to support all the other possible instances? See eval_fn_call in terminator/mod.rs
                 let mir = self.load_mir(instance.def)?;
                 self.push_stack_frame(
                     instance,

--- a/src/step.rs
+++ b/src/step.rs
@@ -14,7 +14,7 @@ use eval_context::{EvalContext, StackPopCleanup};
 use lvalue::{Global, GlobalId, Lvalue};
 use value::{Value, PrimVal};
 use memory::Pointer;
-use syntax::codemap::{Span, DUMMY_SP};
+use syntax::codemap::Span;
 
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub fn inc_step_counter_and_check_limit(&mut self, n: u64) -> EvalResult<'tcx> {
@@ -36,10 +36,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 trace!("Running TLS dtor {:?} on {:?}", instance, ptr);
                 // TODO: Potientiually, this has to support all the other possible instances? See eval_fn_call in terminator/mod.rs
                 let mir = self.load_mir(instance.def)?;
-                // FIXME: Are these the right dummy values?
                 self.push_stack_frame(
                     instance,
-                    DUMMY_SP,
+                    mir.span,
                     mir,
                     Lvalue::from_ptr(Pointer::zst_ptr()),
                     StackPopCleanup::None,
@@ -51,7 +50,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 } else {
                     return Err(EvalError::AbiViolation("TLS dtor does not take enough arguments.".to_owned()));
                 }
-                
+
                 return Ok(true);
             }
             return Ok(false);

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -622,6 +622,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 return Ok(());
             }
 
+            "__rust_start_panic" => {
+                return Err(EvalError::Panic);
+            }
+
             "memcmp" => {
                 let left = args[0].read_ptr(&self.memory)?;
                 let right = args[1].read_ptr(&self.memory)?;

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -727,7 +727,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 
                 // Extract the function type out of the signature (that seems easier than constructing it ourselves...)
                 let dtor_ptr = args[1].read_ptr(&self.memory)?;
-                // TODO: The null-pointer case here is entirely untested
                 let dtor = if dtor_ptr.is_null_ptr() { None } else { Some(self.memory.get_fn(dtor_ptr.alloc_id)?) };
                 
                 // Figure out how large a pthread TLS key actually is. This is libc::pthread_key_t.

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -587,11 +587,11 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let buf = args[1].read_ptr(&self.memory)?;
                 let n = self.value_to_primval(args[2], usize)?.to_u64()?;
                 trace!("Called write({:?}, {:?}, {:?})", fd, buf, n);
-                let result = if fd == 1 { // stdout
+                let result = if fd == 1 || fd == 2 { // stdout/stderr
                     use std::io::{self, Write};
                 
                     let buf_cont = self.memory.read_bytes(buf, n)?;
-                    let res = io::stdout().write(buf_cont);
+                    let res = if fd == 1 { io::stdout().write(buf_cont) } else { io::stderr().write(buf_cont) };
                     match res { Ok(n) => n as isize, Err(_) => -1 }
                 } else {
                     info!("Ignored output to FD {}", fd);

--- a/tests/compile-fail/cast_fn_ptr2.rs
+++ b/tests/compile-fail/cast_fn_ptr2.rs
@@ -1,0 +1,9 @@
+fn main() {
+    fn f(_ : (i32,i32)) {}
+
+    let g = unsafe {
+        std::mem::transmute::<fn((i32,i32)), fn(i32)>(f)
+    };
+
+    g(42) //~ ERROR tried to call a function with sig fn((i32, i32)) through a function pointer of type fn(i32)
+}

--- a/tests/compile-fail/env_args.rs
+++ b/tests/compile-fail/env_args.rs
@@ -1,4 +1,0 @@
-fn main() {
-    let x = std::env::args(); //~ ERROR miri does not support program arguments
-    assert_eq!(x.count(), 1);
-}

--- a/tests/compile-fail/oom.rs
+++ b/tests/compile-fail/oom.rs
@@ -1,7 +1,7 @@
 #![feature(custom_attribute, attr_literals)]
-#![miri(memory_size=20)]
+#![miri(memory_size=4095)]
 
 fn main() {
-    let _x = [42; 10];
-    //~^ERROR tried to allocate 40 more bytes, but only
+    let _x = [42; 1024];
+    //~^ERROR tried to allocate 4096 more bytes, but only
 }

--- a/tests/compile-fail/oom.rs
+++ b/tests/compile-fail/oom.rs
@@ -1,7 +1,7 @@
 #![feature(custom_attribute, attr_literals)]
-#![miri(memory_size=0)]
+#![miri(memory_size=20)]
 
 fn main() {
     let _x = [42; 10];
-    //~^ERROR tried to allocate 40 more bytes, but only 0 bytes are free of the 0 byte memory
+    //~^ERROR tried to allocate 40 more bytes, but only
 }

--- a/tests/compile-fail/oom2.rs
+++ b/tests/compile-fail/oom2.rs
@@ -1,5 +1,5 @@
 #![feature(box_syntax, custom_attribute, attr_literals)]
-#![miri(memory_size=1000)]
+#![miri(memory_size=2048)]
 
 fn main() {
     loop {

--- a/tests/compile-fail/stack_limit.rs
+++ b/tests/compile-fail/stack_limit.rs
@@ -1,5 +1,5 @@
 #![feature(custom_attribute, attr_literals)]
-#![miri(stack_limit=2)]
+#![miri(stack_limit=16)]
 
 fn bar() {
     foo();
@@ -10,10 +10,16 @@ fn foo() {
 }
 
 fn cake() {
-    flubber();
+    flubber(3);
 }
 
-fn flubber() {}
+fn flubber(i: u32) {
+    if i > 0 {
+        flubber(i-1);
+    } else {
+        bar();
+    }
+}
 
 fn main() {
     bar();

--- a/tests/run-pass/aux_test.rs
+++ b/tests/run-pass/aux_test.rs
@@ -1,5 +1,4 @@
 // aux-build:dep.rs
-// ignore-cross-compile
 
 extern crate dep;
 

--- a/tests/run-pass/aux_test.rs
+++ b/tests/run-pass/aux_test.rs
@@ -1,4 +1,5 @@
 // aux-build:dep.rs
+// ignore-cross-compile
 
 extern crate dep;
 

--- a/tests/run-pass/cast_fn_ptr.rs
+++ b/tests/run-pass/cast_fn_ptr.rs
@@ -1,0 +1,9 @@
+fn main() {
+    fn f(_: *const u8) {}
+
+    let g = unsafe {
+        std::mem::transmute::<fn(*const u8), fn(*const i32)>(f)
+    };
+
+    g(&42 as *const _);
+}

--- a/tests/run-pass/catch.rs
+++ b/tests/run-pass/catch.rs
@@ -1,0 +1,9 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+fn main() {
+    let mut i = 3;
+    let _ = catch_unwind(AssertUnwindSafe(|| {i -= 2;} ));
+    for _ in 0..i {
+        println!("I");
+    }
+}

--- a/tests/run-pass/format.rs
+++ b/tests/run-pass/format.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello {}", 13);
+}

--- a/tests/run-pass/hello.rs
+++ b/tests/run-pass/hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/run-pass/thread-local-no-dtor.rs
+++ b/tests/run-pass/thread-local-no-dtor.rs
@@ -1,0 +1,16 @@
+#![feature(libc)]
+extern crate libc;
+
+use std::mem;
+
+pub type Key = libc::pthread_key_t;
+
+pub unsafe fn create(dtor: Option<unsafe extern fn(*mut u8)>) -> Key {
+    let mut key = 0;
+    assert_eq!(libc::pthread_key_create(&mut key, mem::transmute(dtor)), 0);
+    key
+}
+
+fn main() {
+    let _ = unsafe { create(None) };
+}

--- a/tests/run-pass/zst.rs
+++ b/tests/run-pass/zst.rs
@@ -1,9 +1,3 @@
-// the following flag prevents this test from running on the host machine
-// this should only be run on miri, because rust doesn't (yet?) optimize ZSTs of different types
-// into the same memory location
-// ignore-test
-
-
 #[derive(PartialEq, Debug)]
 struct A;
 

--- a/xargo/Cargo.lock
+++ b/xargo/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "miri-xargo"
+version = "0.0.0"
+

--- a/xargo/Cargo.toml
+++ b/xargo/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "miri-xargo"
+description = "A dummy project for building libstd with xargo."
+version = "0.0.0"
+
+[dependencies]

--- a/xargo/Xargo.toml
+++ b/xargo/Xargo.toml
@@ -1,0 +1,2 @@
+[dependencies]
+std = {features = ["panic_unwind", "jemalloc"]}


### PR DESCRIPTION
This makes `println!("String literal")` mostly work when miri has a libstd with full MIR at its hands. It still complains about things not being deallocated when miri terminates; that may be related to thread-local dtors not running.

`println!("{}", foo)` still doesn't work because that code does some crazy casts which are currently rejected by miri.

Also I figured out how to use xargo to build a MIR-libstd, so I documented that. Now there's "just" some bugs to be fixed that currently break xargo's libstd support...