### PR TITLE
Memory::read_ptr has to check for relocations on the edges

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -745,6 +745,7 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
         if self.check_defined(ptr, size).is_err() {
             return Ok(PrimVal::Undef.into());
         }
+        self.check_relocation_edges(ptr, size)?; // Make sure we don't read part of a pointer as a pointer
         let endianess = self.endianess();
         let bytes = self.get_bytes_unchecked(ptr, size, size)?;
         let offset = read_target_uint(endianess, bytes).unwrap();

--- a/tests/compile-fail/reading_half_a_pointer.rs
+++ b/tests/compile-fail/reading_half_a_pointer.rs
@@ -1,0 +1,29 @@
+#![allow(dead_code)]
+
+// We use packed structs to get around alignment restrictions
+#[repr(packed)]
+struct Data {
+    pad: u8,
+    ptr: &'static i32,
+}
+
+// But we need to gurantee some alignment
+struct Wrapper {
+    align: u64,
+    data: Data,
+}
+
+static G : i32 = 0;
+
+fn main() {
+    let mut w = Wrapper { align: 0, data: Data { pad: 0, ptr: &G } };
+
+    // Get a pointer to the beginning of the Data struct (one u8 byte, then the pointer bytes).
+    // Thanks to the wrapper, we know this is aligned-enough to perform a load at ptr size.
+    // We load at pointer type, so having a relocation is okay -- but here, the relocation
+    // starts 1 byte to the right, so using it would actually be wrong!
+    let d_alias = &mut w.data as *mut _ as *mut *const u8;
+    unsafe {
+        let _x = *d_alias; //~ ERROR: tried to access part of a pointer value as raw bytes
+    }
+}


### PR DESCRIPTION
Three uses of `get_bytes_unchecked`, one of them got it wrong. ;)