### PR TITLE
Use a wrapper type to differentiate between `PrimVal` and pointers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt;
 use rustc::mir;
 use rustc::ty::{FnSig, Ty, layout};
-use memory::Pointer;
+use memory::MemoryPointer;
 use rustc_const_math::ConstMathErr;
 use syntax::codemap::Span;
 
@@ -10,14 +10,14 @@ use syntax::codemap::Span;
 pub enum EvalError<'tcx> {
     FunctionPointerTyMismatch(FnSig<'tcx>, FnSig<'tcx>),
     NoMirFor(String),
-    UnterminatedCString(Pointer),
+    UnterminatedCString(MemoryPointer),
     DanglingPointerDeref,
     InvalidMemoryAccess,
     InvalidFunctionPointer,
     InvalidBool,
     InvalidDiscriminant,
     PointerOutOfBounds {
-        ptr: Pointer,
+        ptr: MemoryPointer,
         access: bool,
         allocation_size: u64,
     },

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -19,7 +19,7 @@ use error::{EvalError, EvalResult};
 use lvalue::{Global, GlobalId, Lvalue, LvalueExtra};
 use memory::{Memory, MemoryPointer, TlsKey};
 use operator;
-use value::{PrimVal, PrimValKind, Value};
+use value::{PrimVal, PrimValKind, Value, Pointer};
 
 pub struct EvalContext<'a, 'tcx: 'a> {
     /// The results of the type checker, from rustc.
@@ -395,7 +395,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     let arg_local = self.frame().mir.args_iter().next().ok_or(EvalError::AbiViolation("TLS dtor does not take enough arguments.".to_owned()))?;
                     let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
                     let ty = self.tcx.mk_mut_ptr(self.tcx.types.u8);
-                    self.write_primval(dest, ptr, ty)?;
+                    self.write_ptr(dest, ptr, ty)?;
                 }
             }
         }
@@ -444,7 +444,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         self.memory.write_uint(discr_dest, discr_val, discr_size)?;
 
         let dest = Lvalue::Ptr {
-            ptr: PrimVal::Ptr(dest_ptr),
+            ptr: dest_ptr.into(),
             extra: LvalueExtra::DowncastVariant(variant_idx),
         };
 
@@ -580,7 +580,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                     let operand_ty = self.operand_ty(operand);
                                     assert_eq!(self.type_size(operand_ty)?, Some(0));
                                 }
-                                self.write_primval(dest, PrimVal::Bytes(0), dest_ty)?;
+                                self.write_null(dest, dest_ty)?;
                             }
                         } else {
                             bug!("tried to assign {:?} to Layout::RawNullablePointer", kind);
@@ -662,7 +662,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let value = self.eval_operand(operand)?;
 
                 // FIXME(solson)
-                let dest = PrimVal::Ptr(self.force_allocation(dest)?.to_ptr()?);
+                let dest = Pointer::from(self.force_allocation(dest)?.to_ptr()?);
 
                 for i in 0..length {
                     let elem_dest = dest.offset(i * elem_size, self.memory.layout)?;
@@ -686,9 +686,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let ty = self.lvalue_ty(lvalue);
 
                 let val = match extra {
-                    LvalueExtra::None => Value::ByVal(ptr),
-                    LvalueExtra::Length(len) => Value::ByValPair(ptr, PrimVal::from_u128(len as u128)),
-                    LvalueExtra::Vtable(vtable) => Value::ByValPair(ptr, PrimVal::Ptr(vtable)),
+                    LvalueExtra::None => ptr.to_value(),
+                    LvalueExtra::Length(len) => ptr.with_extra(PrimVal::from_u128(len as u128)),
+                    LvalueExtra::Vtable(vtable) => ptr.with_extra(PrimVal::Ptr(vtable)),
                     LvalueExtra::DowncastVariant(..) =>
                         bug!("attempted to take a reference to an enum downcast lvalue"),
                 };
@@ -928,14 +928,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }
     }
 
-    pub(super) fn wrapping_pointer_offset(&self, ptr: PrimVal, pointee_ty: Ty<'tcx>, offset: i64) -> EvalResult<'tcx, PrimVal> {
+    pub(super) fn wrapping_pointer_offset(&self, ptr: Pointer, pointee_ty: Ty<'tcx>, offset: i64) -> EvalResult<'tcx, Pointer> {
         // FIXME: assuming here that type size is < i64::max_value()
         let pointee_size = self.type_size(pointee_ty)?.expect("cannot offset a pointer to an unsized type") as i64;
         let offset = offset.overflowing_mul(pointee_size).0;
         ptr.wrapping_signed_offset(offset, self.memory.layout)
     }
 
-    pub(super) fn pointer_offset(&self, ptr: PrimVal, pointee_ty: Ty<'tcx>, offset: i64) -> EvalResult<'tcx, PrimVal> {
+    pub(super) fn pointer_offset(&self, ptr: Pointer, pointee_ty: Ty<'tcx>, offset: i64) -> EvalResult<'tcx, Pointer> {
         // This function raises an error if the offset moves the pointer outside of its allocation.  We consider
         // ZSTs their own huge allocation that doesn't overlap with anything (and nothing moves in there because the size is 0).
         // We also consider the NULL pointer its own separate allocation, and all the remaining integers pointers their own
@@ -949,7 +949,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         return if let Some(offset) = offset.checked_mul(pointee_size) {
             let ptr = ptr.signed_offset(offset, self.memory.layout)?;
             // Do not do bounds-checking for integers; they can never alias a normal pointer anyway.
-            if let PrimVal::Ptr(ptr) = ptr {
+            if let PrimVal::Ptr(ptr) = ptr.into_inner_primval() {
                 self.memory.check_bounds(ptr, false)?;
             } else if ptr.is_null()? {
                 // We moved *to* a NULL pointer.  That seems wrong, LLVM considers the NULL pointer its own small allocation.  Reject this, for now.
@@ -1002,7 +1002,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         self.monomorphize(operand.ty(self.mir(), self.tcx), self.substs())
     }
 
-    fn copy(&mut self, src: PrimVal, dest: PrimVal, ty: Ty<'tcx>) -> EvalResult<'tcx> {
+    fn copy(&mut self, src: Pointer, dest: Pointer, ty: Ty<'tcx>) -> EvalResult<'tcx> {
         let size = self.type_size(ty)?.expect("cannot copy from an unsized type");
         let align = self.type_align(ty)?;
         self.memory.copy(src, dest, size, align, false)?;
@@ -1026,8 +1026,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         let ty = self.monomorphize(ty, self.stack[frame].instance.substs);
                         let substs = self.stack[frame].instance.substs;
                         let ptr = self.alloc_ptr_with_substs(ty, substs)?;
-                        self.stack[frame].locals[local.index() - 1] = Some(Value::ByRef(PrimVal::Ptr(ptr))); // it stays live
-                        self.write_value_to_ptr(val, PrimVal::Ptr(ptr), ty)?;
+                        self.stack[frame].locals[local.index() - 1] = Some(Value::ByRef(ptr.into())); // it stays live
+                        self.write_value_to_ptr(val, ptr.into(), ty)?;
                         Lvalue::from_ptr(ptr)
                     }
                 }
@@ -1040,14 +1040,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     _ => {
                         let ptr = self.alloc_ptr_with_substs(global_val.ty, cid.instance.substs)?;
                         self.memory.mark_static(ptr.alloc_id);
-                        self.write_value_to_ptr(global_val.value, PrimVal::Ptr(ptr), global_val.ty)?;
+                        self.write_value_to_ptr(global_val.value, ptr.into(), global_val.ty)?;
                         // see comment on `initialized` field
                         if global_val.initialized {
                             self.memory.mark_static_initalized(ptr.alloc_id, global_val.mutable)?;
                         }
                         let lval = self.globals.get_mut(&cid).expect("already checked");
                         *lval = Global {
-                            value: Value::ByRef(PrimVal::Ptr(ptr)),
+                            value: Value::ByRef(ptr.into()),
                             .. global_val
                         };
                         Lvalue::from_ptr(ptr)
@@ -1085,6 +1085,15 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
         self.write_primval(dest, PrimVal::Bytes(0), dest_ty)
+    }
+
+    pub(super) fn write_ptr(
+        &mut self,
+        dest: Lvalue<'tcx>,
+        val: Pointer,
+        dest_ty: Ty<'tcx>,
+    ) -> EvalResult<'tcx> {
+        self.write_value(val.to_value(), dest, dest_ty)
     }
 
     pub(super) fn write_primval(
@@ -1172,9 +1181,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             if let Ok(Some(src_val)) = self.try_read_value(src_ptr, dest_ty) {
                 write_dest(self, src_val)?;
             } else {
-                let dest_ptr = self.alloc_ptr(dest_ty)?;
-                self.copy(src_ptr, PrimVal::Ptr(dest_ptr), dest_ty)?;
-                write_dest(self, Value::ByRef(PrimVal::Ptr(dest_ptr)))?;
+                let dest_ptr = self.alloc_ptr(dest_ty)?.into();
+                self.copy(src_ptr, dest_ptr, dest_ty)?;
+                write_dest(self, Value::ByRef(dest_ptr))?;
             }
 
         } else {
@@ -1188,7 +1197,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(super) fn write_value_to_ptr(
         &mut self,
         value: Value,
-        dest: PrimVal,
+        dest: Pointer,
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
         match value {
@@ -1218,8 +1227,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let field_1_ty = self.get_field_ty(ty, 1)?;
         let field_0_size = self.type_size(field_0_ty)?.expect("pair element type must be sized");
         let field_1_size = self.type_size(field_1_ty)?.expect("pair element type must be sized");
-        self.memory.write_primval(PrimVal::Ptr(ptr.offset(field_0, self.memory.layout)?), a, field_0_size)?;
-        self.memory.write_primval(PrimVal::Ptr(ptr.offset(field_1, self.memory.layout)?), b, field_1_size)?;
+        self.memory.write_primval(ptr.offset(field_0, self.memory.layout)?.into(), a, field_0_size)?;
+        self.memory.write_primval(ptr.offset(field_1, self.memory.layout)?.into(), b, field_1_size)?;
         Ok(())
     }
 
@@ -1322,7 +1331,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }
     }
 
-    pub(super) fn read_value(&mut self, ptr: PrimVal, ty: Ty<'tcx>) -> EvalResult<'tcx, Value> {
+    pub(super) fn read_value(&mut self, ptr: Pointer, ty: Ty<'tcx>) -> EvalResult<'tcx, Value> {
         if let Some(val) = self.try_read_value(ptr, ty)? {
             Ok(val)
         } else {
@@ -1333,21 +1342,21 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(crate) fn read_ptr(&self, ptr: MemoryPointer, pointee_ty: Ty<'tcx>) -> EvalResult<'tcx, Value> {
         let p = self.memory.read_ptr(ptr)?;
         if self.type_is_sized(pointee_ty) {
-            Ok(Value::ByVal(p))
+            Ok(p.to_value())
         } else {
             trace!("reading fat pointer extra of type {}", pointee_ty);
             let extra = ptr.offset(self.memory.pointer_size(), self.memory.layout)?;
             let extra = match self.tcx.struct_tail(pointee_ty).sty {
-                ty::TyDynamic(..) => self.memory.read_ptr(extra)?,
+                ty::TyDynamic(..) => self.memory.read_ptr(extra)?.into_inner_primval(),
                 ty::TySlice(..) |
                 ty::TyStr => PrimVal::from_u128(self.memory.read_usize(extra)? as u128),
                 _ => bug!("unsized primval ptr read from {:?}", pointee_ty),
             };
-            Ok(Value::ByValPair(p, extra))
+            Ok(p.with_extra(extra))
         }
     }
 
-    fn try_read_value(&mut self, ptr: PrimVal, ty: Ty<'tcx>) -> EvalResult<'tcx, Option<Value>> {
+    fn try_read_value(&mut self, ptr: Pointer, ty: Ty<'tcx>) -> EvalResult<'tcx, Option<Value>> {
         use syntax::ast::FloatTy;
 
         let val = match ty.sty {
@@ -1373,7 +1382,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 // if we transmute a ptr to an isize, reading it back into a primval shouldn't panic
                 // Due to read_ptr ignoring the sign, we need to jump around some hoops
                 match self.memory.read_int(ptr.to_ptr()?, size) {
-                    Err(EvalError::ReadPointerAsBytes) if size == self.memory.pointer_size() => self.memory.read_ptr(ptr.to_ptr()?)?,
+                    Err(EvalError::ReadPointerAsBytes) if size == self.memory.pointer_size() => self.memory.read_ptr(ptr.to_ptr()?)?.into_inner_primval(),
                     other => PrimVal::from_i128(other?),
                 }
             }
@@ -1390,7 +1399,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 };
                 if size == self.memory.pointer_size() {
                     // if we transmute a ptr to an usize, reading it back into a primval shouldn't panic
-                    self.memory.read_ptr(ptr.to_ptr()?)?
+                    self.memory.read_ptr(ptr.to_ptr()?)?.into_inner_primval()
                 } else {
                     PrimVal::from_u128(self.memory.read_uint(ptr.to_ptr()?, size)?)
                 }
@@ -1399,7 +1408,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             ty::TyFloat(FloatTy::F32) => PrimVal::from_f32(self.memory.read_f32(ptr.to_ptr()?)?),
             ty::TyFloat(FloatTy::F64) => PrimVal::from_f64(self.memory.read_f64(ptr.to_ptr()?)?),
 
-            ty::TyFnPtr(_) => self.memory.read_ptr(ptr.to_ptr()?)?,
+            ty::TyFnPtr(_) => self.memory.read_ptr(ptr.to_ptr()?)?.into_inner_primval(),
             ty::TyRef(_, ref tam) |
             ty::TyRawPtr(ref tam) => return self.read_ptr(ptr.to_ptr()?, tam.ty).map(Some),
 
@@ -1458,7 +1467,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             (&ty::TyArray(_, length), &ty::TySlice(_)) => {
                 let ptr = src.read_ptr(&self.memory)?;
                 let len = PrimVal::from_u128(length as u128);
-                self.write_value(Value::ByValPair(ptr, len), dest, dest_ty)
+                self.write_value(ptr.with_extra(len), dest, dest_ty)
             }
             (&ty::TyDynamic(..), &ty::TyDynamic(..)) => {
                 // For now, upcasts are limited to changes in marker
@@ -1472,7 +1481,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let vtable = self.get_vtable(src_pointee_ty, trait_ref)?;
                 let ptr = src.read_ptr(&self.memory)?;
                 let extra = PrimVal::Ptr(vtable);
-                self.write_value(Value::ByValPair(ptr, extra), dest, dest_ty)
+                self.write_value(ptr.with_extra(extra), dest, dest_ty)
             },
 
             _ => bug!("invalid unsizing {:?} -> {:?}", src_ty, dest_ty),
@@ -1532,7 +1541,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     let src_f_ptr = src_ptr.offset(src_field_offset, self.memory.layout)?;
                     let dst_f_ptr = dest.offset(dst_field_offset, self.memory.layout)?;
                     if src_fty == dst_fty {
-                        self.copy(src_f_ptr, PrimVal::Ptr(dst_f_ptr), src_fty)?;
+                        self.copy(src_f_ptr, dst_f_ptr.into(), src_fty)?;
                     } else {
                         self.unsize_into(Value::ByRef(src_f_ptr), src_fty, Lvalue::from_ptr(dst_f_ptr), dst_fty)?;
                     }
@@ -1561,13 +1570,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 Err(err) => {
                     panic!("Failed to access local: {:?}", err);
                 }
-                Ok(Value::ByRef(PrimVal::Ptr(ptr))) => {
-                    write!(msg, " by ref:").unwrap();
-                    allocs.push(ptr.alloc_id);
-                }
-                Ok(Value::ByRef(ptr)) => {
-                    write!(msg, " integral by ref: {:?}", ptr).unwrap();
-                }
+                Ok(Value::ByRef(ptr)) => match ptr.into_inner_primval() {
+                    PrimVal::Ptr(ptr) => {
+                        write!(msg, " by ref:").unwrap();
+                        allocs.push(ptr.alloc_id);
+                    },
+                    ptr => write!(msg, " integral by ref: {:?}", ptr).unwrap(),
+                },
                 Ok(Value::ByVal(val)) => {
                     write!(msg, " {:?}", val).unwrap();
                     if let PrimVal::Ptr(ptr) = val { allocs.push(ptr.alloc_id); }

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -1079,6 +1079,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }
     }
 
+    pub(super) fn write_null(
+        &mut self,
+        dest: Lvalue<'tcx>,
+        dest_ty: Ty<'tcx>,
+    ) -> EvalResult<'tcx> {
+        self.write_primval(dest, PrimVal::Bytes(0), dest_ty)
+    }
+
     pub(super) fn write_primval(
         &mut self,
         dest: Lvalue<'tcx>,
@@ -1696,12 +1704,12 @@ pub fn eval_main<'a, 'tcx: 'a>(
             // Second argument (argc): 0
             let dest = ecx.eval_lvalue(&mir::Lvalue::Local(args.next().unwrap()))?;
             let ty = ecx.tcx.types.isize;
-            ecx.write_value(Value::ByVal(PrimVal::Bytes(0)), dest, ty)?;
+            ecx.write_null(dest, ty)?;
 
             // Third argument (argv): 0
             let dest = ecx.eval_lvalue(&mir::Lvalue::Local(args.next().unwrap()))?;
             let ty = ecx.tcx.mk_imm_ptr(ecx.tcx.mk_imm_ptr(ecx.tcx.types.u8));
-            ecx.write_value(Value::ByVal(PrimVal::Bytes(0)), dest, ty)?;
+            ecx.write_null(dest, ty)?;
         } else {
             ecx.push_stack_frame(
                 main_instance,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use lvalue::{
 pub use memory::{
     AllocId,
     Memory,
-    Pointer,
+    MemoryPointer,
 };
 
 pub use value::{

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -315,7 +315,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
         let offset = match base_extra {
             LvalueExtra::Vtable(tab) => {
-                let (_, align) = self.size_and_align_of_dst(base_ty, base_ptr.with_extra(PrimVal::Ptr(tab)))?;
+                let (_, align) = self.size_and_align_of_dst(base_ty, base_ptr.to_value_with_vtable(tab))?;
                 offset.abi_align(Align::from_bytes(align, align).unwrap()).bytes()
             }
             _ => offset.bytes(),

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::indexed_vec::Idx;
 
 use error::{EvalError, EvalResult};
 use eval_context::{EvalContext};
-use memory::Pointer;
+use memory::MemoryPointer;
 use value::{PrimVal, Value};
 
 #[derive(Copy, Clone, Debug)]
@@ -34,7 +34,7 @@ pub enum Lvalue<'tcx> {
 pub enum LvalueExtra {
     None,
     Length(u64),
-    Vtable(Pointer),
+    Vtable(MemoryPointer),
     DowncastVariant(usize),
 }
 
@@ -71,7 +71,7 @@ impl<'tcx> Lvalue<'tcx> {
         Lvalue::Ptr { ptr, extra: LvalueExtra::None }
     }
 
-    pub(crate) fn from_ptr(ptr: Pointer) -> Self {
+    pub(crate) fn from_ptr(ptr: MemoryPointer) -> Self {
         Self::from_primval_ptr(PrimVal::Ptr(ptr))
     }
 
@@ -83,7 +83,7 @@ impl<'tcx> Lvalue<'tcx> {
         }
     }
 
-    pub(super) fn to_ptr(self) -> EvalResult<'tcx, Pointer> {
+    pub(super) fn to_ptr(self) -> EvalResult<'tcx, MemoryPointer> {
         let (ptr, extra) = self.to_ptr_and_extra();
         assert_eq!(extra, LvalueExtra::None);
         ptr.to_ptr()

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -6,7 +6,7 @@ use rustc_data_structures::indexed_vec::Idx;
 use error::{EvalError, EvalResult};
 use eval_context::{EvalContext};
 use memory::MemoryPointer;
-use value::{PrimVal, Value};
+use value::{PrimVal, Value, Pointer};
 
 #[derive(Copy, Clone, Debug)]
 pub enum Lvalue<'tcx> {
@@ -15,7 +15,7 @@ pub enum Lvalue<'tcx> {
         /// An lvalue may have an invalid (integral or undef) pointer,
         /// since it might be turned back into a reference
         /// before ever being dereferenced.
-        ptr: PrimVal,
+        ptr: Pointer,
         extra: LvalueExtra,
     },
 
@@ -64,18 +64,18 @@ pub struct Global<'tcx> {
 impl<'tcx> Lvalue<'tcx> {
     /// Produces an Lvalue that will error if attempted to be read from
     pub fn undef() -> Self {
-        Self::from_primval_ptr(PrimVal::Undef)
+        Self::from_primval_ptr(PrimVal::Undef.into())
     }
 
-    pub(crate) fn from_primval_ptr(ptr: PrimVal) -> Self {
+    pub(crate) fn from_primval_ptr(ptr: Pointer) -> Self {
         Lvalue::Ptr { ptr, extra: LvalueExtra::None }
     }
 
     pub(crate) fn from_ptr(ptr: MemoryPointer) -> Self {
-        Self::from_primval_ptr(PrimVal::Ptr(ptr))
+        Self::from_primval_ptr(ptr.into())
     }
 
-    pub(super) fn to_ptr_and_extra(self) -> (PrimVal, LvalueExtra) {
+    pub(super) fn to_ptr_and_extra(self) -> (Pointer, LvalueExtra) {
         match self {
             Lvalue::Ptr { ptr, extra } => (ptr, extra),
             _ => bug!("to_ptr_and_extra: expected Lvalue::Ptr, got {:?}", self),
@@ -315,7 +315,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
         let offset = match base_extra {
             LvalueExtra::Vtable(tab) => {
-                let (_, align) = self.size_and_align_of_dst(base_ty, Value::ByValPair(base_ptr, PrimVal::Ptr(tab)))?;
+                let (_, align) = self.size_and_align_of_dst(base_ty, base_ptr.with_extra(PrimVal::Ptr(tab)))?;
                 offset.abi_align(Align::from_bytes(align, align).unwrap()).bytes()
             }
             _ => offset.bytes(),

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -3,7 +3,7 @@ use rustc::ty::{self, Ty};
 
 use error::{EvalError, EvalResult};
 use eval_context::EvalContext;
-use memory::Pointer;
+use memory::MemoryPointer;
 use lvalue::Lvalue;
 use value::{
     PrimVal,
@@ -297,13 +297,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     fn ptr_int_arithmetic(
         &self,
         bin_op: mir::BinOp,
-        left: Pointer,
+        left: MemoryPointer,
         right: i128,
         signed: bool,
     ) -> EvalResult<'tcx, (PrimVal, bool)> {
         use rustc::mir::BinOp::*;
 
-        fn map_to_primval((res, over) : (Pointer, bool)) -> (PrimVal, bool) {
+        fn map_to_primval((res, over) : (MemoryPointer, bool)) -> (PrimVal, bool) {
             (PrimVal::Ptr(res), over)
         }
 
@@ -321,7 +321,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let right = right as u64;
                 if right & base_mask == base_mask {
                     // Case 1: The base address bits are all preserved, i.e., right is all-1 there
-                    (PrimVal::Ptr(Pointer::new(left.alloc_id, left.offset & right)), false)
+                    (PrimVal::Ptr(MemoryPointer::new(left.alloc_id, left.offset & right)), false)
                 } else if right & base_mask == 0 {
                     // Case 2: The base address bits are all taken away, i.e., right is all-0 there
                     (PrimVal::from_u128((left.offset & right) as u128), false)

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -158,8 +158,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             match bin_op {
                 Offset if left_kind == Ptr && right_kind == usize => {
                     let pointee_ty = left_ty.builtin_deref(true, ty::LvaluePreference::NoPreference).expect("Offset called on non-ptr type").ty;
-                    let ptr = self.pointer_offset(left, pointee_ty, right.to_bytes()? as i64)?;
-                    return Ok((ptr, false));
+                    let ptr = self.pointer_offset(left.into(), pointee_ty, right.to_bytes()? as i64)?;
+                    return Ok((ptr.into_inner_primval(), false));
                 },
                 // These work on anything
                 Eq if left_kind == right_kind => {

--- a/src/step.rs
+++ b/src/step.rs
@@ -99,9 +99,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     }
 
                     Layout::RawNullablePointer { nndiscr, .. } => {
-                        use value::PrimVal;
                         if variant_index as u64 != nndiscr {
-                            self.write_primval(dest, PrimVal::Bytes(0), dest_ty)?;
+                            self.write_null(dest, dest_ty)?;
                         }
                     }
 

--- a/src/terminator/drop.rs
+++ b/src/terminator/drop.rs
@@ -12,9 +12,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(crate) fn drop_lvalue(&mut self, lval: Lvalue<'tcx>, instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
         trace!("drop_lvalue: {:#?}", lval);
         let val = match self.force_allocation(lval)? {
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable) } => Value::ByValPair(ptr, PrimVal::Ptr(vtable)),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len) } => Value::ByValPair(ptr, PrimVal::Bytes(len as u128)),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::None } => Value::ByVal(ptr),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable) } => ptr.with_extra(PrimVal::Ptr(vtable)),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len) } => ptr.with_extra(PrimVal::Bytes(len as u128)),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::None } => ptr.to_value(),
             _ => bug!("force_allocation broken"),
         };
         self.drop(val, instance, ty, span)

--- a/src/terminator/drop.rs
+++ b/src/terminator/drop.rs
@@ -12,8 +12,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(crate) fn drop_lvalue(&mut self, lval: Lvalue<'tcx>, instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
         trace!("drop_lvalue: {:#?}", lval);
         let val = match self.force_allocation(lval)? {
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable) } => ptr.with_extra(PrimVal::Ptr(vtable)),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len) } => ptr.with_extra(PrimVal::Bytes(len as u128)),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable) } => ptr.to_value_with_vtable(vtable),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len) } => ptr.to_value_with_len(len),
             Lvalue::Ptr { ptr, extra: LvalueExtra::None } => ptr.to_value(),
             _ => bug!("force_allocation broken"),
         };

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -9,7 +9,7 @@ use syntax::abi::Abi;
 use error::{EvalError, EvalResult};
 use eval_context::{EvalContext, IntegerExt, StackPopCleanup, is_inhabited};
 use lvalue::Lvalue;
-use memory::{Pointer, TlsKey};
+use memory::{MemoryPointer, TlsKey};
 use value::PrimVal;
 use value::Value;
 use rustc_data_structures::indexed_vec::Idx;
@@ -461,7 +461,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         Ok(false)
     }
 
-    pub fn read_discriminant_value(&self, adt_ptr: Pointer, adt_ty: Ty<'tcx>) -> EvalResult<'tcx, u128> {
+    pub fn read_discriminant_value(&self, adt_ptr: MemoryPointer, adt_ty: Ty<'tcx>) -> EvalResult<'tcx, u128> {
         use rustc::ty::layout::Layout::*;
         let adt_layout = self.type_layout(adt_ty)?;
         trace!("read_discriminant_value {:#?}", adt_layout);
@@ -500,7 +500,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         Ok(discr_val)
     }
 
-    fn read_nonnull_discriminant_value(&self, ptr: Pointer, nndiscr: u128, discr_size: u64) -> EvalResult<'tcx, u128> {
+    fn read_nonnull_discriminant_value(&self, ptr: MemoryPointer, nndiscr: u128, discr_size: u64) -> EvalResult<'tcx, u128> {
         trace!("read_nonnull_discriminant_value: {:?}, {}, {}", ptr, nndiscr, discr_size);
         let not_null = match self.memory.read_uint(ptr, discr_size) {
             Ok(0) => false,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
 use rustc::traits::{self, Reveal};
 
 use eval_context::EvalContext;
-use memory::Pointer;
+use memory::MemoryPointer;
 use value::{Value, PrimVal};
 
 use rustc::hir::def_id::DefId;
@@ -43,7 +43,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     /// The `trait_ref` encodes the erased self type. Hence if we are
     /// making an object `Foo<Trait>` from a value of type `Foo<T>`, then
     /// `trait_ref` would map `T:Trait`.
-    pub fn get_vtable(&mut self, ty: Ty<'tcx>, trait_ref: ty::PolyTraitRef<'tcx>) -> EvalResult<'tcx, Pointer> {
+    pub fn get_vtable(&mut self, ty: Ty<'tcx>, trait_ref: ty::PolyTraitRef<'tcx>) -> EvalResult<'tcx, MemoryPointer> {
         debug!("get_vtable(trait_ref={:?})", trait_ref);
 
         let size = self.type_size(trait_ref.self_ty())?.expect("can't create a vtable for an unsized type");
@@ -73,7 +73,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         Ok(vtable)
     }
 
-    pub fn read_drop_type_from_vtable(&self, vtable: Pointer) -> EvalResult<'tcx, Option<ty::Instance<'tcx>>> {
+    pub fn read_drop_type_from_vtable(&self, vtable: MemoryPointer) -> EvalResult<'tcx, Option<ty::Instance<'tcx>>> {
         // we don't care about the pointee type, we just want a pointer
         match self.read_ptr(vtable, self.tcx.mk_nil_ptr())? {
             // some values don't need to call a drop impl, so the value is null
@@ -83,7 +83,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }
     }
 
-    pub fn read_size_and_align_from_vtable(&self, vtable: Pointer) -> EvalResult<'tcx, (u64, u64)> {
+    pub fn read_size_and_align_from_vtable(&self, vtable: MemoryPointer) -> EvalResult<'tcx, (u64, u64)> {
         let pointer_size = self.memory.pointer_size();
         let size = self.memory.read_usize(vtable.offset(pointer_size, self.memory.layout)?)?;
         let align = self.memory.read_usize(vtable.offset(pointer_size * 2, self.memory.layout)?)?;

--- a/src/value.rs
+++ b/src/value.rs
@@ -98,9 +98,14 @@ impl<'tcx> Pointer {
         }
     }
 
-    pub fn with_extra(self, extra: PrimVal) -> Value {
-        Value::ByValPair(self.primval, extra)
+    pub fn to_value_with_len(self, len: u64) -> Value {
+        Value::ByValPair(self.primval, PrimVal::from_u128(len as u128))
     }
+
+    pub fn to_value_with_vtable(self, vtable: MemoryPointer) -> Value {
+        Value::ByValPair(self.primval, PrimVal::Ptr(vtable))
+    }
+
     pub fn to_value(self) -> Value {
         Value::ByVal(self.primval)
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -41,6 +41,10 @@ pub enum Value {
 /// A wrapper type around `PrimVal` that cannot be turned back into a `PrimVal` accidentally.
 /// This type clears up a few APIs where having a `PrimVal` argument for something that is
 /// potentially an integer pointer or a pointer to an allocation was unclear.
+///
+/// I (@oli-obk) believe it is less easy to mix up generic primvals and primvals that are just
+/// the representation of pointers. Also all the sites that convert between primvals and pointers
+/// are explicit now (and rare!)
 #[derive(Clone, Copy, Debug)]
 pub struct Pointer {
     primval: PrimVal,

--- a/src/value.rs
+++ b/src/value.rs
@@ -5,7 +5,7 @@ use std::mem::transmute;
 use rustc::ty::layout::TargetDataLayout;
 
 use error::{EvalError, EvalResult};
-use memory::{Memory, Pointer};
+use memory::{Memory, MemoryPointer};
 
 pub(super) fn bytes_to_f32(bytes: u128) -> f32 {
     unsafe { transmute::<u32, f32>(bytes as u32) }
@@ -49,8 +49,8 @@ pub enum PrimVal {
 
     /// A pointer into an `Allocation`. An `Allocation` in the `memory` module has a list of
     /// relocations, but a `PrimVal` is only large enough to contain one, so we just represent the
-    /// relocation and its associated offset together as a `Pointer` here.
-    Ptr(Pointer),
+    /// relocation and its associated offset together as a `MemoryPointer` here.
+    Ptr(MemoryPointer),
 
     /// An undefined `PrimVal`, for representing values that aren't safe to examine, but are safe
     /// to copy around, just like undefined bytes in an `Allocation`.
@@ -80,7 +80,7 @@ impl<'a, 'tcx: 'a> Value {
     pub(super) fn expect_ptr_vtable_pair(
         &self,
         mem: &Memory<'a, 'tcx>
-    ) -> EvalResult<'tcx, (PrimVal, Pointer)> {
+    ) -> EvalResult<'tcx, (PrimVal, MemoryPointer)> {
         use self::Value::*;
         match *self {
             ByRef(ref_ptr) => {
@@ -146,7 +146,7 @@ impl<'tcx> PrimVal {
         }
     }
 
-    pub fn to_ptr(self) -> EvalResult<'tcx, Pointer> {
+    pub fn to_ptr(self) -> EvalResult<'tcx, MemoryPointer> {
         match self {
             PrimVal::Bytes(_) => Err(EvalError::ReadBytesAsPointer),
             PrimVal::Ptr(p) => Ok(p),


### PR DESCRIPTION
I renamed the pointers to allocations as `MemoryPointer` and created a wrapper type `Pointer` around  `PrimVal` to be used wherever we currently use `PrimVal` but named the variable `ptr`.