### PR TITLE
get cargo-miri to work

### DIFF
--- a/cargo-miri-test/Cargo.lock
+++ b/cargo-miri-test/Cargo.lock
@@ -1,4 +1,14 @@
 [root]
 name = "cargo-miri-test"
 version = "0.1.0"
+dependencies = [
+ "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[[package]]
+name = "byteorder"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"

--- a/cargo-miri-test/Cargo.toml
+++ b/cargo-miri-test/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 
 [dependencies]
+byteorder = "1.0"

--- a/cargo-miri-test/src/main.rs
+++ b/cargo-miri-test/src/main.rs
@@ -1,3 +1,9 @@
+extern crate byteorder;
+
+use byteorder::{BigEndian, ByteOrder};
+
 fn main() {
-    assert_eq!(5, 5);
+    let buf = &[1,2,3,4];
+    let n = <BigEndian as ByteOrder>::read_u32(buf);
+    assert_eq!(n, 0x01020304);
 }


### PR DESCRIPTION
Fixes #229.

For dependencies, invokes plain `rustc` with `-Z always-encode-mir`.

Also removes `dep_path`, as in https://github.com/Manishearth/rust-clippy/commit/8f88ead7d65ad9a80fa2535dfce83458efda3a7b.