### PR TITLE
No longer check aligment and non-NULLness on `&`

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -46,9 +46,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     fn cast_int(&self, v: u128, ty: ty::Ty<'tcx>, negative: bool) -> EvalResult<'tcx, PrimVal> {
         use rustc::ty::TypeVariants::*;
         match ty.sty {
-            TyBool if v == 0 => Ok(PrimVal::from_bool(false)),
-            TyBool if v == 1 => Ok(PrimVal::from_bool(true)),
-            TyBool => Err(EvalError::InvalidBool),
+            // Casts to bool are not permitted by rustc, no need to handle them here.
 
             TyInt(IntTy::I8)  => Ok(PrimVal::Bytes(v as i128 as i8  as u128)),
             TyInt(IntTy::I16) => Ok(PrimVal::Bytes(v as i128 as i16 as u128)),

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -682,10 +682,6 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                         bug!("attempted to take a reference to an enum downcast lvalue"),
                 };
 
-                // Check alignment and non-NULLness.
-                let (_, align) = self.size_and_align_of_dst(ty, val)?;
-                self.memory.check_align(ptr, align)?;
-
                 self.write_value(val, dest, dest_ty)?;
             }
 

--- a/src/eval_context.rs
+++ b/src/eval_context.rs
@@ -670,9 +670,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             Ref(_, _, ref lvalue) => {
                 let src = self.eval_lvalue(lvalue)?;
-                // We ignore the alignment of the lvalue here -- this rvalue produces sth. of type &, which must always be aligned.
+                // We ignore the alignment of the lvalue here -- special handling for packed structs ends
+                // at the `&` operator.
                 let (ptr, extra, _aligned) = self.force_allocation(src)?.to_ptr_extra_aligned();
-                let ty = self.lvalue_ty(lvalue);
 
                 let val = match extra {
                     LvalueExtra::None => ptr.to_value(),

--- a/tests/compile-fail/int_ptr_cast.rs
+++ b/tests/compile-fail/int_ptr_cast.rs
@@ -1,5 +1,0 @@
-fn main() {
-    let x = 2usize as *const u32;
-    // This must fail because alignment is violated
-    let _ = unsafe { &*x }; //~ ERROR: tried to access memory with alignment 2, but alignment 4 is required
-}

--- a/tests/compile-fail/int_ptr_cast2.rs
+++ b/tests/compile-fail/int_ptr_cast2.rs
@@ -1,5 +1,0 @@
-fn main() {
-    let x = 0usize as *const u32;
-    // This must fail because the pointer is NULL
-    let _ = unsafe { &*x }; //~ ERROR: invalid use of NULL pointer
-}

--- a/tests/compile-fail/reference_to_packed.rs
+++ b/tests/compile-fail/reference_to_packed.rs
@@ -11,6 +11,6 @@ fn main() {
         x: 42,
         y: 99,
     };
-    let p = &foo.x; //~ ERROR tried to access memory with alignment 1, but alignment 4 is required
-    let i = *p;
+    let p = &foo.x;
+    let i = *p; //~ ERROR tried to access memory with alignment 1, but alignment 4 is required
 }

--- a/tests/compile-fail/unaligned_ptr_cast.rs
+++ b/tests/compile-fail/unaligned_ptr_cast.rs
@@ -2,5 +2,5 @@ fn main() {
     let x = &2u16;
     let x = x as *const _ as *const u32;
     // This must fail because alignment is violated
-    let _ = unsafe { &*x }; //~ ERROR: tried to access memory with alignment 2, but alignment 4 is required
+    let _x = unsafe { *x }; //~ ERROR: tried to access memory with alignment 2, but alignment 4 is required
 }

--- a/tests/compile-fail/unaligned_ptr_cast2.rs
+++ b/tests/compile-fail/unaligned_ptr_cast2.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let x = &2u16;
+    let x = x as *const _ as *const *const u8;
+    // This must fail because alignment is violated.  Test specifically for loading pointers, which have special code
+    // in miri's memory.
+    let _x = unsafe { *x }; //~ ERROR: tried to access memory with alignment 2, but alignment
+}


### PR DESCRIPTION
This breaks creating unaligned raw pointers via `&packed.field as *const _`, which needs to be legal.
Also it doesn't seem like LLVM still relies on this, see
* https://github.com/solson/miri/issues/244#issuecomment-315563640
* https://internals.rust-lang.org/t/rules-for-alignment-and-non-nullness-of-references/5430/16

We probably want to handle this invariant like the others that validation is concerned with, and only
check it on function boundaries for now.
