### PR TITLE
Allow any offset on integer and ZST pointers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum EvalError<'tcx> {
         access: bool,
         allocation_size: u64,
     },
+    NullPointerOutOfBounds,
     ReadPointerAsBytes,
     ReadBytesAsPointer,
     InvalidPointerMath,
@@ -80,12 +81,14 @@ impl<'tcx> Error for EvalError<'tcx> {
                 "invalid enum discriminant value read",
             EvalError::PointerOutOfBounds { .. } =>
                 "pointer offset outside bounds of allocation",
+            EvalError::NullPointerOutOfBounds =>
+                "invalid NULL pointer offset",
             EvalError::ReadPointerAsBytes =>
                 "a raw memory access tried to access part of a pointer value as raw bytes",
             EvalError::ReadBytesAsPointer =>
                 "a memory access tried to interpret some bytes as a pointer",
             EvalError::InvalidPointerMath =>
-                "attempted to do math or a comparison on pointers into different allocations",
+                "attempted to do invalid arithmetic on pointers that would leak base addresses, e.g. compating pointers into different allocations",
             EvalError::ReadUndefBytes =>
                 "attempted to read undefined bytes",
             EvalError::DeadLocal =>

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -892,7 +892,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     }
 
     pub(super) fn pointer_offset(&self, ptr: PrimVal, pointee_ty: Ty<'tcx>, offset: i64) -> EvalResult<'tcx, PrimVal> {
-        if ptr == PrimVal::from_u128(0) { // rule out NULL pointers
+        if ptr.is_null()? { // rule out NULL pointers
             return Err(EvalError::InvalidPointerMath);
         }
         // FIXME: assuming here that type size is < i64::max_value()

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -892,8 +892,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     }
 
     pub(super) fn pointer_offset(&self, ptr: PrimVal, pointee_ty: Ty<'tcx>, offset: i64) -> EvalResult<'tcx, PrimVal> {
-        if ptr.is_null()? { // rule out NULL pointers
-            return Err(EvalError::InvalidPointerMath);
+        // This function raises an error if the offset moves the pointer outside of its allocation.  We consider
+        // ZSTs their own huge allocation that doesn't overlap with anything (and nothing moves in there because the size is 0).
+        // We also consider the NULL pointer its own separate allocation, and all the remaining integers pointers their own
+        // allocation.
+
+        if ptr.is_null()? { // NULL pointers must only be offset by 0
+            return if offset == 0 { Ok(ptr) } else { Err(EvalError::NullPointerOutOfBounds) };
         }
         // FIXME: assuming here that type size is < i64::max_value()
         let pointee_size = self.type_size(pointee_ty)?.expect("cannot offset a pointer to an unsized type") as i64;
@@ -901,9 +906,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             let ptr = ptr.signed_offset(offset, self.memory.layout)?;
             // Do not do bounds-checking for integers or ZST; they can never alias a normal pointer anyway.
             if let PrimVal::Ptr(ptr) = ptr {
-                if !ptr.points_to_zst() {
+                if !(ptr.points_to_zst() && pointee_size == 0) {
                     self.memory.check_bounds(ptr, false)?;
                 }
+            } else if ptr.is_null()? {
+                // We moved *to* a NULL pointer.  That seems wrong, LLVM considers the NULL pointer its own small allocation.  Reject this, for now.
+                return Err(EvalError::NullPointerOutOfBounds);
             }
             Ok(ptr)
         } else {

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -906,7 +906,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             let ptr = ptr.signed_offset(offset, self.memory.layout)?;
             // Do not do bounds-checking for integers or ZST; they can never alias a normal pointer anyway.
             if let PrimVal::Ptr(ptr) = ptr {
-                if !(ptr.points_to_zst() && pointee_size == 0) {
+                if !(ptr.points_to_zst() && (offset == 0 || pointee_size == 0)) {
                     self.memory.check_bounds(ptr, false)?;
                 }
             } else if ptr.is_null()? {

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -585,14 +585,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "dlsym" => {
-                let handle = args[0].read_ptr(&self.memory)?;
-                {
-                    let symbol = args[1].read_ptr(&self.memory)?.to_ptr()?;
-                    let symbol_name = self.memory.read_c_str(symbol)?;
-                    let err = format!("bad c unicode symbol: {:?}", symbol_name);
-                    let symbol_name = ::std::str::from_utf8(symbol_name).unwrap_or(&err);
-                    return Err(EvalError::Unimplemented(format!("miri does not support dynamically loading libraries (requested symbol: {})", symbol_name)));
-                }
+                let _handle = args[0].read_ptr(&self.memory)?;
+                let symbol = args[1].read_ptr(&self.memory)?.to_ptr()?;
+                let symbol_name = self.memory.read_c_str(symbol)?;
+                let err = format!("bad c unicode symbol: {:?}", symbol_name);
+                let symbol_name = ::std::str::from_utf8(symbol_name).unwrap_or(&err);
+                return Err(EvalError::Unimplemented(format!("miri does not support dynamically loading libraries (requested symbol: {})", symbol_name)));
             }
 
             "__rust_allocate" => {

--- a/tests/compile-fail/pointers_to_different_allocations_are_unorderable.rs
+++ b/tests/compile-fail/pointers_to_different_allocations_are_unorderable.rs
@@ -1,7 +1,7 @@
 fn main() {
     let x: *const u8 = &1;
     let y: *const u8 = &2;
-    if x < y { //~ ERROR: attempted to do math or a comparison on pointers into different allocations
+    if x < y { //~ ERROR: attempted to do invalid arithmetic on pointers
         unreachable!()
     }
 }


### PR DESCRIPTION
Do not allow offset-by-0 on other out-of-bounds or dangling pointers.