### PR TITLE
Remove reundant dangling checks in {r,d}eallocate

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -230,7 +230,7 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
     pub fn reallocate(&mut self, ptr: MemoryPointer, old_size: u64, old_align: u64, new_size: u64, new_align: u64, kind: Kind) -> EvalResult<'tcx, MemoryPointer> {
         use std::cmp::min;
 
-        if ptr.offset != 0 || self.get(ptr.alloc_id).is_err() {
+        if ptr.offset != 0 {
             return Err(EvalError::ReallocateNonBasePtr);
         }
         if let Ok(alloc) = self.get(ptr.alloc_id) {
@@ -248,7 +248,7 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
     }
 
     pub fn deallocate(&mut self, ptr: MemoryPointer, size_and_align: Option<(u64, u64)>, kind: Kind) -> EvalResult<'tcx> {
-        if ptr.offset != 0 || self.get(ptr.alloc_id).is_err() {
+        if ptr.offset != 0 {
             return Err(EvalError::DeallocateNonBasePtr);
         }
 

--- a/tests/compile-fail/reallocate-dangling.rs
+++ b/tests/compile-fail/reallocate-dangling.rs
@@ -5,13 +5,13 @@ extern crate alloc;
 use alloc::heap::Heap;
 use alloc::allocator::*;
 
-// error-pattern: tried to deallocate dangling pointer
+// error-pattern: dangling pointer was dereferenced
 
 use alloc::heap::*;
 fn main() {
     unsafe {
         let x = Heap.alloc(Layout::from_size_align_unchecked(1, 1)).unwrap();
         Heap.dealloc(x, Layout::from_size_align_unchecked(1, 1));
-        Heap.dealloc(x, Layout::from_size_align_unchecked(1, 1));
+        Heap.realloc(x, Layout::from_size_align_unchecked(1, 1), Layout::from_size_align_unchecked(1, 1));
     }
 }


### PR DESCRIPTION
This was mentioned but not fixed in #245.