### PR TITLE
Various pointer-related things

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub enum EvalError<'tcx> {
     InvalidDiscriminant,
     PointerOutOfBounds {
         ptr: Pointer,
-        size: u64,
+        access: bool,
         allocation_size: u64,
     },
     ReadPointerAsBytes,
@@ -150,9 +150,10 @@ impl<'tcx> Error for EvalError<'tcx> {
 impl<'tcx> fmt::Display for EvalError<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            EvalError::PointerOutOfBounds { ptr, size, allocation_size } => {
-                write!(f, "memory access of {}..{} outside bounds of allocation {} which has size {}",
-                       ptr.offset, ptr.offset + size, ptr.alloc_id, allocation_size)
+            EvalError::PointerOutOfBounds { ptr, access, allocation_size } => {
+                write!(f, "{} at offset {}, outside bounds of allocation {} which has size {}",
+                       if access { "memory access" } else { "pointer computed" },
+                       ptr.offset, ptr.alloc_id, allocation_size)
             },
             EvalError::NoMirFor(ref func) => write!(f, "no mir for `{}`", func),
             EvalError::FunctionPointerTyMismatch(sig, got) =>

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,7 @@ pub enum EvalError<'tcx> {
     },
     ReadPointerAsBytes,
     InvalidPointerMath,
+    OverflowingPointerMath,
     ReadUndefBytes,
     DeadLocal,
     InvalidBoolOp(mir::BinOp),
@@ -82,6 +83,8 @@ impl<'tcx> Error for EvalError<'tcx> {
                 "a raw memory access tried to access part of a pointer value as raw bytes",
             EvalError::InvalidPointerMath =>
                 "attempted to do math or a comparison on pointers into different allocations",
+            EvalError::OverflowingPointerMath =>
+                "attempted to do overflowing math on a pointer",
             EvalError::ReadUndefBytes =>
                 "attempted to read undefined bytes",
             EvalError::DeadLocal =>

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -1438,6 +1438,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     panic!("Failed to access local: {:?}", err);
                 }
                 Ok(Value::ByRef(ptr)) => {
+                    write!(msg, " by ref:").unwrap();
                     allocs.push(ptr.alloc_id);
                 }
                 Ok(Value::ByVal(val)) => {

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -391,7 +391,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         // FIXME(solson)
         let dest_ptr = self.force_allocation(dest)?.to_ptr();
 
-        let discr_dest = dest_ptr.offset(discr_offset)?;
+        let discr_dest = dest_ptr.offset(discr_offset, self.memory.layout)?;
         self.memory.write_uint(discr_dest, discr_val, discr_size)?;
 
         let dest = Lvalue::Ptr {
@@ -550,7 +550,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                 // FIXME(solson)
                                 let dest = self.force_allocation(dest)?.to_ptr();
 
-                                let dest = dest.offset(offset.bytes())?;
+                                let dest = dest.offset(offset.bytes(), self.memory.layout)?;
                                 let dest_size = self.type_size(ty)?
                                     .expect("bad StructWrappedNullablePointer discrfield");
                                 self.memory.write_int(dest, 0, dest_size)?;
@@ -610,7 +610,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let dest = self.force_allocation(dest)?.to_ptr();
 
                 for i in 0..length {
-                    let elem_dest = dest.offset(i * elem_size)?;
+                    let elem_dest = dest.offset(i * elem_size, self.memory.layout)?;
                     self.write_value_to_ptr(value, elem_dest, elem_ty)?;
                 }
             }
@@ -854,7 +854,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         // FIXME: assuming here that type size is < i64::max_value()
         let pointee_size = self.type_size(pointee_ty)?.expect("cannot offset a pointer to an unsized type") as i64;
         let offset = offset.overflowing_mul(pointee_size).0;
-        Ok(ptr.wrapping_signed_offset(offset))
+        Ok(ptr.wrapping_signed_offset(offset, self.memory.layout))
     }
 
     pub(super) fn pointer_offset(&self, ptr: Pointer, pointee_ty: Ty<'tcx>, offset: i64) -> EvalResult<'tcx, Pointer> {
@@ -865,7 +865,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         // FIXME: assuming here that type size is < i64::max_value()
         let pointee_size = self.type_size(pointee_ty)?.expect("cannot offset a pointer to an unsized type") as i64;
         return if let Some(offset) = offset.checked_mul(pointee_size) {
-            let ptr = ptr.signed_offset(offset)?;
+            let ptr = ptr.signed_offset(offset, self.memory.layout)?;
             self.memory.check_bounds(ptr, false)?;
             Ok(ptr)
         } else {
@@ -1124,8 +1124,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let field_1_ty = self.get_field_ty(ty, 1)?;
         let field_0_size = self.type_size(field_0_ty)?.expect("pair element type must be sized");
         let field_1_size = self.type_size(field_1_ty)?.expect("pair element type must be sized");
-        self.memory.write_primval(ptr.offset(field_0)?, a, field_0_size)?;
-        self.memory.write_primval(ptr.offset(field_1)?, b, field_1_size)?;
+        self.memory.write_primval(ptr.offset(field_0, self.memory.layout)?, a, field_0_size)?;
+        self.memory.write_primval(ptr.offset(field_1, self.memory.layout)?, b, field_1_size)?;
         Ok(())
     }
 
@@ -1242,7 +1242,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             Ok(Value::ByVal(PrimVal::Ptr(p)))
         } else {
             trace!("reading fat pointer extra of type {}", pointee_ty);
-            let extra = ptr.offset(self.memory.pointer_size())?;
+            let extra = ptr.offset(self.memory.pointer_size(), self.memory.layout)?;
             let extra = match self.tcx.struct_tail(pointee_ty).sty {
                 ty::TyDynamic(..) => PrimVal::Ptr(self.memory.read_ptr(extra)?),
                 ty::TySlice(..) |
@@ -1427,8 +1427,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     }
                     let src_field_offset = self.get_field_offset(src_ty, i)?.bytes();
                     let dst_field_offset = self.get_field_offset(dest_ty, i)?.bytes();
-                    let src_f_ptr = src_ptr.offset(src_field_offset)?;
-                    let dst_f_ptr = dest.offset(dst_field_offset)?;
+                    let src_f_ptr = src_ptr.offset(src_field_offset, self.memory.layout)?;
+                    let dst_f_ptr = dest.offset(dst_field_offset, self.memory.layout)?;
                     if src_fty == dst_fty {
                         self.copy(src_f_ptr, dst_f_ptr, src_fty)?;
                     } else {

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -270,7 +270,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             _ => offset.bytes(),
         };
 
-        let ptr = base_ptr.offset(offset)?;
+        let ptr = base_ptr.offset(offset, self.memory.layout)?;
 
         let field_ty = self.monomorphize(field_ty, self.substs());
 
@@ -363,7 +363,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let usize = self.tcx.types.usize;
                 let n = self.value_to_primval(n_ptr, usize)?.to_u64()?;
                 assert!(n < len, "Tried to access element {} of array/slice with length {}", n, len);
-                let ptr = base_ptr.offset(n * elem_size)?;
+                let ptr = base_ptr.offset(n * elem_size, self.memory.layout)?;
                 (ptr, LvalueExtra::None)
             }
 
@@ -384,7 +384,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     u64::from(offset)
                 };
 
-                let ptr = base_ptr.offset(index * elem_size)?;
+                let ptr = base_ptr.offset(index * elem_size, self.memory.layout)?;
                 (ptr, LvalueExtra::None)
             }
 
@@ -398,7 +398,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let (elem_ty, n) = base.elem_ty_and_len(base_ty);
                 let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized");
                 assert!(u64::from(from) <= n - u64::from(to));
-                let ptr = base_ptr.offset(u64::from(from) * elem_size)?;
+                let ptr = base_ptr.offset(u64::from(from) * elem_size, self.memory.layout)?;
                 let extra = LvalueExtra::Length(n - u64::from(to) - u64::from(from));
                 (ptr, extra)
             }

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -270,7 +270,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             _ => offset.bytes(),
         };
 
-        let ptr = base_ptr.offset(offset);
+        let ptr = base_ptr.offset(offset)?;
 
         let field_ty = self.monomorphize(field_ty, self.substs());
 
@@ -363,7 +363,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let usize = self.tcx.types.usize;
                 let n = self.value_to_primval(n_ptr, usize)?.to_u64()?;
                 assert!(n < len, "Tried to access element {} of array/slice with length {}", n, len);
-                let ptr = base_ptr.offset(n * elem_size);
+                let ptr = base_ptr.offset(n * elem_size)?;
                 (ptr, LvalueExtra::None)
             }
 
@@ -384,7 +384,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     u64::from(offset)
                 };
 
-                let ptr = base_ptr.offset(index * elem_size);
+                let ptr = base_ptr.offset(index * elem_size)?;
                 (ptr, LvalueExtra::None)
             }
 
@@ -398,7 +398,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let (elem_ty, n) = base.elem_ty_and_len(base_ty);
                 let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized");
                 assert!(u64::from(from) <= n - u64::from(to));
-                let ptr = base_ptr.offset(u64::from(from) * elem_size);
+                let ptr = base_ptr.offset(u64::from(from) * elem_size)?;
                 let extra = LvalueExtra::Length(n - u64::from(to) - u64::from(from));
                 (ptr, extra)
             }

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -43,10 +43,11 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
 
             "arith_offset" => {
+                // FIXME: Switch to non-checked, wrapped version of pointer_offset
+                let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()? as i64;
                 let ptr = arg_vals[0].read_ptr(&self.memory)?;
-                let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()?;
-                let new_ptr = ptr.signed_offset(offset as i64);
-                self.write_primval(dest, PrimVal::Ptr(new_ptr), dest_ty)?;
+                let result_ptr = self.pointer_offset(ptr, substs.type_at(0), offset)?;
+                self.write_primval(dest, PrimVal::Ptr(result_ptr), dest_ty)?;
             }
 
             "assume" => {

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -414,8 +414,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let size = self.type_size(ty)?.expect("write_bytes() type must be sized");
                 let ptr = arg_vals[0].read_ptr(&self.memory)?;
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
-                self.memory.check_align(ptr, ty_align, size * count)?;
-                self.memory.write_repeat(ptr, val_byte, size * count)?;
+                if count > 0 {
+                    self.memory.check_align(ptr, ty_align, size * count)?;
+                    self.memory.write_repeat(ptr, val_byte, size * count)?;
+                }
             }
 
             name => return Err(EvalError::Unimplemented(format!("unimplemented intrinsic: {}", name))),

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -46,7 +46,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 // FIXME: Switch to non-checked, wrapped version of pointer_offset
                 let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()? as i64;
                 let ptr = arg_vals[0].read_ptr(&self.memory)?;
-                let result_ptr = self.pointer_offset(ptr, substs.type_at(0), offset)?;
+                let result_ptr = self.wrapping_pointer_offset(ptr, substs.type_at(0), offset)?;
                 self.write_primval(dest, PrimVal::Ptr(result_ptr), dest_ty)?;
             }
 

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -305,7 +305,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                 match arg_val {
                                     Value::ByRef(ptr) => {
                                         for ((offset, ty), arg_local) in offsets.zip(fields).zip(arg_locals) {
-                                            let arg = Value::ByRef(ptr.offset(offset));
+                                            let arg = Value::ByRef(ptr.offset(offset)?);
                                             let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
                                             trace!("writing arg {:?} to {:?} (type: {})", arg, dest, ty);
                                             self.write_value(arg, dest, ty)?;
@@ -387,7 +387,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             ty::InstanceDef::Virtual(_, idx) => {
                 let ptr_size = self.memory.pointer_size();
                 let (_, vtable) = self.eval_operand(&arg_operands[0])?.expect_ptr_vtable_pair(&self.memory)?;
-                let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3)))?;
+                let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3))?)?;
                 let instance = self.memory.get_fn(fn_ptr.alloc_id)?;
                 let mut arg_operands = arg_operands.to_vec();
                 let ty = self.operand_ty(&arg_operands[0]);
@@ -473,7 +473,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             StructWrappedNullablePointer { nndiscr, ref discrfield, .. } => {
                 let (offset, ty) = self.nonnull_offset_and_ty(adt_ty, nndiscr, discrfield)?;
-                let nonnull = adt_ptr.offset(offset.bytes());
+                let nonnull = adt_ptr.offset(offset.bytes())?;
                 trace!("struct wrapped nullable pointer type: {}", ty);
                 // only the pointer part of a fat pointer is used for this space optimization
                 let discr_size = self.type_size(ty)?.expect("bad StructWrappedNullablePointer discrfield");
@@ -654,7 +654,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().rev().position(|&c| c == val) {
-                    let new_ptr = ptr.offset(num - idx as u64 - 1);
+                    let new_ptr = ptr.offset(num - idx as u64 - 1)?;
                     self.write_primval(dest, PrimVal::Ptr(new_ptr), dest_ty)?;
                 } else {
                     self.write_primval(dest, PrimVal::Bytes(0), dest_ty)?;
@@ -666,7 +666,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().position(|&c| c == val) {
-                    let new_ptr = ptr.offset(idx as u64);
+                    let new_ptr = ptr.offset(idx as u64)?;
                     self.write_primval(dest, PrimVal::Ptr(new_ptr), dest_ty)?;
                 } else {
                     self.write_primval(dest, PrimVal::Bytes(0), dest_ty)?;

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -742,6 +742,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 if key_size.bits() < 128 && key >= (1u128 << key_size.bits() as u128) {
                     return Err(EvalError::OutOfTls);
                 }
+                // TODO: Does this need checking for alignment?
                 self.memory.write_uint(key_ptr, key, key_size.bytes())?;
 
                 // Return success (0)

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -305,7 +305,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                 match arg_val {
                                     Value::ByRef(ptr) => {
                                         for ((offset, ty), arg_local) in offsets.zip(fields).zip(arg_locals) {
-                                            let arg = Value::ByRef(ptr.offset(offset)?);
+                                            let arg = Value::ByRef(ptr.offset(offset, self.memory.layout)?);
                                             let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
                                             trace!("writing arg {:?} to {:?} (type: {})", arg, dest, ty);
                                             self.write_value(arg, dest, ty)?;
@@ -387,7 +387,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             ty::InstanceDef::Virtual(_, idx) => {
                 let ptr_size = self.memory.pointer_size();
                 let (_, vtable) = self.eval_operand(&arg_operands[0])?.expect_ptr_vtable_pair(&self.memory)?;
-                let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3))?)?;
+                let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3), self.memory.layout)?)?;
                 let instance = self.memory.get_fn(fn_ptr.alloc_id)?;
                 let mut arg_operands = arg_operands.to_vec();
                 let ty = self.operand_ty(&arg_operands[0]);
@@ -473,7 +473,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             StructWrappedNullablePointer { nndiscr, ref discrfield, .. } => {
                 let (offset, ty) = self.nonnull_offset_and_ty(adt_ty, nndiscr, discrfield)?;
-                let nonnull = adt_ptr.offset(offset.bytes())?;
+                let nonnull = adt_ptr.offset(offset.bytes(), self.memory.layout)?;
                 trace!("struct wrapped nullable pointer type: {}", ty);
                 // only the pointer part of a fat pointer is used for this space optimization
                 let discr_size = self.type_size(ty)?.expect("bad StructWrappedNullablePointer discrfield");
@@ -654,7 +654,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().rev().position(|&c| c == val) {
-                    let new_ptr = ptr.offset(num - idx as u64 - 1)?;
+                    let new_ptr = ptr.offset(num - idx as u64 - 1, self.memory.layout)?;
                     self.write_primval(dest, PrimVal::Ptr(new_ptr), dest_ty)?;
                 } else {
                     self.write_primval(dest, PrimVal::Bytes(0), dest_ty)?;
@@ -666,7 +666,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().position(|&c| c == val) {
-                    let new_ptr = ptr.offset(idx as u64)?;
+                    let new_ptr = ptr.offset(idx as u64, self.memory.layout)?;
                     self.write_primval(dest, PrimVal::Ptr(new_ptr), dest_ty)?;
                 } else {
                     self.write_primval(dest, PrimVal::Bytes(0), dest_ty)?;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -56,14 +56,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let drop = self.memory.create_fn_alloc(drop);
         self.memory.write_ptr(vtable, drop)?;
 
-        self.memory.write_usize(vtable.offset(ptr_size)?, size)?;
-        self.memory.write_usize(vtable.offset(ptr_size * 2)?, align)?;
+        self.memory.write_usize(vtable.offset(ptr_size, self.memory.layout)?, size)?;
+        self.memory.write_usize(vtable.offset(ptr_size * 2, self.memory.layout)?, align)?;
 
         for (i, method) in ::rustc::traits::get_vtable_methods(self.tcx, trait_ref).enumerate() {
             if let Some((def_id, substs)) = method {
                 let instance = ::eval_context::resolve(self.tcx, def_id, substs);
                 let fn_ptr = self.memory.create_fn_alloc(instance);
-                self.memory.write_ptr(vtable.offset(ptr_size * (3 + i as u64))?, fn_ptr)?;
+                self.memory.write_ptr(vtable.offset(ptr_size * (3 + i as u64), self.memory.layout)?, fn_ptr)?;
             }
         }
 
@@ -88,8 +88,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
     pub fn read_size_and_align_from_vtable(&self, vtable: Pointer) -> EvalResult<'tcx, (u64, u64)> {
         let pointer_size = self.memory.pointer_size();
-        let size = self.memory.read_usize(vtable.offset(pointer_size)?)?;
-        let align = self.memory.read_usize(vtable.offset(pointer_size * 2)?)?;
+        let size = self.memory.read_usize(vtable.offset(pointer_size, self.memory.layout)?)?;
+        let align = self.memory.read_usize(vtable.offset(pointer_size * 2, self.memory.layout)?)?;
         Ok((size, align))
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -56,14 +56,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let drop = self.memory.create_fn_alloc(drop);
         self.memory.write_ptr(vtable, drop)?;
 
-        self.memory.write_usize(vtable.offset(ptr_size), size)?;
-        self.memory.write_usize(vtable.offset(ptr_size * 2), align)?;
+        self.memory.write_usize(vtable.offset(ptr_size)?, size)?;
+        self.memory.write_usize(vtable.offset(ptr_size * 2)?, align)?;
 
         for (i, method) in ::rustc::traits::get_vtable_methods(self.tcx, trait_ref).enumerate() {
             if let Some((def_id, substs)) = method {
                 let instance = ::eval_context::resolve(self.tcx, def_id, substs);
                 let fn_ptr = self.memory.create_fn_alloc(instance);
-                self.memory.write_ptr(vtable.offset(ptr_size * (3 + i as u64)), fn_ptr)?;
+                self.memory.write_ptr(vtable.offset(ptr_size * (3 + i as u64))?, fn_ptr)?;
             }
         }
 
@@ -88,8 +88,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
     pub fn read_size_and_align_from_vtable(&self, vtable: Pointer) -> EvalResult<'tcx, (u64, u64)> {
         let pointer_size = self.memory.pointer_size();
-        let size = self.memory.read_usize(vtable.offset(pointer_size))?;
-        let align = self.memory.read_usize(vtable.offset(pointer_size * 2))?;
+        let size = self.memory.read_usize(vtable.offset(pointer_size)?)?;
+        let align = self.memory.read_usize(vtable.offset(pointer_size * 2)?)?;
         Ok((size, align))
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -90,7 +90,7 @@ impl<'a, 'tcx: 'a> Value {
         match *self {
             ByRef(ref_ptr) => {
                 let ptr = mem.read_ptr(ref_ptr)?;
-                let vtable = mem.read_ptr(ref_ptr.offset(mem.pointer_size()))?;
+                let vtable = mem.read_ptr(ref_ptr.offset(mem.pointer_size())?)?;
                 Ok((ptr, vtable))
             }
 
@@ -105,7 +105,7 @@ impl<'a, 'tcx: 'a> Value {
         match *self {
             ByRef(ref_ptr) => {
                 let ptr = mem.read_ptr(ref_ptr)?;
-                let len = mem.read_usize(ref_ptr.offset(mem.pointer_size()))?;
+                let len = mem.read_usize(ref_ptr.offset(mem.pointer_size())?)?;
                 Ok((ptr, len))
             },
             ByValPair(ptr, val) => {

--- a/src/value.rs
+++ b/src/value.rs
@@ -243,4 +243,12 @@ impl PrimValKind {
             _ => bug!("can't make int with size {}", size),
         }
     }
+
+    pub fn is_ptr(self) -> bool {
+        use self::PrimValKind::*;
+        match self {
+            Ptr | FnPtr => true,
+            _ => false,
+        }
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -90,7 +90,7 @@ impl<'a, 'tcx: 'a> Value {
         match *self {
             ByRef(ref_ptr) => {
                 let ptr = mem.read_ptr(ref_ptr)?;
-                let vtable = mem.read_ptr(ref_ptr.offset(mem.pointer_size())?)?;
+                let vtable = mem.read_ptr(ref_ptr.offset(mem.pointer_size(), mem.layout)?)?;
                 Ok((ptr, vtable))
             }
 
@@ -105,7 +105,7 @@ impl<'a, 'tcx: 'a> Value {
         match *self {
             ByRef(ref_ptr) => {
                 let ptr = mem.read_ptr(ref_ptr)?;
-                let len = mem.read_usize(ref_ptr.offset(mem.pointer_size())?)?;
+                let len = mem.read_usize(ref_ptr.offset(mem.pointer_size(), mem.layout)?)?;
                 Ok((ptr, len))
             },
             ByValPair(ptr, val) => {

--- a/tests/compile-fail/out_of_bounds_ptr_1.rs
+++ b/tests/compile-fail/out_of_bounds_ptr_1.rs
@@ -1,0 +1,8 @@
+// error-pattern: pointer computed at offset 5, outside bounds of allocation
+fn main() {
+    let v = [0i8; 4];
+    let x = &v as *const i8;
+    // The error is inside another function, so we cannot match it by line
+    let x = unsafe { x.offset(5) };
+    panic!("this should never print: {:?}", x);
+}

--- a/tests/compile-fail/out_of_bounds_ptr_2.rs
+++ b/tests/compile-fail/out_of_bounds_ptr_2.rs
@@ -1,0 +1,7 @@
+// error-pattern: overflowing math on a pointer
+fn main() {
+    let v = [0i8; 4];
+    let x = &v as *const i8;
+    let x = unsafe { x.offset(-1) };
+    panic!("this should never print: {:?}", x);
+}

--- a/tests/compile-fail/out_of_bounds_read.rs
+++ b/tests/compile-fail/out_of_bounds_read.rs
@@ -1,5 +1,5 @@
 fn main() {
     let v: Vec<u8> = vec![1, 2];
-    let x = unsafe { *v.get_unchecked(5) }; //~ ERROR: which has size 2
+    let x = unsafe { *v.as_ptr().wrapping_offset(5) }; //~ ERROR: which has size 2
     panic!("this should never print: {}", x);
 }

--- a/tests/compile-fail/out_of_bounds_read2.rs
+++ b/tests/compile-fail/out_of_bounds_read2.rs
@@ -1,5 +1,5 @@
 fn main() {
     let v: Vec<u8> = vec![1, 2];
-    let x = unsafe { *v.get_unchecked(5) }; //~ ERROR: memory access of 5..6 outside bounds of allocation
+    let x = unsafe { *v.as_ptr().wrapping_offset(5) }; //~ ERROR: memory access at offset 6, outside bounds of allocation
     panic!("this should never print: {}", x);
 }

--- a/tests/compile-fail/overflowing-lsh-neg.rs
+++ b/tests/compile-fail/overflowing-lsh-neg.rs
@@ -1,0 +1,16 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![allow(exceeding_bitshifts)]
+#![allow(const_err)]
+
+fn main() {
+    let _n = 2i64 << -1; //~ Overflow(Shl)
+}

--- a/tests/compile-fail/pointer_byte_read_1.rs
+++ b/tests/compile-fail/pointer_byte_read_1.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let x = 13;
+    let y = &x;
+    let z = &y as *const &i32 as *const usize;
+    let ptr_bytes = unsafe { *z }; // the actual deref is fine, because we read the entire pointer at once
+    let _ = ptr_bytes == 15; //~ ERROR: tried to access part of a pointer value as raw bytes
+}

--- a/tests/compile-fail/pointer_byte_read_2.rs
+++ b/tests/compile-fail/pointer_byte_read_2.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let x = 13;
+    let y = &x;
+    let z = &y as *const &i32 as *const u8;
+    // the deref fails, because we are reading only a part of the pointer
+    let _ = unsafe { *z }; //~ ERROR: tried to access part of a pointer value as raw bytes
+}

--- a/tests/compile-fail/ptr_bitops.rs
+++ b/tests/compile-fail/ptr_bitops.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let bytes = [0i8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let one = bytes.as_ptr().wrapping_offset(1);
+    let three = bytes.as_ptr().wrapping_offset(3);
+    let res = (one as usize) | (three as usize); //~ ERROR a raw memory access tried to access part of a pointer value as raw bytes
+    println!("{}", res);
+}

--- a/tests/compile-fail/ptr_offset_overflow.rs
+++ b/tests/compile-fail/ptr_offset_overflow.rs
@@ -2,7 +2,5 @@
 fn main() {
     let v = [1i8, 2];
     let x = &v[1] as *const i8;
-    // One of them is guaranteed to overflow
-    let _ = unsafe { x.offset(isize::max_value()) };
     let _ = unsafe { x.offset(isize::min_value()) };
 }

--- a/tests/compile-fail/ptr_offset_overflow.rs
+++ b/tests/compile-fail/ptr_offset_overflow.rs
@@ -1,0 +1,8 @@
+//error-pattern: overflowing math on a pointer
+fn main() {
+    let v = [1i8, 2];
+    let x = &v[1] as *const i8;
+    // One of them is guaranteed to overflow
+    let _ = unsafe { x.offset(isize::max_value()) };
+    let _ = unsafe { x.offset(isize::min_value()) };
+}

--- a/tests/run-pass/aux_test.rs
+++ b/tests/run-pass/aux_test.rs
@@ -1,4 +1,5 @@
 // aux-build:dep.rs
+// This ignores the test against rustc, but runs it against miri:
 // ignore-cross-compile
 
 extern crate dep;

--- a/tests/run-pass/drop_empty_slice.rs
+++ b/tests/run-pass/drop_empty_slice.rs
@@ -1,0 +1,9 @@
+#![feature(box_syntax)]
+// This disables the test completely:
+// ignore-stage1
+
+fn main() {
+    // With the nested Vec, this is calling Offset(Unique::empty(), 0).
+    let args : Vec<Vec<i32>> = Vec::new();
+    let local = box args;
+}

--- a/tests/run-pass/hashmap.rs
+++ b/tests/run-pass/hashmap.rs
@@ -1,0 +1,19 @@
+use std::collections::{self, HashMap};
+use std::hash::BuildHasherDefault;
+
+// This disables the test completely:
+// ignore-stage1
+// TODO: The tests actually passes against rustc and miri with MIR-libstd, but right now, we cannot express that in the test flags
+
+fn main() {
+    let map : HashMap<String, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
+    assert_eq!(map.values().fold(0, |x, y| x+y), 0);
+
+    // TODO: This performs bit operations on the least significant bit of a pointer
+//     for i in 0..33 {
+//         map.insert(format!("key_{}", i), i);
+//         assert_eq!(map.values().fold(0, |x, y| x+y), i*(i+1)/2);
+//     }
+
+    // TODO: Test Entry API
+}

--- a/tests/run-pass/iter_slice.rs
+++ b/tests/run-pass/iter_slice.rs
@@ -1,0 +1,12 @@
+fn main() {
+    for _ in Vec::<u32>::new().iter() { // this iterates over a Unique::empty()
+        panic!("We should never be here.");
+    }
+
+    // Iterate over a ZST (uses arith_offset internally)
+    let mut count = 0;
+    for _ in &[(), (), ()] {
+        count += 1;
+    }
+    assert_eq!(count, 3);
+}

--- a/tests/run-pass/ptr_arith_offset.rs
+++ b/tests/run-pass/ptr_arith_offset.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let v = [1i16, 2];
+    let x = &v as *const i16;
+    let x = x.wrapping_offset(1);
+    assert_eq!(unsafe { *x }, 2);
+}

--- a/tests/run-pass/ptr_arith_offset_overflow.rs
+++ b/tests/run-pass/ptr_arith_offset_overflow.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let v = [1i16, 2];
+    let x = &v[1] as *const i16;
+    // Adding 2*isize::max and then 1 is like substracting 1
+    let x = x.wrapping_offset(isize::max_value());
+    let x = x.wrapping_offset(isize::max_value());
+    let x = x.wrapping_offset(1);
+    assert_eq!(unsafe { *x }, 1);
+}

--- a/tests/run-pass/ptr_int_casts.rs
+++ b/tests/run-pass/ptr_int_casts.rs
@@ -1,0 +1,16 @@
+// fn eq_ref<T>(x: &T, y: &T) -> bool {
+//     x as *const _ == y as *const _
+// }
+
+fn main() {
+    // int-ptr-int
+    assert_eq!(1 as *const i32 as usize, 1);
+
+    // TODO
+//     {   // ptr-int-ptr
+//         let x = 13;
+//         let y = &x as *const _ as usize;
+//         let y = y as *const _;
+//         assert!(eq_ref(&x, unsafe { &*y }));
+//     }
+}

--- a/tests/run-pass/ptr_int_casts.rs
+++ b/tests/run-pass/ptr_int_casts.rs
@@ -1,16 +1,15 @@
-// fn eq_ref<T>(x: &T, y: &T) -> bool {
-//     x as *const _ == y as *const _
-// }
+fn eq_ref<T>(x: &T, y: &T) -> bool {
+    x as *const _ == y as *const _
+}
 
 fn main() {
     // int-ptr-int
     assert_eq!(1 as *const i32 as usize, 1);
 
-    // TODO
-//     {   // ptr-int-ptr
-//         let x = 13;
-//         let y = &x as *const _ as usize;
-//         let y = y as *const _;
-//         assert!(eq_ref(&x, unsafe { &*y }));
-//     }
+    {   // ptr-int-ptr
+        let x = 13;
+        let y = &x as *const _ as usize;
+        let y = y as *const _;
+        assert!(eq_ref(&x, unsafe { &*y }));
+    }
 }

--- a/tests/run-pass/ptr_offset.rs
+++ b/tests/run-pass/ptr_offset.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let v = [1i16, 2];
+    let x = &v as *const i16;
+    let x = unsafe { x.offset(1) };
+    assert_eq!(unsafe { *x }, 2);
+}

--- a/tests/run-pass/u128.rs
+++ b/tests/run-pass/u128.rs
@@ -8,10 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// ignore-stage0
+// This disables the test completely:
 // ignore-stage1
-
-// ignore-emscripten
 
 #![feature(i128_type)]
 


### PR DESCRIPTION
This started out with the intention of making the following test case pass:
```rust
fn eq_ref<T>(x: &T, y: &T) -> bool {
    x as *const _ == y as *const _
}

fn main() {
    // int-ptr-int
    assert_eq!(1 as *const i32 as usize, 1);

    {   // ptr-int-ptr
        let x = 13;
        let y = &x as *const _ as usize;
        let y = y as *const _;
        assert!(eq_ref(&x, unsafe { &*y }));
    }
}
```
However, various other pointer-related things came up, and they are now also in this PR. Specifically:
* Offset and the offset intrinsic do bounds checks. There's a special case here ti always permit offsetting by 0, mostly because rustc relies on this being allowed. The discussion whether that is true did not reach a firm conclusion yet.
* Test that pointer bytes cannot be observed via pointer casts.
* Fix arith_offset, which forgot to multiply the offset by the size of the type.
* Make it so that `let map : HashMap<String, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();` runs, which calls the `write_bytes` intrinsic on a dangling pointer, but writes 0 bytes to it, so that should be fine.