### PR TITLE
remove ad-hoc 'never' type check in read_lvalue

### DIFF
--- a/tests/compile-fail/never_say_never.rs
+++ b/tests/compile-fail/never_say_never.rs
@@ -4,7 +4,7 @@
 fn main() {
     let y = &5;
     let x: ! = unsafe {
-        *(y as *const _ as *const !) //~ ERROR entered unreachable code
+        *(y as *const _ as *const !) //~ ERROR tried to access a dead local variable
     };
     f(x)
 }


### PR DESCRIPTION
Funny enough, the correspond test still fails -- thanks to miri checking the storage liveness annotations. ;)

Fixes #261 
