### PR TITLE
Always test alignment in memory.rs

### DIFF
--- a/src/terminator/mod.rs
+++ b/src/terminator/mod.rs
@@ -813,8 +813,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 if let Some((name, value)) = new {
                     // +1 for the null terminator
                     let value_copy = self.memory.allocate((value.len() + 1) as u64, 1, Kind::Env)?;
-                    self.memory.write_bytes(PrimVal::Ptr(value_copy), &value)?;
-                    self.memory.write_bytes(PrimVal::Ptr(value_copy.offset(value.len() as u64, self.memory.layout)?), &[0])?;
+                    self.memory.write_bytes(value_copy.into(), &value)?;
+                    self.memory.write_bytes(value_copy.offset(value.len() as u64, self.memory.layout)?.into(), &[0])?;
                     if let Some(var) = self.env_vars.insert(name.to_owned(), value_copy) {
                         self.memory.deallocate(var, None, Kind::Env)?;
                     }

--- a/tests/compile-fail/unaligned_ptr_cast_zst.rs
+++ b/tests/compile-fail/unaligned_ptr_cast_zst.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let x = &2u16;
+    let x = x as *const _ as *const [u32; 0];
+    // This must fail because alignment is violated.  Test specifically for loading ZST.
+    let _x = unsafe { *x }; //~ ERROR: tried to access memory with alignment 2, but alignment 4 is required
+}

--- a/tests/run-pass-fullmir/vecs.rs
+++ b/tests/run-pass-fullmir/vecs.rs
@@ -24,6 +24,13 @@ fn vec_into_iter() -> u8 {
         .fold(0, |x, y| x + y)
 }
 
+fn vec_into_iter_zst() -> usize {
+    vec![[0u64; 0], [0u64; 0]]
+        .into_iter()
+        .map(|x| x.len())
+        .sum()
+}
+
 fn vec_reallocate() -> Vec<u8> {
     let mut v = vec![1, 2];
     v.push(3);
@@ -35,6 +42,7 @@ fn vec_reallocate() -> Vec<u8> {
 fn main() {
     assert_eq!(vec_reallocate().len(), 5);
     assert_eq!(vec_into_iter(), 30);
+    assert_eq!(vec_into_iter_zst(), 0);
     assert_eq!(make_vec().capacity(), 4);
     assert_eq!(make_vec_macro(), [1, 2]);
     assert_eq!(make_vec_macro_repeat(), [42; 5]);


### PR DESCRIPTION
We still skip alignment and non-NULL tests for `copy` and `write_bytes` intrinsics when nothing is copied/written. There is code in libstd that relies on this. Also, considering that these are intrinsics rather than "primitive" loads/stores, LLVM may also be more relaxed there.

Ideally, we'd know which LLVM intrinsics these rustc intrinsics lower to and what exactly the contract is for these.