### PR TITLE
remove unneeded '-gnu' suffix from compiletest ignore directives

### DIFF
--- a/tests/run-pass/send-is-not-static-par-for.rs
+++ b/tests/run-pass/send-is-not-static-par-for.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//ignore-windows-gnu
+//ignore-windows
 
 use std::sync::Mutex;
 

--- a/tests/run-pass/thread-local-no-dtor.rs
+++ b/tests/run-pass/thread-local-no-dtor.rs
@@ -1,4 +1,4 @@
-//ignore-windows-gnu
+//ignore-windows
 
 #![feature(libc)]
 extern crate libc;


### PR DESCRIPTION
The `//ignore-windows-gnu` line accomplishes its goal because compiletest [searches for a match of `ignore-windows`](https://github.com/laumann/compiletest-rs/blob/904ec75edeeb67f892c29bf6c7d9ca0b9a809acf/src/header.rs#L57); the `-gnu` part has no effect.

See also, for example, [this rustc test](https://github.com/rust-lang/rust/blob/fd7b44b78e39c71e5049a210a0c84a8931835cc3/src/test/run-pass/i128-ffi.rs#L15) that is ignored on Windows.