### PR TITLE
Re-do packed memory accesses

### DIFF
--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -352,7 +352,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     .expect("global should have been cached (static)");
                 match global_value.value {
                     // FIXME: to_ptr()? might be too extreme here, static zsts might reach this under certain conditions
-                    Value::ByRef(ptr) => self.memory.mark_static_initalized(ptr.to_ptr()?.alloc_id, mutable)?,
+                    Value::ByRef(ptr, _aligned) =>
+                        // Alignment does not matter for this call
+                        self.memory.mark_static_initalized(ptr.to_ptr()?.alloc_id, mutable)?,
                     Value::ByVal(val) => if let PrimVal::Ptr(ptr) = val {
                         self.memory.mark_inner_allocation(ptr.alloc_id, mutable)?;
                     },
@@ -408,7 +410,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     }
 
     pub fn deallocate_local(&mut self, local: Option<Value>) -> EvalResult<'tcx> {
-        if let Some(Value::ByRef(ptr)) = local {
+        if let Some(Value::ByRef(ptr, _aligned)) = local {
             trace!("deallocating local");
             let ptr = ptr.to_ptr()?;
             self.memory.dump_alloc(ptr.alloc_id);
@@ -497,10 +499,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         use rustc::mir::Rvalue::*;
         match *rvalue {
             Use(ref operand) => {
-                let (value, aligned) = self.eval_operand_maybe_unaligned(operand)?;
-                self.memory.reads_are_aligned = aligned;
+                let value = self.eval_operand(operand)?;
                 self.write_value(value, dest, dest_ty)?;
-                self.memory.reads_are_aligned = true;
             }
 
             BinaryOp(bin_op, ref left, ref right) => {
@@ -725,7 +725,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         let src_ty = self.operand_ty(operand);
                         if self.type_is_fat_ptr(src_ty) {
                             match (src, self.type_is_fat_ptr(dest_ty)) {
-                                (Value::ByRef(_), _) |
+                                (Value::ByRef(..), _) |
                                 (Value::ByValPair(..), true) => {
                                     self.write_value(src, dest, dest_ty)?;
                                 },
@@ -955,7 +955,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         self.value_to_primval(value, ty)
     }
 
-    pub(super) fn eval_operand_maybe_unaligned(&mut self, op: &mir::Operand<'tcx>) -> EvalResult<'tcx, (Value, bool)> {
+    pub(super) fn eval_operand(&mut self, op: &mir::Operand<'tcx>) -> EvalResult<'tcx, Value> {
         use rustc::mir::Operand::*;
         match *op {
             Consume(ref lvalue) => self.eval_and_read_lvalue(lvalue),
@@ -981,14 +981,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     }
                 };
 
-                Ok((value, true))
+                Ok(value)
             }
         }
-    }
-
-    pub(super) fn eval_operand(&mut self, op: &mir::Operand<'tcx>) -> EvalResult<'tcx, Value> {
-        // This is called when the packed flag is not taken into account. Ignore alignment.
-        Ok(self.eval_operand_maybe_unaligned(op)?.0)
     }
 
     pub(super) fn operand_ty(&self, operand: &mir::Operand<'tcx>) -> Ty<'tcx> {
@@ -1011,15 +1006,15 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 // -1 since we don't store the return value
                 match self.stack[frame].locals[local.index() - 1] {
                     None => return Err(EvalError::DeadLocal),
-                    Some(Value::ByRef(ptr)) => {
-                        Lvalue::from_primval_ptr(ptr)
+                    Some(Value::ByRef(ptr, aligned)) => {
+                        Lvalue::Ptr { ptr, aligned, extra: LvalueExtra::None }
                     },
                     Some(val) => {
                         let ty = self.stack[frame].mir.local_decls[local].ty;
                         let ty = self.monomorphize(ty, self.stack[frame].instance.substs);
                         let substs = self.stack[frame].instance.substs;
                         let ptr = self.alloc_ptr_with_substs(ty, substs)?;
-                        self.stack[frame].locals[local.index() - 1] = Some(Value::ByRef(ptr.into())); // it stays live
+                        self.stack[frame].locals[local.index() - 1] = Some(Value::by_ref(ptr.into())); // it stays live
                         self.write_value_to_ptr(val, ptr.into(), ty)?;
                         Lvalue::from_ptr(ptr)
                     }
@@ -1029,7 +1024,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             Lvalue::Global(cid) => {
                 let global_val = *self.globals.get(&cid).expect("global not cached");
                 match global_val.value {
-                    Value::ByRef(ptr) => Lvalue::from_primval_ptr(ptr),
+                    Value::ByRef(ptr, aligned) =>
+                        Lvalue::Ptr { ptr, aligned, extra: LvalueExtra::None },
                     _ => {
                         let ptr = self.alloc_ptr_with_substs(global_val.ty, cid.instance.substs)?;
                         self.memory.mark_static(ptr.alloc_id);
@@ -1040,7 +1036,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         }
                         let lval = self.globals.get_mut(&cid).expect("already checked");
                         *lval = Global {
-                            value: Value::ByRef(ptr.into()),
+                            value: Value::by_ref(ptr.into()),
                             .. global_val
                         };
                         Lvalue::from_ptr(ptr)
@@ -1054,14 +1050,19 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     /// ensures this Value is not a ByRef
     pub(super) fn follow_by_ref_value(&mut self, value: Value, ty: Ty<'tcx>) -> EvalResult<'tcx, Value> {
         match value {
-            Value::ByRef(ptr) => self.read_value(ptr, ty),
+            Value::ByRef(ptr, aligned) => {
+                self.memory.begin_unaligned_read(aligned);
+                let r = self.read_value(ptr, ty);
+                self.memory.end_unaligned_read();
+                r
+            }
             other => Ok(other),
         }
     }
 
     pub(super) fn value_to_primval(&mut self, value: Value, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
         match self.follow_by_ref_value(value, ty)? {
-            Value::ByRef(_) => bug!("follow_by_ref_value can't result in `ByRef`"),
+            Value::ByRef(..) => bug!("follow_by_ref_value can't result in `ByRef`"),
 
             Value::ByVal(primval) => {
                 self.ensure_valid_value(primval, ty)?;
@@ -1126,9 +1127,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             Lvalue::Ptr { ptr, extra, aligned } => {
                 assert_eq!(extra, LvalueExtra::None);
-                self.memory.writes_are_aligned = aligned;
+                self.memory.begin_unaligned_write(aligned);
                 let r = self.write_value_to_ptr(src_val, ptr, dest_ty);
-                self.memory.writes_are_aligned = true;
+                self.memory.end_unaligned_write();
                 r
             }
 
@@ -1152,7 +1153,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         old_dest_val: Value,
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
-        if let Value::ByRef(dest_ptr) = old_dest_val {
+        if let Value::ByRef(dest_ptr, aligned) = old_dest_val {
             // If the value is already `ByRef` (that is, backed by an `Allocation`),
             // then we must write the new value into this allocation, because there may be
             // other pointers into the allocation. These other pointers are logically
@@ -1160,9 +1161,11 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             //
             // Thus, it would be an error to replace the `ByRef` with a `ByVal`, unless we
             // knew for certain that there were no outstanding pointers to this allocation.
+            self.memory.begin_unaligned_write(aligned);
             self.write_value_to_ptr(src_val, dest_ptr, dest_ty)?;
+            self.memory.end_unaligned_write();
 
-        } else if let Value::ByRef(src_ptr) = src_val {
+        } else if let Value::ByRef(src_ptr, aligned) = src_val {
             // If the value is not `ByRef`, then we know there are no pointers to it
             // and we can simply overwrite the `Value` in the locals array directly.
             //
@@ -1174,13 +1177,15 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             // It is a valid optimization to attempt reading a primitive value out of the
             // source and write that into the destination without making an allocation, so
             // we do so here.
+            self.memory.begin_unaligned_read(aligned);
             if let Ok(Some(src_val)) = self.try_read_value(src_ptr, dest_ty) {
                 write_dest(self, src_val)?;
             } else {
                 let dest_ptr = self.alloc_ptr(dest_ty)?.into();
                 self.copy(src_ptr, dest_ptr, dest_ty)?;
-                write_dest(self, Value::ByRef(dest_ptr))?;
+                write_dest(self, Value::by_ref(dest_ptr))?;
             }
+            self.memory.end_unaligned_read();
 
         } else {
             // Finally, we have the simple case where neither source nor destination are
@@ -1197,7 +1202,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
         match value {
-            Value::ByRef(ptr) => self.copy(ptr, dest, dest_ty),
+            Value::ByRef(ptr, aligned) => {
+                self.memory.begin_unaligned_read(aligned);
+                let r = self.copy(ptr, dest, dest_ty);
+                self.memory.end_unaligned_read();
+                r
+            },
             Value::ByVal(primval) => {
                 let size = self.type_size(dest_ty)?.expect("dest type must be sized");
                 self.memory.write_primval(dest, primval, size)
@@ -1460,7 +1470,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
         match (&src_pointee_ty.sty, &dest_pointee_ty.sty) {
             (&ty::TyArray(_, length), &ty::TySlice(_)) => {
-                let ptr = src.into_ptr(&self.memory)?;
+                let ptr = src.into_ptr(&mut self.memory)?;
                 // u64 cast is from usize to u64, which is always good
                 self.write_value(ptr.to_value_with_len(length as u64), dest, dest_ty)
             }
@@ -1474,7 +1484,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let trait_ref = data.principal().unwrap().with_self_ty(self.tcx, src_pointee_ty);
                 let trait_ref = self.tcx.erase_regions(&trait_ref);
                 let vtable = self.get_vtable(src_pointee_ty, trait_ref)?;
-                let ptr = src.into_ptr(&self.memory)?;
+                let ptr = src.into_ptr(&mut self.memory)?;
                 self.write_value(ptr.to_value_with_vtable(vtable), dest, dest_ty)
             },
 
@@ -1517,8 +1527,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 //let src = adt::MaybeSizedValue::sized(src);
                 //let dst = adt::MaybeSizedValue::sized(dst);
                 let src_ptr = match src {
-                    Value::ByRef(ptr) => ptr,
-                    _ => bug!("expected pointer, got {:?}", src),
+                    Value::ByRef(ptr, true) => ptr,
+                    // TODO: Is it possible for unaligned pointers to occur here?
+                    _ => bug!("expected aligned pointer, got {:?}", src),
                 };
 
                 // FIXME(solson)
@@ -1537,7 +1548,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     if src_fty == dst_fty {
                         self.copy(src_f_ptr, dst_f_ptr.into(), src_fty)?;
                     } else {
-                        self.unsize_into(Value::ByRef(src_f_ptr), src_fty, Lvalue::from_ptr(dst_f_ptr), dst_fty)?;
+                        self.unsize_into(Value::by_ref(src_f_ptr), src_fty, Lvalue::from_ptr(dst_f_ptr), dst_fty)?;
                     }
                 }
                 Ok(())
@@ -1564,7 +1575,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 Err(err) => {
                     panic!("Failed to access local: {:?}", err);
                 }
-                Ok(Value::ByRef(ptr)) => match ptr.into_inner_primval() {
+                Ok(Value::ByRef(ptr, _aligned)) => match ptr.into_inner_primval() {
                     PrimVal::Ptr(ptr) => {
                         write!(msg, " by ref:").unwrap();
                         allocs.push(ptr.alloc_id);

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -1575,9 +1575,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 Err(err) => {
                     panic!("Failed to access local: {:?}", err);
                 }
-                Ok(Value::ByRef(ptr, _aligned)) => match ptr.into_inner_primval() {
+                Ok(Value::ByRef(ptr, aligned)) => match ptr.into_inner_primval() {
                     PrimVal::Ptr(ptr) => {
-                        write!(msg, " by ref:").unwrap();
+                        write!(msg, " by {}ref:", if aligned { "" } else { "unaligned " }).unwrap();
                         allocs.push(ptr.alloc_id);
                     },
                     ptr => write!(msg, " integral by ref: {:?}", ptr).unwrap(),

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -1460,7 +1460,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
         match (&src_pointee_ty.sty, &dest_pointee_ty.sty) {
             (&ty::TyArray(_, length), &ty::TySlice(_)) => {
-                let ptr = src.read_ptr(&self.memory)?;
+                let ptr = src.into_ptr(&self.memory)?;
                 // u64 cast is from usize to u64, which is always good
                 self.write_value(ptr.to_value_with_len(length as u64), dest, dest_ty)
             }
@@ -1474,7 +1474,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let trait_ref = data.principal().unwrap().with_self_ty(self.tcx, src_pointee_ty);
                 let trait_ref = self.tcx.erase_regions(&trait_ref);
                 let vtable = self.get_vtable(src_pointee_ty, trait_ref)?;
-                let ptr = src.read_ptr(&self.memory)?;
+                let ptr = src.into_ptr(&self.memory)?;
                 self.write_value(ptr.to_value_with_vtable(vtable), dest, dest_ty)
             },
 

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -389,11 +389,11 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
                 match self.tcx.struct_tail(pointee_type).sty {
                     ty::TyDynamic(..) => {
-                        let (ptr, vtable) = val.into_ptr_vtable_pair(&self.memory)?;
+                        let (ptr, vtable) = val.into_ptr_vtable_pair(&mut self.memory)?;
                         (ptr, LvalueExtra::Vtable(vtable), true)
                     },
                     ty::TyStr | ty::TySlice(_) => {
-                        let (ptr, len) = val.into_slice(&self.memory)?;
+                        let (ptr, len) = val.into_slice(&mut self.memory)?;
                         (ptr, LvalueExtra::Length(len), true)
                     },
                     _ => (val.into_ptr(&mut self.memory)?, LvalueExtra::None, true),

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -86,9 +86,10 @@ impl<'tcx> Lvalue<'tcx> {
     }
 
     pub(super) fn to_ptr(self) -> EvalResult<'tcx, MemoryPointer> {
-        let (ptr, extra, aligned) = self.to_ptr_extra_aligned();
+        let (ptr, extra, _aligned) = self.to_ptr_extra_aligned();
+        // At this point, we forget about the alignment information -- the lvalue has been turned into a reference,
+        // and no matter where it came from, it now must be aligned.
         assert_eq!(extra, LvalueExtra::None);
-        assert_eq!(aligned, true, "tried converting an unaligned lvalue into a ptr");
         ptr.to_ptr()
     }
 

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -391,14 +391,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
                 match self.tcx.struct_tail(pointee_type).sty {
                     ty::TyDynamic(..) => {
-                        let (ptr, vtable) = val.expect_ptr_vtable_pair(&self.memory)?;
+                        let (ptr, vtable) = val.into_ptr_vtable_pair(&self.memory)?;
                         (ptr, LvalueExtra::Vtable(vtable), true)
                     },
                     ty::TyStr | ty::TySlice(_) => {
-                        let (ptr, len) = val.expect_slice(&self.memory)?;
+                        let (ptr, len) = val.into_slice(&self.memory)?;
                         (ptr, LvalueExtra::Length(len), true)
                     },
-                    _ => (val.read_ptr(&self.memory)?, LvalueExtra::None, true),
+                    _ => (val.into_ptr(&self.memory)?, LvalueExtra::None, true),
                 }
             }
 

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -4,7 +4,7 @@ use rustc::ty::{self, Ty};
 use rustc_data_structures::indexed_vec::Idx;
 
 use error::{EvalError, EvalResult};
-use eval_context::{EvalContext};
+use eval_context::EvalContext;
 use memory::MemoryPointer;
 use value::{PrimVal, Value, Pointer};
 

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -17,6 +17,8 @@ pub enum Lvalue<'tcx> {
         /// before ever being dereferenced.
         ptr: Pointer,
         extra: LvalueExtra,
+        /// Remember whether this lvalue is *supposed* to be aligned.
+        aligned: bool,
     },
 
     /// An lvalue referring to a value on the stack. Represented by a stack frame index paired with
@@ -68,24 +70,25 @@ impl<'tcx> Lvalue<'tcx> {
     }
 
     pub(crate) fn from_primval_ptr(ptr: Pointer) -> Self {
-        Lvalue::Ptr { ptr, extra: LvalueExtra::None }
+        Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true }
     }
 
     pub(crate) fn from_ptr(ptr: MemoryPointer) -> Self {
         Self::from_primval_ptr(ptr.into())
     }
 
-    pub(super) fn to_ptr_and_extra(self) -> (Pointer, LvalueExtra) {
+    pub(super) fn to_ptr_extra_aligned(self) -> (Pointer, LvalueExtra, bool) {
         match self {
-            Lvalue::Ptr { ptr, extra } => (ptr, extra),
+            Lvalue::Ptr { ptr, extra, aligned } => (ptr, extra, aligned),
             _ => bug!("to_ptr_and_extra: expected Lvalue::Ptr, got {:?}", self),
 
         }
     }
 
     pub(super) fn to_ptr(self) -> EvalResult<'tcx, MemoryPointer> {
-        let (ptr, extra) = self.to_ptr_and_extra();
+        let (ptr, extra, aligned) = self.to_ptr_extra_aligned();
         assert_eq!(extra, LvalueExtra::None);
+        assert_eq!(aligned, true, "tried converting an unaligned lvalue into a ptr");
         ptr.to_ptr()
     }
 
@@ -175,13 +178,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }
     }
 
-    pub(super) fn eval_and_read_lvalue(&mut self, lvalue: &mir::Lvalue<'tcx>) -> EvalResult<'tcx, Value> {
+    /// Returns a value and (in case of a ByRef) if we are supposed to use aligned accesses.
+    pub(super) fn eval_and_read_lvalue(&mut self, lvalue: &mir::Lvalue<'tcx>) -> EvalResult<'tcx, (Value, bool)> {
         let ty = self.lvalue_ty(lvalue);
         // Shortcut for things like accessing a fat pointer's field,
         // which would otherwise (in the `eval_lvalue` path) require moving a `ByValPair` to memory
         // and returning an `Lvalue::Ptr` to it
         if let Some(val) = self.try_read_lvalue(lvalue)? {
-            return Ok(val);
+            return Ok((val, true));
         }
         let lvalue = self.eval_lvalue(lvalue)?;
 
@@ -190,15 +194,15 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }
 
         match lvalue {
-            Lvalue::Ptr { ptr, extra } => {
+            Lvalue::Ptr { ptr, extra, aligned } => {
                 assert_eq!(extra, LvalueExtra::None);
-                Ok(Value::ByRef(ptr))
+                Ok((Value::ByRef(ptr), aligned))
             }
             Lvalue::Local { frame, local } => {
-                self.stack[frame].get_local(local)
+                Ok((self.stack[frame].get_local(local)?, true))
             }
             Lvalue::Global(cid) => {
-                Ok(self.globals.get(&cid).expect("global not cached").value)
+                Ok((self.globals.get(&cid).expect("global not cached").value, true))
             }
         }
     }
@@ -239,7 +243,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             },
 
             General { ref variants, .. } => {
-                let (_, base_extra) = base.to_ptr_and_extra();
+                let (_, base_extra, _) = base.to_ptr_extra_aligned();
                 if let LvalueExtra::DowncastVariant(variant_idx) = base_extra {
                     // +1 for the discriminant, which is field 0
                     (variants[variant_idx].offsets[field_index + 1], variants[variant_idx].packed)
@@ -289,8 +293,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         };
 
         // Do not allocate in trivial cases
-        let (base_ptr, base_extra) = match base {
-            Lvalue::Ptr { ptr, extra } => (ptr, extra),
+        let (base_ptr, base_extra, aligned) = match base {
+            Lvalue::Ptr { ptr, extra, aligned } => (ptr, extra, aligned),
             Lvalue::Local { frame, local } => match self.stack[frame].get_local(local)? {
                 // in case the type has a single field, just return the value
                 Value::ByVal(_) if self.get_field_count(base_ty).map(|c| c == 1).unwrap_or(false) => {
@@ -299,7 +303,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 },
                 Value::ByRef(_) |
                 Value::ByValPair(..) |
-                Value::ByVal(_) => self.force_allocation(base)?.to_ptr_and_extra(),
+                Value::ByVal(_) => self.force_allocation(base)?.to_ptr_extra_aligned(),
             },
             Lvalue::Global(cid) => match self.globals.get(&cid).expect("uncached global").value {
                 // in case the type has a single field, just return the value
@@ -309,7 +313,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 },
                 Value::ByRef(_) |
                 Value::ByValPair(..) |
-                Value::ByVal(_) => self.force_allocation(base)?.to_ptr_and_extra(),
+                Value::ByVal(_) => self.force_allocation(base)?.to_ptr_extra_aligned(),
             },
         };
 
@@ -325,11 +329,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
         let field_ty = self.monomorphize(field_ty, self.substs());
 
-        if packed {
-            let size = self.type_size(field_ty)?.expect("packed struct must be sized");
-            self.memory.mark_packed(ptr.to_ptr()?, size);
-        }
-
         let extra = if self.type_is_sized(field_ty) {
             LvalueExtra::None
         } else {
@@ -343,7 +342,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             base_extra
         };
 
-        Ok(Lvalue::Ptr { ptr, extra })
+        Ok(Lvalue::Ptr { ptr, extra, aligned: aligned && !packed })
     }
 
     fn eval_lvalue_projection(
@@ -351,7 +350,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         proj: &mir::LvalueProjection<'tcx>,
     ) -> EvalResult<'tcx, Lvalue<'tcx>> {
         use rustc::mir::ProjectionElem::*;
-        let (ptr, extra) = match proj.elem {
+        let (ptr, extra, aligned) = match proj.elem {
             Field(field, field_ty) => {
                 let base = self.eval_lvalue(&proj.base)?;
                 let base_ty = self.lvalue_ty(&proj.base);
@@ -364,7 +363,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let base_layout = self.type_layout(base_ty)?;
                 // FIXME(solson)
                 let base = self.force_allocation(base)?;
-                let (base_ptr, base_extra) = base.to_ptr_and_extra();
+                let (base_ptr, base_extra, aligned) = base.to_ptr_extra_aligned();
 
                 use rustc::ty::layout::Layout::*;
                 let extra = match *base_layout {
@@ -372,12 +371,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     RawNullablePointer { .. } | StructWrappedNullablePointer { .. } => base_extra,
                     _ => bug!("variant downcast on non-aggregate: {:?}", base_layout),
                 };
-                (base_ptr, extra)
+                (base_ptr, extra, aligned)
             }
 
             Deref => {
                 let base_ty = self.lvalue_ty(&proj.base);
-                let val = self.eval_and_read_lvalue(&proj.base)?;
+                let (val, _aligned) = self.eval_and_read_lvalue(&proj.base)?;
+                // Conservatively, the intermediate accesses of a Deref lvalue do not take into account the packed flag.
+                // Hence we ignore alignment here.
 
                 let pointee_type = match base_ty.sty {
                     ty::TyRawPtr(ref tam) |
@@ -391,13 +392,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 match self.tcx.struct_tail(pointee_type).sty {
                     ty::TyDynamic(..) => {
                         let (ptr, vtable) = val.expect_ptr_vtable_pair(&self.memory)?;
-                        (ptr, LvalueExtra::Vtable(vtable))
+                        (ptr, LvalueExtra::Vtable(vtable), true)
                     },
                     ty::TyStr | ty::TySlice(_) => {
                         let (ptr, len) = val.expect_slice(&self.memory)?;
-                        (ptr, LvalueExtra::Length(len))
+                        (ptr, LvalueExtra::Length(len), true)
                     },
-                    _ => (val.read_ptr(&self.memory)?, LvalueExtra::None),
+                    _ => (val.read_ptr(&self.memory)?, LvalueExtra::None, true),
                 }
             }
 
@@ -406,7 +407,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let base_ty = self.lvalue_ty(&proj.base);
                 // FIXME(solson)
                 let base = self.force_allocation(base)?;
-                let (base_ptr, _) = base.to_ptr_and_extra();
+                let (base_ptr, _, aligned) = base.to_ptr_extra_aligned();
 
                 let (elem_ty, len) = base.elem_ty_and_len(base_ty);
                 let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized");
@@ -415,7 +416,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let n = self.value_to_primval(n_ptr, usize)?.to_u64()?;
                 assert!(n < len, "Tried to access element {} of array/slice with length {}", n, len);
                 let ptr = base_ptr.offset(n * elem_size, self.memory.layout)?;
-                (ptr, LvalueExtra::None)
+                (ptr, LvalueExtra::None, aligned)
             }
 
             ConstantIndex { offset, min_length, from_end } => {
@@ -423,7 +424,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let base_ty = self.lvalue_ty(&proj.base);
                 // FIXME(solson)
                 let base = self.force_allocation(base)?;
-                let (base_ptr, _) = base.to_ptr_and_extra();
+                let (base_ptr, _, aligned) = base.to_ptr_extra_aligned();
 
                 let (elem_ty, n) = base.elem_ty_and_len(base_ty);
                 let elem_size = self.type_size(elem_ty)?.expect("sequence element must be sized");
@@ -436,7 +437,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 };
 
                 let ptr = base_ptr.offset(index * elem_size, self.memory.layout)?;
-                (ptr, LvalueExtra::None)
+                (ptr, LvalueExtra::None, aligned)
             }
 
             Subslice { from, to } => {
@@ -444,18 +445,18 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let base_ty = self.lvalue_ty(&proj.base);
                 // FIXME(solson)
                 let base = self.force_allocation(base)?;
-                let (base_ptr, _) = base.to_ptr_and_extra();
+                let (base_ptr, _, aligned) = base.to_ptr_extra_aligned();
 
                 let (elem_ty, n) = base.elem_ty_and_len(base_ty);
                 let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized");
                 assert!(u64::from(from) <= n - u64::from(to));
                 let ptr = base_ptr.offset(u64::from(from) * elem_size, self.memory.layout)?;
                 let extra = LvalueExtra::Length(n - u64::from(to) - u64::from(from));
-                (ptr, extra)
+                (ptr, extra, aligned)
             }
         };
 
-        Ok(Lvalue::Ptr { ptr, extra })
+        Ok(Lvalue::Ptr { ptr, extra, aligned })
     }
 
     pub(super) fn lvalue_ty(&self, lvalue: &mir::Lvalue<'tcx>) -> Ty<'tcx> {

--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -200,7 +200,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 Ok(Value::ByRef(ptr, aligned))
             }
             Lvalue::Local { frame, local } => {
-                Ok(self.stack[frame].get_local(local)?)
+                self.stack[frame].get_local(local)
             }
             Lvalue::Global(cid) => {
                 Ok(self.globals.get(&cid).expect("global not cached").value)

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -136,8 +136,8 @@ pub struct Memory<'a, 'tcx> {
 
     /// To avoid having to pass flags to every single memory access, we have some global state saying whether
     /// alignment checking is currently enforced for read and/or write accesses.
-    pub reads_are_aligned: bool,
-    pub writes_are_aligned: bool,
+    reads_are_aligned: bool,
+    writes_are_aligned: bool,
 }
 
 impl<'a, 'tcx> Memory<'a, 'tcx> {
@@ -383,6 +383,33 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
             }
         }
         return Ok(None);
+    }
+
+    #[inline]
+    pub(crate) fn begin_unaligned_read(&mut self, aligned: bool) {
+        assert!(self.reads_are_aligned, "Unaligned reads must not be nested");
+        self.reads_are_aligned = aligned;
+    }
+
+    #[inline]
+    pub(crate) fn end_unaligned_read(&mut self) {
+        self.reads_are_aligned = true;
+    }
+
+    #[inline]
+    pub(crate) fn begin_unaligned_write(&mut self, aligned: bool) {
+        assert!(self.writes_are_aligned, "Unaligned writes must not be nested");
+        self.writes_are_aligned = aligned;
+    }
+
+    #[inline]
+    pub(crate) fn end_unaligned_write(&mut self) {
+        self.writes_are_aligned = true;
+    }
+
+    #[inline]
+    pub(crate) fn assert_all_aligned(&mut self) {
+        assert!(self.reads_are_aligned && self.writes_are_aligned, "Someone forgot to clear the 'unaligned' flag");
     }
 }
 

--- a/src/step.rs
+++ b/src/step.rs
@@ -28,7 +28,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
     /// Returns true as long as there are more things to do.
     pub fn step(&mut self) -> EvalResult<'tcx, bool> {
-        self.memory.assert_all_aligned();
         self.inc_step_counter_and_check_limit(1)?;
         if self.stack.is_empty() {
             return Ok(false);

--- a/src/step.rs
+++ b/src/step.rs
@@ -28,7 +28,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
     /// Returns true as long as there are more things to do.
     pub fn step(&mut self) -> EvalResult<'tcx, bool> {
-        assert!(self.memory.reads_are_aligned && self.memory.writes_are_aligned, "Someone forgot to clear the 'unaligned' flag");
+        self.memory.assert_all_aligned();
         self.inc_step_counter_and_check_limit(1)?;
         if self.stack.is_empty() {
             return Ok(false);

--- a/src/step.rs
+++ b/src/step.rs
@@ -28,8 +28,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
     /// Returns true as long as there are more things to do.
     pub fn step(&mut self) -> EvalResult<'tcx, bool> {
-        // see docs on the `Memory::packed` field for why we do this
-        self.memory.clear_packed();
+        assert!(self.memory.reads_are_aligned && self.memory.writes_are_aligned, "Someone forgot to clear the 'unaligned' flag");
         self.inc_step_counter_and_check_limit(1)?;
         if self.stack.is_empty() {
             return Ok(false);

--- a/src/terminator/drop.rs
+++ b/src/terminator/drop.rs
@@ -12,9 +12,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(crate) fn drop_lvalue(&mut self, lval: Lvalue<'tcx>, instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
         trace!("drop_lvalue: {:#?}", lval);
         let val = match self.force_allocation(lval)? {
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable) } => ptr.to_value_with_vtable(vtable),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len) } => ptr.to_value_with_len(len),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::None } => ptr.to_value(),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable), aligned: true } => ptr.to_value_with_vtable(vtable),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len), aligned: true } => ptr.to_value_with_len(len),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true } => ptr.to_value(),
             _ => bug!("force_allocation broken"),
         };
         self.drop(val, instance, ty, span)

--- a/src/terminator/drop.rs
+++ b/src/terminator/drop.rs
@@ -11,10 +11,11 @@ use value::Value;
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(crate) fn drop_lvalue(&mut self, lval: Lvalue<'tcx>, instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
         trace!("drop_lvalue: {:#?}", lval);
+        // We take the address of the object.
         let val = match self.force_allocation(lval)? {
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable), aligned: true } => ptr.to_value_with_vtable(vtable),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len), aligned: true } => ptr.to_value_with_len(len),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true } => ptr.to_value(),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable), aligned: _ } => ptr.to_value_with_vtable(vtable),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len), aligned: _ } => ptr.to_value_with_len(len),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: _ } => ptr.to_value(),
             _ => bug!("force_allocation broken"),
         };
         self.drop(val, instance, ty, span)

--- a/src/terminator/drop.rs
+++ b/src/terminator/drop.rs
@@ -11,7 +11,9 @@ use value::Value;
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(crate) fn drop_lvalue(&mut self, lval: Lvalue<'tcx>, instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
         trace!("drop_lvalue: {:#?}", lval);
-        // We take the address of the object.
+        // We take the address of the object.  This may well be unaligned, which is fine for us here.
+        // However, unaligned accesses will probably make the actual drop implementation fail -- a problem shared
+        // by rustc.
         let val = match self.force_allocation(lval)? {
             Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable), aligned: _ } => ptr.to_value_with_vtable(vtable),
             Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len), aligned: _ } => ptr.to_value_with_len(len),

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -396,9 +396,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "transmute" => {
                 let src_ty = substs.type_at(0);
                 let ptr = self.force_allocation(dest)?.to_ptr()?;
-                self.memory.begin_unaligned_read(false);
+                self.memory.begin_unaligned_write(/*aligned*/false);
                 self.write_value_to_ptr(arg_vals[0], ptr.into(), src_ty)?;
-                self.memory.end_unaligned_read();
+                self.memory.end_unaligned_write();
             }
 
             "unchecked_shl" => {

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -482,7 +482,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     }
 
     pub fn size_and_align_of_dst(
-        &self,
+        &mut self,
         ty: ty::Ty<'tcx>,
         value: Value,
     ) -> EvalResult<'tcx, (u64, u64)> {
@@ -546,7 +546,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     Ok((size, align.abi()))
                 }
                 ty::TyDynamic(..) => {
-                    let (_, vtable) = value.into_ptr_vtable_pair(&self.memory)?;
+                    let (_, vtable) = value.into_ptr_vtable_pair(&mut self.memory)?;
                     // the second entry in the vtable is the dynamic size of the object.
                     self.read_size_and_align_from_vtable(vtable)
                 }
@@ -554,7 +554,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 ty::TySlice(_) | ty::TyStr => {
                     let elem_ty = ty.sequence_element_type(self.tcx);
                     let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized") as u64;
-                    let (_, len) = value.into_slice(&self.memory)?;
+                    let (_, len) = value.into_slice(&mut self.memory)?;
                     let align = self.type_align(elem_ty)?;
                     Ok((len * elem_size, align as u64))
                 }

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -44,7 +44,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "arith_offset" => {
                 let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()? as i64;
-                let ptr = arg_vals[0].read_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 let result_ptr = self.wrapping_pointer_offset(ptr, substs.type_at(0), offset)?;
                 self.write_ptr(dest, result_ptr, dest_ty)?;
             }
@@ -60,7 +60,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "atomic_load_acq" |
             "volatile_load" => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].read_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 self.write_value(Value::ByRef(ptr), dest, ty)?;
             }
 
@@ -69,7 +69,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "atomic_store_rel" |
             "volatile_store" => {
                 let ty = substs.type_at(0);
-                let dest = arg_vals[0].read_ptr(&self.memory)?;
+                let dest = arg_vals[0].into_ptr(&self.memory)?;
                 self.write_value_to_ptr(arg_vals[1], dest, ty)?;
             }
 
@@ -79,7 +79,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             _ if intrinsic_name.starts_with("atomic_xchg") => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].read_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 let change = self.value_to_primval(arg_vals[1], ty)?;
                 let old = self.read_value(ptr, ty)?;
                 let old = match old {
@@ -93,7 +93,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             _ if intrinsic_name.starts_with("atomic_cxchg") => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].read_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 let expect_old = self.value_to_primval(arg_vals[1], ty)?;
                 let change = self.value_to_primval(arg_vals[2], ty)?;
                 let old = self.read_value(ptr, ty)?;
@@ -114,7 +114,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "atomic_xadd" | "atomic_xadd_acq" | "atomic_xadd_rel" | "atomic_xadd_acqrel" | "atomic_xadd_relaxed" |
             "atomic_xsub" | "atomic_xsub_acq" | "atomic_xsub_rel" | "atomic_xsub_acqrel" | "atomic_xsub_relaxed" => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].read_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 let change = self.value_to_primval(arg_vals[1], ty)?;
                 let old = self.read_value(ptr, ty)?;
                 let old = match old {
@@ -144,8 +144,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let elem_size = self.type_size(elem_ty)?.expect("cannot copy unsized value");
                 if elem_size != 0 {
                     let elem_align = self.type_align(elem_ty)?;
-                    let src = arg_vals[0].read_ptr(&self.memory)?;
-                    let dest = arg_vals[1].read_ptr(&self.memory)?;
+                    let src = arg_vals[0].into_ptr(&self.memory)?;
+                    let dest = arg_vals[1].into_ptr(&self.memory)?;
                     let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                     self.memory.copy(src, dest, count * elem_size, elem_align, intrinsic_name.ends_with("_nonoverlapping"))?;
                 }
@@ -173,7 +173,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "discriminant_value" => {
                 let ty = substs.type_at(0);
-                let adt_ptr = arg_vals[0].read_ptr(&self.memory)?.to_ptr()?;
+                let adt_ptr = arg_vals[0].into_ptr(&self.memory)?.to_ptr()?;
                 let discr_val = self.read_discriminant_value(adt_ptr, ty)?;
                 self.write_primval(dest, PrimVal::Bytes(discr_val), dest_ty)?;
             }
@@ -293,7 +293,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "move_val_init" => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].read_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 self.write_value_to_ptr(arg_vals[1], ptr, ty)?;
             }
 
@@ -306,7 +306,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "offset" => {
                 let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()? as i64;
-                let ptr = arg_vals[0].read_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 let result_ptr = self.pointer_offset(ptr, substs.type_at(0), offset)?;
                 self.write_ptr(dest, result_ptr, dest_ty)?;
             }
@@ -460,7 +460,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let ty_align = self.type_align(ty)?;
                 let val_byte = self.value_to_primval(arg_vals[1], u8)?.to_u128()? as u8;
                 let size = self.type_size(ty)?.expect("write_bytes() type must be sized");
-                let ptr = arg_vals[0].read_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                 if count > 0 {
                     // TODO: Should we, at least, validate the alignment? (Also see memory::copy)
@@ -545,7 +545,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     Ok((size, align.abi()))
                 }
                 ty::TyDynamic(..) => {
-                    let (_, vtable) = value.expect_ptr_vtable_pair(&self.memory)?;
+                    let (_, vtable) = value.into_ptr_vtable_pair(&self.memory)?;
                     // the second entry in the vtable is the dynamic size of the object.
                     self.read_size_and_align_from_vtable(vtable)
                 }
@@ -553,7 +553,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 ty::TySlice(_) | ty::TyStr => {
                     let elem_ty = ty.sequence_element_type(self.tcx);
                     let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized") as u64;
-                    let (_, len) = value.expect_slice(&self.memory)?;
+                    let (_, len) = value.into_slice(&self.memory)?;
                     let align = self.type_align(elem_ty)?;
                     Ok((len * elem_size, align as u64))
                 }

--- a/src/terminator/intrinsic.rs
+++ b/src/terminator/intrinsic.rs
@@ -44,7 +44,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "arith_offset" => {
                 let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()? as i64;
-                let ptr = arg_vals[0].into_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&mut self.memory)?;
                 let result_ptr = self.wrapping_pointer_offset(ptr, substs.type_at(0), offset)?;
                 self.write_ptr(dest, result_ptr, dest_ty)?;
             }
@@ -60,8 +60,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "atomic_load_acq" |
             "volatile_load" => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].into_ptr(&self.memory)?;
-                self.write_value(Value::ByRef(ptr), dest, ty)?;
+                let ptr = arg_vals[0].into_ptr(&mut self.memory)?;
+                self.write_value(Value::by_ref(ptr), dest, ty)?;
             }
 
             "atomic_store" |
@@ -69,7 +69,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "atomic_store_rel" |
             "volatile_store" => {
                 let ty = substs.type_at(0);
-                let dest = arg_vals[0].into_ptr(&self.memory)?;
+                let dest = arg_vals[0].into_ptr(&mut self.memory)?;
                 self.write_value_to_ptr(arg_vals[1], dest, ty)?;
             }
 
@@ -79,12 +79,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             _ if intrinsic_name.starts_with("atomic_xchg") => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].into_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&mut self.memory)?;
                 let change = self.value_to_primval(arg_vals[1], ty)?;
                 let old = self.read_value(ptr, ty)?;
                 let old = match old {
                     Value::ByVal(val) => val,
-                    Value::ByRef(_) => bug!("just read the value, can't be byref"),
+                    Value::ByRef(..) => bug!("just read the value, can't be byref"),
                     Value::ByValPair(..) => bug!("atomic_xchg doesn't work with nonprimitives"),
                 };
                 self.write_primval(dest, old, ty)?;
@@ -93,13 +93,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             _ if intrinsic_name.starts_with("atomic_cxchg") => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].into_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&mut self.memory)?;
                 let expect_old = self.value_to_primval(arg_vals[1], ty)?;
                 let change = self.value_to_primval(arg_vals[2], ty)?;
                 let old = self.read_value(ptr, ty)?;
                 let old = match old {
                     Value::ByVal(val) => val,
-                    Value::ByRef(_) => bug!("just read the value, can't be byref"),
+                    Value::ByRef(..) => bug!("just read the value, can't be byref"),
                     Value::ByValPair(..) => bug!("atomic_cxchg doesn't work with nonprimitives"),
                 };
                 let (val, _) = self.binary_op(mir::BinOp::Eq, old, ty, expect_old, ty)?;
@@ -114,12 +114,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "atomic_xadd" | "atomic_xadd_acq" | "atomic_xadd_rel" | "atomic_xadd_acqrel" | "atomic_xadd_relaxed" |
             "atomic_xsub" | "atomic_xsub_acq" | "atomic_xsub_rel" | "atomic_xsub_acqrel" | "atomic_xsub_relaxed" => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].into_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&mut self.memory)?;
                 let change = self.value_to_primval(arg_vals[1], ty)?;
                 let old = self.read_value(ptr, ty)?;
                 let old = match old {
                     Value::ByVal(val) => val,
-                    Value::ByRef(_) => bug!("just read the value, can't be byref"),
+                    Value::ByRef(..) => bug!("just read the value, can't be byref"),
                     Value::ByValPair(..) => bug!("atomic_xadd_relaxed doesn't work with nonprimitives"),
                 };
                 self.write_primval(dest, old, ty)?;
@@ -144,8 +144,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let elem_size = self.type_size(elem_ty)?.expect("cannot copy unsized value");
                 if elem_size != 0 {
                     let elem_align = self.type_align(elem_ty)?;
-                    let src = arg_vals[0].into_ptr(&self.memory)?;
-                    let dest = arg_vals[1].into_ptr(&self.memory)?;
+                    let src = arg_vals[0].into_ptr(&mut self.memory)?;
+                    let dest = arg_vals[1].into_ptr(&mut self.memory)?;
                     let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                     self.memory.copy(src, dest, count * elem_size, elem_align, intrinsic_name.ends_with("_nonoverlapping"))?;
                 }
@@ -173,7 +173,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "discriminant_value" => {
                 let ty = substs.type_at(0);
-                let adt_ptr = arg_vals[0].into_ptr(&self.memory)?.to_ptr()?;
+                let adt_ptr = arg_vals[0].into_ptr(&mut self.memory)?.to_ptr()?;
                 let discr_val = self.read_discriminant_value(adt_ptr, ty)?;
                 self.write_primval(dest, PrimVal::Bytes(discr_val), dest_ty)?;
             }
@@ -248,9 +248,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let size = self.type_size(dest_ty)?.expect("cannot zero unsized value");
                 let init = |this: &mut Self, val: Value| {
                     let zero_val = match val {
-                        Value::ByRef(ptr) => {
+                        Value::ByRef(ptr, aligned) => {
+                            // These writes have no alignment restriction anyway.
                             this.memory.write_repeat(ptr, 0, size)?;
-                            Value::ByRef(ptr)
+                            Value::ByRef(ptr, aligned)
                         },
                         // TODO(solson): Revisit this, it's fishy to check for Undef here.
                         Value::ByVal(PrimVal::Undef) => match this.ty_to_primval_kind(dest_ty) {
@@ -259,7 +260,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                 let ptr = this.alloc_ptr_with_substs(dest_ty, substs)?;
                                 let ptr = Pointer::from(PrimVal::Ptr(ptr));
                                 this.memory.write_repeat(ptr, 0, size)?;
-                                Value::ByRef(ptr)
+                                Value::by_ref(ptr)
                             }
                         },
                         Value::ByVal(_) => Value::ByVal(PrimVal::Bytes(0)),
@@ -293,7 +294,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "move_val_init" => {
                 let ty = substs.type_at(0);
-                let ptr = arg_vals[0].into_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&mut self.memory)?;
                 self.write_value_to_ptr(arg_vals[1], ptr, ty)?;
             }
 
@@ -306,7 +307,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "offset" => {
                 let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()? as i64;
-                let ptr = arg_vals[0].into_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&mut self.memory)?;
                 let result_ptr = self.pointer_offset(ptr, substs.type_at(0), offset)?;
                 self.write_ptr(dest, result_ptr, dest_ty)?;
             }
@@ -395,9 +396,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "transmute" => {
                 let src_ty = substs.type_at(0);
                 let ptr = self.force_allocation(dest)?.to_ptr()?;
-                self.memory.writes_are_aligned = false;
+                self.memory.begin_unaligned_read(false);
                 self.write_value_to_ptr(arg_vals[0], ptr.into(), src_ty)?;
-                self.memory.writes_are_aligned = true;
+                self.memory.end_unaligned_read();
             }
 
             "unchecked_shl" => {
@@ -438,9 +439,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let size = dest_layout.size(&self.tcx.data_layout).bytes();
                 let uninit = |this: &mut Self, val: Value| {
                     match val {
-                        Value::ByRef(ptr) => {
+                        Value::ByRef(ptr, aligned) => {
                             this.memory.mark_definedness(ptr, size, false)?;
-                            Ok(Value::ByRef(ptr))
+                            Ok(Value::ByRef(ptr, aligned))
                         },
                         _ => Ok(Value::ByVal(PrimVal::Undef)),
                     }
@@ -460,7 +461,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let ty_align = self.type_align(ty)?;
                 let val_byte = self.value_to_primval(arg_vals[1], u8)?.to_u128()? as u8;
                 let size = self.type_size(ty)?.expect("write_bytes() type must be sized");
-                let ptr = arg_vals[0].into_ptr(&self.memory)?;
+                let ptr = arg_vals[0].into_ptr(&mut self.memory)?;
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                 if count > 0 {
                     // TODO: Should we, at least, validate the alignment? (Also see memory::copy)

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -394,7 +394,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             },
             ty::InstanceDef::Virtual(_, idx) => {
                 let ptr_size = self.memory.pointer_size();
-                let (_, vtable) = self.eval_operand(&arg_operands[0])?.into_ptr_vtable_pair(&self.memory)?;
+                let (_, vtable) = self.eval_operand(&arg_operands[0])?.into_ptr_vtable_pair(&mut self.memory)?;
                 let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3), self.memory.layout)?)?;
                 let instance = self.memory.get_fn(fn_ptr.to_ptr()?)?;
                 let mut arg_operands = arg_operands.to_vec();

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -310,9 +310,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                             if self.frame().mir.args_iter().count() == fields.len() + 1 {
                                 let offsets = variant.offsets.iter().map(|s| s.bytes());
                                 match arg_val {
-                                    Value::ByRef(ptr) => {
+                                    Value::ByRef(ptr, aligned) => {
+                                        assert!(aligned, "Unaligned ByRef-values cannot occur as function arguments");
                                         for ((offset, ty), arg_local) in offsets.zip(fields).zip(arg_locals) {
-                                            let arg = Value::ByRef(ptr.offset(offset, self.memory.layout)?);
+                                            let arg = Value::ByRef(ptr.offset(offset, self.memory.layout)?, true);
                                             let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
                                             trace!("writing arg {:?} to {:?} (type: {})", arg, dest, ty);
                                             self.write_value(arg, dest, ty)?;
@@ -572,7 +573,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 self.write_primval(dest, PrimVal::Ptr(ptr), dest_ty)?;
             }
             "alloc::heap::::__rust_dealloc" => {
-                let ptr = args[0].into_ptr(&self.memory)?.to_ptr()?;
+                let ptr = args[0].into_ptr(&mut self.memory)?.to_ptr()?;
                 let old_size = self.value_to_primval(args[1], usize)?.to_u64()?;
                 let align = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if old_size == 0 {
@@ -584,7 +585,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 self.memory.deallocate(ptr, Some((old_size, align)))?;
             }
             "alloc::heap::::__rust_realloc" => {
-                let ptr = args[0].into_ptr(&self.memory)?.to_ptr()?;
+                let ptr = args[0].into_ptr(&mut self.memory)?.to_ptr()?;
                 let old_size = self.value_to_primval(args[1], usize)?.to_u64()?;
                 let old_align = self.value_to_primval(args[2], usize)?.to_u64()?;
                 let new_size = self.value_to_primval(args[3], usize)?.to_u64()?;
@@ -660,7 +661,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "free" => {
-                let ptr = args[0].into_ptr(&self.memory)?;
+                let ptr = args[0].into_ptr(&mut self.memory)?;
                 if !ptr.is_null()? {
                     self.memory.deallocate(ptr.to_ptr()?, None)?;
                 }
@@ -674,8 +675,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "dlsym" => {
-                let _handle = args[0].into_ptr(&self.memory)?;
-                let symbol = args[1].into_ptr(&self.memory)?.to_ptr()?;
+                let _handle = args[0].into_ptr(&mut self.memory)?;
+                let symbol = args[1].into_ptr(&mut self.memory)?.to_ptr()?;
                 let symbol_name = self.memory.read_c_str(symbol)?;
                 let err = format!("bad c unicode symbol: {:?}", symbol_name);
                 let symbol_name = ::std::str::from_utf8(symbol_name).unwrap_or(&err);
@@ -686,8 +687,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 // fn __rust_maybe_catch_panic(f: fn(*mut u8), data: *mut u8, data_ptr: *mut usize, vtable_ptr: *mut usize) -> u32
                 // We abort on panic, so not much is going on here, but we still have to call the closure
                 let u8_ptr_ty = self.tcx.mk_mut_ptr(self.tcx.types.u8);
-                let f = args[0].into_ptr(&self.memory)?.to_ptr()?;
-                let data = args[1].into_ptr(&self.memory)?;
+                let f = args[0].into_ptr(&mut self.memory)?.to_ptr()?;
+                let data = args[1].into_ptr(&mut self.memory)?;
                 let f_instance = self.memory.get_fn(f)?;
                 self.write_null(dest, dest_ty)?;
 
@@ -718,8 +719,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "memcmp" => {
-                let left = args[0].into_ptr(&self.memory)?;
-                let right = args[1].into_ptr(&self.memory)?;
+                let left = args[0].into_ptr(&mut self.memory)?;
+                let right = args[1].into_ptr(&mut self.memory)?;
                 let n = self.value_to_primval(args[2], usize)?.to_u64()?;
 
                 let result = {
@@ -738,7 +739,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "memrchr" => {
-                let ptr = args[0].into_ptr(&self.memory)?;
+                let ptr = args[0].into_ptr(&mut self.memory)?;
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().rev().position(|&c| c == val) {
@@ -750,7 +751,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "memchr" => {
-                let ptr = args[0].into_ptr(&self.memory)?;
+                let ptr = args[0].into_ptr(&mut self.memory)?;
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().position(|&c| c == val) {
@@ -763,7 +764,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "getenv" => {
                 let result = {
-                    let name_ptr = args[0].into_ptr(&self.memory)?.to_ptr()?;
+                    let name_ptr = args[0].into_ptr(&mut self.memory)?.to_ptr()?;
                     let name = self.memory.read_c_str(name_ptr)?;
                     match self.env_vars.get(name) {
                         Some(&var) => PrimVal::Ptr(var),
@@ -776,7 +777,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "unsetenv" => {
                 let mut success = None;
                 {
-                    let name_ptr = args[0].into_ptr(&self.memory)?;
+                    let name_ptr = args[0].into_ptr(&mut self.memory)?;
                     if !name_ptr.is_null()? {
                         let name = self.memory.read_c_str(name_ptr.to_ptr()?)?;
                         if !name.is_empty() && !name.contains(&b'=') {
@@ -797,8 +798,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "setenv" => {
                 let mut new = None;
                 {
-                    let name_ptr = args[0].into_ptr(&self.memory)?;
-                    let value_ptr = args[1].into_ptr(&self.memory)?.to_ptr()?;
+                    let name_ptr = args[0].into_ptr(&mut self.memory)?;
+                    let value_ptr = args[1].into_ptr(&mut self.memory)?.to_ptr()?;
                     let value = self.memory.read_c_str(value_ptr)?;
                     if !name_ptr.is_null()? {
                         let name = self.memory.read_c_str(name_ptr.to_ptr()?)?;
@@ -823,7 +824,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "write" => {
                 let fd = self.value_to_primval(args[0], usize)?.to_u64()?;
-                let buf = args[1].into_ptr(&self.memory)?;
+                let buf = args[1].into_ptr(&mut self.memory)?;
                 let n = self.value_to_primval(args[2], usize)?.to_u64()?;
                 trace!("Called write({:?}, {:?}, {:?})", fd, buf, n);
                 let result = if fd == 1 || fd == 2 { // stdout/stderr
@@ -840,7 +841,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "strlen" => {
-                let ptr = args[0].into_ptr(&self.memory)?.to_ptr()?;
+                let ptr = args[0].into_ptr(&mut self.memory)?.to_ptr()?;
                 let n = self.memory.read_c_str(ptr)?.len();
                 self.write_primval(dest, PrimVal::Bytes(n as u128), dest_ty)?;
             }
@@ -863,10 +864,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             // Hook pthread calls that go to the thread-local storage memory subsystem
             "pthread_key_create" => {
-                let key_ptr = args[0].into_ptr(&self.memory)?;
+                let key_ptr = args[0].into_ptr(&mut self.memory)?;
 
                 // Extract the function type out of the signature (that seems easier than constructing it ourselves...)
-                let dtor = match args[1].into_ptr(&self.memory)?.into_inner_primval() {
+                let dtor = match args[1].into_ptr(&mut self.memory)?.into_inner_primval() {
                     PrimVal::Ptr(dtor_ptr) => Some(self.memory.get_fn(dtor_ptr)?),
                     PrimVal::Bytes(0) => None,
                     PrimVal::Bytes(_) => return Err(EvalError::ReadBytesAsPointer),
@@ -908,7 +909,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "pthread_setspecific" => {
                 // The conversion into TlsKey here is a little fishy, but should work as long as usize >= libc::pthread_key_t
                 let key = self.value_to_primval(args[0], usize)?.to_u64()? as TlsKey;
-                let new_ptr = args[1].into_ptr(&self.memory)?;
+                let new_ptr = args[1].into_ptr(&mut self.memory)?;
                 self.memory.store_tls(key, new_ptr)?;
                 
                 // Return success (0)

--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -393,7 +393,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             },
             ty::InstanceDef::Virtual(_, idx) => {
                 let ptr_size = self.memory.pointer_size();
-                let (_, vtable) = self.eval_operand(&arg_operands[0])?.expect_ptr_vtable_pair(&self.memory)?;
+                let (_, vtable) = self.eval_operand(&arg_operands[0])?.into_ptr_vtable_pair(&self.memory)?;
                 let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3), self.memory.layout)?)?;
                 let instance = self.memory.get_fn(fn_ptr.to_ptr()?)?;
                 let mut arg_operands = arg_operands.to_vec();
@@ -572,7 +572,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 self.write_primval(dest, PrimVal::Ptr(ptr), dest_ty)?;
             }
             "alloc::heap::::__rust_dealloc" => {
-                let ptr = args[0].read_ptr(&self.memory)?.to_ptr()?;
+                let ptr = args[0].into_ptr(&self.memory)?.to_ptr()?;
                 let old_size = self.value_to_primval(args[1], usize)?.to_u64()?;
                 let align = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if old_size == 0 {
@@ -584,7 +584,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 self.memory.deallocate(ptr, Some((old_size, align)))?;
             }
             "alloc::heap::::__rust_realloc" => {
-                let ptr = args[0].read_ptr(&self.memory)?.to_ptr()?;
+                let ptr = args[0].into_ptr(&self.memory)?.to_ptr()?;
                 let old_size = self.value_to_primval(args[1], usize)?.to_u64()?;
                 let old_align = self.value_to_primval(args[2], usize)?.to_u64()?;
                 let new_size = self.value_to_primval(args[3], usize)?.to_u64()?;
@@ -660,7 +660,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "free" => {
-                let ptr = args[0].read_ptr(&self.memory)?;
+                let ptr = args[0].into_ptr(&self.memory)?;
                 if !ptr.is_null()? {
                     self.memory.deallocate(ptr.to_ptr()?, None)?;
                 }
@@ -674,8 +674,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "dlsym" => {
-                let _handle = args[0].read_ptr(&self.memory)?;
-                let symbol = args[1].read_ptr(&self.memory)?.to_ptr()?;
+                let _handle = args[0].into_ptr(&self.memory)?;
+                let symbol = args[1].into_ptr(&self.memory)?.to_ptr()?;
                 let symbol_name = self.memory.read_c_str(symbol)?;
                 let err = format!("bad c unicode symbol: {:?}", symbol_name);
                 let symbol_name = ::std::str::from_utf8(symbol_name).unwrap_or(&err);
@@ -686,8 +686,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 // fn __rust_maybe_catch_panic(f: fn(*mut u8), data: *mut u8, data_ptr: *mut usize, vtable_ptr: *mut usize) -> u32
                 // We abort on panic, so not much is going on here, but we still have to call the closure
                 let u8_ptr_ty = self.tcx.mk_mut_ptr(self.tcx.types.u8);
-                let f = args[0].read_ptr(&self.memory)?.to_ptr()?;
-                let data = args[1].read_ptr(&self.memory)?;
+                let f = args[0].into_ptr(&self.memory)?.to_ptr()?;
+                let data = args[1].into_ptr(&self.memory)?;
                 let f_instance = self.memory.get_fn(f)?;
                 self.write_null(dest, dest_ty)?;
 
@@ -718,8 +718,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "memcmp" => {
-                let left = args[0].read_ptr(&self.memory)?;
-                let right = args[1].read_ptr(&self.memory)?;
+                let left = args[0].into_ptr(&self.memory)?;
+                let right = args[1].into_ptr(&self.memory)?;
                 let n = self.value_to_primval(args[2], usize)?.to_u64()?;
 
                 let result = {
@@ -738,7 +738,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "memrchr" => {
-                let ptr = args[0].read_ptr(&self.memory)?;
+                let ptr = args[0].into_ptr(&self.memory)?;
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().rev().position(|&c| c == val) {
@@ -750,7 +750,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "memchr" => {
-                let ptr = args[0].read_ptr(&self.memory)?;
+                let ptr = args[0].into_ptr(&self.memory)?;
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().position(|&c| c == val) {
@@ -763,7 +763,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "getenv" => {
                 let result = {
-                    let name_ptr = args[0].read_ptr(&self.memory)?.to_ptr()?;
+                    let name_ptr = args[0].into_ptr(&self.memory)?.to_ptr()?;
                     let name = self.memory.read_c_str(name_ptr)?;
                     match self.env_vars.get(name) {
                         Some(&var) => PrimVal::Ptr(var),
@@ -776,7 +776,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "unsetenv" => {
                 let mut success = None;
                 {
-                    let name_ptr = args[0].read_ptr(&self.memory)?;
+                    let name_ptr = args[0].into_ptr(&self.memory)?;
                     if !name_ptr.is_null()? {
                         let name = self.memory.read_c_str(name_ptr.to_ptr()?)?;
                         if !name.is_empty() && !name.contains(&b'=') {
@@ -797,8 +797,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "setenv" => {
                 let mut new = None;
                 {
-                    let name_ptr = args[0].read_ptr(&self.memory)?;
-                    let value_ptr = args[1].read_ptr(&self.memory)?.to_ptr()?;
+                    let name_ptr = args[0].into_ptr(&self.memory)?;
+                    let value_ptr = args[1].into_ptr(&self.memory)?.to_ptr()?;
                     let value = self.memory.read_c_str(value_ptr)?;
                     if !name_ptr.is_null()? {
                         let name = self.memory.read_c_str(name_ptr.to_ptr()?)?;
@@ -823,7 +823,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             "write" => {
                 let fd = self.value_to_primval(args[0], usize)?.to_u64()?;
-                let buf = args[1].read_ptr(&self.memory)?;
+                let buf = args[1].into_ptr(&self.memory)?;
                 let n = self.value_to_primval(args[2], usize)?.to_u64()?;
                 trace!("Called write({:?}, {:?}, {:?})", fd, buf, n);
                 let result = if fd == 1 || fd == 2 { // stdout/stderr
@@ -840,7 +840,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             }
 
             "strlen" => {
-                let ptr = args[0].read_ptr(&self.memory)?.to_ptr()?;
+                let ptr = args[0].into_ptr(&self.memory)?.to_ptr()?;
                 let n = self.memory.read_c_str(ptr)?.len();
                 self.write_primval(dest, PrimVal::Bytes(n as u128), dest_ty)?;
             }
@@ -863,10 +863,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             // Hook pthread calls that go to the thread-local storage memory subsystem
             "pthread_key_create" => {
-                let key_ptr = args[0].read_ptr(&self.memory)?;
+                let key_ptr = args[0].into_ptr(&self.memory)?;
 
                 // Extract the function type out of the signature (that seems easier than constructing it ourselves...)
-                let dtor = match args[1].read_ptr(&self.memory)?.into_inner_primval() {
+                let dtor = match args[1].into_ptr(&self.memory)?.into_inner_primval() {
                     PrimVal::Ptr(dtor_ptr) => Some(self.memory.get_fn(dtor_ptr)?),
                     PrimVal::Bytes(0) => None,
                     PrimVal::Bytes(_) => return Err(EvalError::ReadBytesAsPointer),
@@ -908,7 +908,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             "pthread_setspecific" => {
                 // The conversion into TlsKey here is a little fishy, but should work as long as usize >= libc::pthread_key_t
                 let key = self.value_to_primval(args[0], usize)?.to_u64()? as TlsKey;
-                let new_ptr = args[1].read_ptr(&self.memory)?;
+                let new_ptr = args[1].into_ptr(&self.memory)?;
                 self.memory.store_tls(key, new_ptr)?;
                 
                 // Return success (0)

--- a/src/value.rs
+++ b/src/value.rs
@@ -158,7 +158,9 @@ pub enum PrimValKind {
 }
 
 impl<'a, 'tcx: 'a> Value {
-    pub(super) fn read_ptr(&self, mem: &Memory<'a, 'tcx>) -> EvalResult<'tcx, Pointer> {
+    /// Convert the value into a pointer (or a pointer-sized integer).  If the value is a ByRef,
+    /// this may have to perform a load.
+    pub(super) fn into_ptr(&self, mem: &Memory<'a, 'tcx>) -> EvalResult<'tcx, Pointer> {
         use self::Value::*;
         match *self {
             ByRef(ptr) => mem.read_ptr(ptr.to_ptr()?),
@@ -166,7 +168,7 @@ impl<'a, 'tcx: 'a> Value {
         }
     }
 
-    pub(super) fn expect_ptr_vtable_pair(
+    pub(super) fn into_ptr_vtable_pair(
         &self,
         mem: &Memory<'a, 'tcx>
     ) -> EvalResult<'tcx, (Pointer, MemoryPointer)> {
@@ -184,7 +186,7 @@ impl<'a, 'tcx: 'a> Value {
         }
     }
 
-    pub(super) fn expect_slice(&self, mem: &Memory<'a, 'tcx>) -> EvalResult<'tcx, (Pointer, u64)> {
+    pub(super) fn into_slice(&self, mem: &Memory<'a, 'tcx>) -> EvalResult<'tcx, (Pointer, u64)> {
         use self::Value::*;
         match *self {
             ByRef(ref_ptr) => {

--- a/tests/run-pass/packed_struct.rs
+++ b/tests/run-pass/packed_struct.rs
@@ -5,7 +5,7 @@ struct S {
 }
 
 fn main() {
-    let x = S {
+    let mut x = S {
         a: 42,
         b: 99,
     };
@@ -16,4 +16,7 @@ fn main() {
     // can't do `assert_eq!(x.a, 42)`, because `assert_eq!` takes a reference
     assert_eq!({x.a}, 42);
     assert_eq!({x.b}, 99);
+
+    x.b = 77;
+    assert_eq!({x.b}, 77);
 }

--- a/tests/run-pass/packed_struct.rs
+++ b/tests/run-pass/packed_struct.rs
@@ -1,7 +1,25 @@
+#![allow(dead_code)]
 #[repr(packed)]
 struct S {
     a: i32,
     b: i64,
+}
+
+#[repr(packed)]
+struct Test1<'a> {
+    x: u8,
+    other: &'a u32,
+}
+
+#[repr(packed)]
+struct Test2<'a> {
+    x: u8,
+    other: &'a Test1<'a>,
+}
+
+fn test(t: Test2) {
+    let x = *t.other.other;
+    assert_eq!(x, 42);
 }
 
 fn main() {
@@ -19,4 +37,6 @@ fn main() {
 
     x.b = 77;
     assert_eq!({x.b}, 77);
+
+    test(Test2 { x: 0, other: &Test1 { x: 0, other: &42 }});
 }


### PR DESCRIPTION
We now track in the lvalue whether what we computed is expected to be aligend or not, and then set some state in the memory system accordingly to make it (not) do alignment checks. Note that I did not understand the old handling completely, so I am not sure if this is correct -- but from the part that I did understand, this should actually improve things because alignment checks are disabled on a much more fine-grained basis.

Furthermore, I'd like to know if you are willing to accept this trick I am using that avoids passing "is_aligned" to every single function on the memory: Instead, store such things in the state. This is certainly less clean, but may still overall be nicer. If you *are* willing to accept this, I will probably also use this in my MIR validation branch where each memory access needs to know the stack frame that is performing the access.

I also did some refactoring of `Value` methods.