### PR TITLE
Rustup 1.4 fixed the permissions of the extracted files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_script:
 - rustup target add i686-pc-windows-gnu
 - rustup target add i686-pc-windows-msvc
 - rustup component add rust-src
-- chmod +x -R ~/.rustup/toolchains/*/lib/rustlib/src/rust/src/jemalloc/include/jemalloc/
 - cargo install xargo
 - export RUST_SYSROOT=$HOME/rust
 script:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ possible to compile libstd with full MIR:
 
 ```sh
 rustup component add rust-src
-chmod +x -R ~/.rustup/toolchains/*/lib/rustlib/src/rust/src/jemalloc/include/jemalloc/
 cargo install xargo
 cd xargo/
 RUSTFLAGS='-Zalways-encode-mir' xargo build


### PR DESCRIPTION
This means we can remove the work-around of manually marking things as executable.