### PR TITLE
Test the Rc::{into,from}_raw roundtrip

### DIFF
--- a/tests/run-pass/rc.rs
+++ b/tests/run-pass/rc.rs
@@ -8,6 +8,16 @@ fn rc_refcell() -> i32 {
     x
 }
 
+fn rc_raw() {
+    let r = Rc::new(0);
+    let r2 = Rc::into_raw(r.clone());
+    let r2 = unsafe { Rc::from_raw(r2) };
+    assert!(Rc::ptr_eq(&r, &r2));
+    drop(r);
+    assert!(Rc::try_unwrap(r2).is_ok());
+}
+
 fn main() {
     rc_refcell();
+    rc_raw();
 }


### PR DESCRIPTION
This uses some pointer arithmetic based on field offsets.