### PR TITLE
Fix ptr-int-casts

### DIFF
--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -77,8 +77,8 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             TyChar if v as u8 as u128 == v => Ok(PrimVal::Bytes(v)),
             TyChar => Err(EvalError::InvalidChar(v)),
 
-            // No alignment check needed for raw pointers
-            TyRawPtr(_) => Ok(PrimVal::Bytes(v % (1 << (self.memory.pointer_size()*8)))),
+            // No alignment check needed for raw pointers.  But we have to truncate to target ptr size.
+            TyRawPtr(_) => Ok(PrimVal::Bytes(v % (1u128 << self.memory.layout.pointer_size.bits()))),
 
             _ => Err(EvalError::Unimplemented(format!("int to {:?} cast", ty))),
         }

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -4,7 +4,7 @@ use syntax::ast::{FloatTy, IntTy, UintTy};
 use error::{EvalResult, EvalError};
 use eval_context::EvalContext;
 use value::PrimVal;
-use memory::{MemoryPointer, HasDataLayout};
+use memory::{MemoryPointer, PointerArithmetic};
 
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(super) fn cast_primval(

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -12,10 +12,10 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         src_ty: Ty<'tcx>,
         dest_ty: Ty<'tcx>
     ) -> EvalResult<'tcx, PrimVal> {
-        let kind = self.ty_to_primval_kind(src_ty)?;
+        let src_kind = self.ty_to_primval_kind(src_ty)?;
 
         use value::PrimValKind::*;
-        match kind {
+        match src_kind {
             F32 => self.cast_float(val.to_f32()? as f64, dest_ty),
             F64 => self.cast_float(val.to_f64()?, dest_ty),
 
@@ -81,7 +81,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             TyChar => Err(EvalError::InvalidChar(v)),
 
             // No alignment check needed for raw pointers
-            TyRawPtr(_) => Ok(PrimVal::Bytes(v % (1 << self.memory.pointer_size()))),
+            TyRawPtr(_) => Ok(PrimVal::Bytes(v % (1 << (self.memory.pointer_size()*8)))),
 
             _ => Err(EvalError::Unimplemented(format!("int to {:?} cast", ty))),
         }

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -4,7 +4,7 @@ use syntax::ast::{FloatTy, IntTy, UintTy};
 use error::{EvalResult, EvalError};
 use eval_context::EvalContext;
 use value::PrimVal;
-use memory::MemoryPointer;
+use memory::{MemoryPointer, HasDataLayout};
 
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(super) fn cast_primval(
@@ -78,7 +78,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             TyChar => Err(EvalError::InvalidChar(v)),
 
             // No alignment check needed for raw pointers.  But we have to truncate to target ptr size.
-            TyRawPtr(_) => Ok(PrimVal::Bytes(v % (1u128 << self.memory.layout.pointer_size.bits()))),
+            TyRawPtr(_) => Ok(PrimVal::Bytes(self.memory.truncate_to_ptr(v).0 as u128)),
 
             _ => Err(EvalError::Unimplemented(format!("int to {:?} cast", ty))),
         }

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -4,6 +4,7 @@ use syntax::ast::{FloatTy, IntTy, UintTy};
 use error::{EvalResult, EvalError};
 use eval_context::EvalContext;
 use value::PrimVal;
+use memory::MemoryPointer;
 
 impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     pub(super) fn cast_primval(
@@ -14,36 +15,32 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
     ) -> EvalResult<'tcx, PrimVal> {
         let src_kind = self.ty_to_primval_kind(src_ty)?;
 
-        use value::PrimValKind::*;
-        match src_kind {
-            F32 => self.cast_float(val.to_f32()? as f64, dest_ty),
-            F64 => self.cast_float(val.to_f64()?, dest_ty),
+        match val {
+            PrimVal::Undef => Ok(PrimVal::Undef),
+            PrimVal::Ptr(ptr) => self.cast_from_ptr(ptr, dest_ty),
+            val @ PrimVal::Bytes(_) => {
+                use value::PrimValKind::*;
+                match src_kind {
+                    F32 => self.cast_from_float(val.to_f32()? as f64, dest_ty),
+                    F64 => self.cast_from_float(val.to_f64()?, dest_ty),
 
-            I8 | I16 | I32 | I64 | I128 => {
-                if val.is_ptr() {
-                    self.cast_ptr(val, dest_ty)
-                } else {
-                    self.cast_signed_int(val.to_i128()?, dest_ty)
+                    I8 | I16 | I32 | I64 | I128 => {
+                        self.cast_from_signed_int(val.to_i128()?, dest_ty)
+                    },
+
+                    Bool | Char | U8 | U16 | U32 | U64 | U128 | FnPtr | Ptr => {
+                        self.cast_from_int(val.to_u128()?, dest_ty, false)
+                    },
                 }
-            },
-
-            Bool | Char | U8 | U16 | U32 | U64 | U128 => {
-                if val.is_ptr() {
-                    self.cast_ptr(val, dest_ty)
-                } else {
-                    self.cast_int(val.to_u128()?, dest_ty, false)
-                }
-            },
-
-            FnPtr | Ptr => self.cast_ptr(val, dest_ty),
+            }
         }
     }
 
-    fn cast_signed_int(&self, val: i128, ty: ty::Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
-        self.cast_int(val as u128, ty, val < 0)
+    fn cast_from_signed_int(&self, val: i128, ty: ty::Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
+        self.cast_from_int(val as u128, ty, val < 0)
     }
 
-    fn cast_int(&self, v: u128, ty: ty::Ty<'tcx>, negative: bool) -> EvalResult<'tcx, PrimVal> {
+    fn cast_from_int(&self, v: u128, ty: ty::Ty<'tcx>, negative: bool) -> EvalResult<'tcx, PrimVal> {
         use rustc::ty::TypeVariants::*;
         match ty.sty {
             // Casts to bool are not permitted by rustc, no need to handle them here.
@@ -63,13 +60,13 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             TyInt(IntTy::Is) => {
                 let int_ty = self.tcx.sess.target.int_type;
                 let ty = self.tcx.mk_mach_int(int_ty);
-                self.cast_int(v, ty, negative)
+                self.cast_from_int(v, ty, negative)
             }
 
             TyUint(UintTy::Us) => {
                 let uint_ty = self.tcx.sess.target.uint_type;
                 let ty = self.tcx.mk_mach_uint(uint_ty);
-                self.cast_int(v, ty, negative)
+                self.cast_from_int(v, ty, negative)
             }
 
             TyFloat(FloatTy::F64) if negative => Ok(PrimVal::from_f64(v as i128 as f64)),
@@ -87,14 +84,14 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }
     }
 
-    fn cast_float(&self, val: f64, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
+    fn cast_from_float(&self, val: f64, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
         use rustc::ty::TypeVariants::*;
         match ty.sty {
             // Casting negative floats to unsigned integers yields zero.
-            TyUint(_) if val < 0.0 => self.cast_int(0, ty, false),
-            TyInt(_)  if val < 0.0 => self.cast_int(val as i128 as u128, ty, true),
+            TyUint(_) if val < 0.0 => self.cast_from_int(0, ty, false),
+            TyInt(_)  if val < 0.0 => self.cast_from_int(val as i128 as u128, ty, true),
 
-            TyInt(_) | ty::TyUint(_) => self.cast_int(val as u128, ty, false),
+            TyInt(_) | ty::TyUint(_) => self.cast_from_int(val as u128, ty, false),
 
             TyFloat(FloatTy::F64) => Ok(PrimVal::from_f64(val)),
             TyFloat(FloatTy::F32) => Ok(PrimVal::from_f32(val as f32)),
@@ -102,12 +99,12 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         }
     }
 
-    fn cast_ptr(&self, ptr: PrimVal, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
+    fn cast_from_ptr(&self, ptr: MemoryPointer, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
         use rustc::ty::TypeVariants::*;
         match ty.sty {
             // Casting to a reference or fn pointer is not permitted by rustc, no need to support it here.
             TyRawPtr(_) | TyInt(IntTy::Is) | TyUint(UintTy::Us) =>
-                Ok(ptr),
+                Ok(PrimVal::Ptr(ptr)),
             TyInt(_) | TyUint(_) => Err(EvalError::ReadPointerAsBytes),
             _ => Err(EvalError::Unimplemented(format!("ptr to {:?} cast", ty))),
         }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -1226,8 +1226,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let field_1_ty = self.get_field_ty(ty, 1)?;
         let field_0_size = self.type_size(field_0_ty)?.expect("pair element type must be sized");
         let field_1_size = self.type_size(field_1_ty)?.expect("pair element type must be sized");
-        self.memory.write_primval(ptr.offset(field_0, self.memory.layout)?.into(), a, field_0_size)?;
-        self.memory.write_primval(ptr.offset(field_1, self.memory.layout)?.into(), b, field_1_size)?;
+        let layout = self.memory.layout;
+        self.memory.write_primval(ptr.offset(field_0, layout)?.into(), a, field_0_size)?;
+        self.memory.write_primval(ptr.offset(field_1, layout)?.into(), b, field_1_size)?;
         Ok(())
     }
 

--- a/src/librustc_mir/interpret/lvalue.rs
+++ b/src/librustc_mir/interpret/lvalue.rs
@@ -329,7 +329,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             _ => offset.bytes(),
         };
 
-        let ptr = base_ptr.offset(offset, self.memory.layout)?;
+        let ptr = base_ptr.offset(offset, &self)?;
 
         let field_ty = self.monomorphize(field_ty, self.substs());
 
@@ -412,7 +412,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let usize = self.tcx.types.usize;
                 let n = self.value_to_primval(n_ptr, usize)?.to_u64()?;
                 assert!(n < len, "Tried to access element {} of array/slice with length {}", n, len);
-                let ptr = base_ptr.offset(n * elem_size, self.memory.layout)?;
+                let ptr = base_ptr.offset(n * elem_size, &self)?;
                 (ptr, LvalueExtra::None, aligned)
             }
 
@@ -431,7 +431,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     u64::from(offset)
                 };
 
-                let ptr = base_ptr.offset(index * elem_size, self.memory.layout)?;
+                let ptr = base_ptr.offset(index * elem_size, &self)?;
                 (ptr, LvalueExtra::None, aligned)
             }
 
@@ -443,7 +443,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let (elem_ty, n) = base.elem_ty_and_len(base_ty);
                 let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized");
                 assert!(u64::from(from) <= n - u64::from(to));
-                let ptr = base_ptr.offset(u64::from(from) * elem_size, self.memory.layout)?;
+                let ptr = base_ptr.offset(u64::from(from) * elem_size, &self)?;
                 let extra = LvalueExtra::Length(n - u64::from(to) - u64::from(from));
                 (ptr, extra, aligned)
             }

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -7,7 +7,7 @@ use rustc::ty::layout::{self, TargetDataLayout};
 use syntax::ast::Mutability;
 
 use error::{EvalError, EvalResult};
-use value::{PrimVal, self, Pointer};
+use value::{PrimVal, Pointer};
 use eval_context::EvalContext;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -73,26 +73,26 @@ impl MemoryPointer {
         MemoryPointer { alloc_id, offset }
     }
 
-    pub fn wrapping_signed_offset<'tcx>(self, i: i64, layout: &TargetDataLayout) -> Self {
-        MemoryPointer::new(self.alloc_id, value::wrapping_signed_offset(self.offset, i, layout))
+    pub(crate) fn wrapping_signed_offset<'a, L: HasDataLayout<'a>>(self, i: i64, l: L) -> Self {
+        MemoryPointer::new(self.alloc_id, l.wrapping_signed_offset(self.offset, i))
     }
 
-    pub fn overflowing_signed_offset<'tcx>(self, i: i128, layout: &TargetDataLayout) -> (Self, bool) {
-        let (res, over) = value::overflowing_signed_offset(self.offset, i, layout);
+    pub(crate) fn overflowing_signed_offset<'a, L: HasDataLayout<'a>>(self, i: i128, l: L) -> (Self, bool) {
+        let (res, over) = l.overflowing_signed_offset(self.offset, i);
         (MemoryPointer::new(self.alloc_id, res), over)
     }
 
-    pub fn signed_offset<'tcx>(self, i: i64, layout: &TargetDataLayout) -> EvalResult<'tcx, Self> {
-        Ok(MemoryPointer::new(self.alloc_id, value::signed_offset(self.offset, i, layout)?))
+    pub(crate) fn signed_offset<'a, 'tcx, L: HasDataLayout<'a>>(self, i: i64, l: L) -> EvalResult<'tcx, Self> {
+        Ok(MemoryPointer::new(self.alloc_id, l.signed_offset(self.offset, i)?))
     }
 
-    pub fn overflowing_offset<'tcx>(self, i: u64, layout: &TargetDataLayout) -> (Self, bool) {
-        let (res, over) = value::overflowing_offset(self.offset, i, layout);
+    pub(crate) fn overflowing_offset<'a, L: HasDataLayout<'a>>(self, i: u64, l: L) -> (Self, bool) {
+        let (res, over) = l.overflowing_offset(self.offset, i);
         (MemoryPointer::new(self.alloc_id, res), over)
     }
 
-    pub fn offset<'tcx>(self, i: u64, layout: &TargetDataLayout) -> EvalResult<'tcx, Self> {
-        Ok(MemoryPointer::new(self.alloc_id, value::offset(self.offset, i, layout)?))
+    pub(crate) fn offset<'a, 'tcx, L: HasDataLayout<'a>>(self, i: u64, l: L) -> EvalResult<'tcx, Self> {
+        Ok(MemoryPointer::new(self.alloc_id, l.offset(self.offset, i)?))
     }
 }
 
@@ -540,7 +540,7 @@ impl<'a, 'tcx> Memory<'a, 'tcx> {
         if size == 0 {
             return Ok(&[]);
         }
-        self.check_bounds(ptr.offset(size, self.layout)?, true)?; // if ptr.offset is in bounds, then so is ptr (because offset checks for overflow)
+        self.check_bounds(ptr.offset(size, self)?, true)?; // if ptr.offset is in bounds, then so is ptr (because offset checks for overflow)
         let alloc = self.get(ptr.alloc_id)?;
         assert_eq!(ptr.offset as usize as u64, ptr.offset);
         assert_eq!(size as usize as u64, size);
@@ -1131,6 +1131,7 @@ fn bit_index(bits: u64) -> (usize, usize) {
 
 pub(crate) trait HasMemory<'a, 'tcx> {
     fn memory_mut(&mut self) -> &mut Memory<'a, 'tcx>;
+    fn memory(&self) -> &Memory<'a, 'tcx>;
 
     // These are not supposed to be overriden.
     fn read_maybe_aligned<F, T>(&mut self, aligned: bool, f: F) -> EvalResult<'tcx, T>
@@ -1159,11 +1160,93 @@ impl<'a, 'tcx> HasMemory<'a, 'tcx> for Memory<'a, 'tcx> {
     fn memory_mut(&mut self) -> &mut Memory<'a, 'tcx> {
         self
     }
+
+    #[inline]
+    fn memory(&self) -> &Memory<'a, 'tcx> {
+        self
+    }
 }
 
 impl<'a, 'tcx> HasMemory<'a, 'tcx> for EvalContext<'a, 'tcx> {
     #[inline]
     fn memory_mut(&mut self) -> &mut Memory<'a, 'tcx> {
         &mut self.memory
+    }
+
+    #[inline]
+    fn memory(&self) -> &Memory<'a, 'tcx> {
+        &self.memory
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Pointer arithmetic
+////////////////////////////////////////////////////////////////////////////////
+
+pub(crate) trait HasDataLayout<'a> : Copy {
+    fn data_layout(self) -> &'a TargetDataLayout;
+
+    // These are not supposed to be overriden.
+
+    //// Trunace the given value to the pointer size; also return whether there was an overflow
+    fn truncate_to_ptr(self, val: u128) -> (u64, bool) {
+        let max_ptr_plus_1 = 1u128 << self.data_layout().pointer_size.bits();
+        ((val % max_ptr_plus_1) as u64, val >= max_ptr_plus_1)
+    }
+
+    // Overflow checking only works properly on the range from -u64 to +u64.
+    fn overflowing_signed_offset(self, val: u64, i: i128) -> (u64, bool) {
+        // FIXME: is it possible to over/underflow here?
+        if i < 0 {
+            // trickery to ensure that i64::min_value() works fine
+            // this formula only works for true negative values, it panics for zero!
+            let n = u64::max_value() - (i as u64) + 1;
+            val.overflowing_sub(n)
+        } else {
+            self.overflowing_offset(val, i as u64)
+        }
+    }
+
+    fn overflowing_offset(self, val: u64, i: u64) -> (u64, bool) {
+        let (res, over1) = val.overflowing_add(i);
+        let (res, over2) = self.truncate_to_ptr(res as u128);
+        (res, over1 || over2)
+    }
+
+    fn signed_offset<'tcx>(self, val: u64, i: i64) -> EvalResult<'tcx, u64> {
+        let (res, over) = self.overflowing_signed_offset(val, i as i128);
+        if over {
+            Err(EvalError::OverflowingMath)
+        } else {
+            Ok(res)
+        }
+    }
+
+    fn offset<'tcx>(self, val: u64, i: u64) -> EvalResult<'tcx, u64> {
+        let (res, over) = self.overflowing_offset(val, i);
+        if over {
+            Err(EvalError::OverflowingMath)
+        } else {
+            Ok(res)
+        }
+    }
+
+    fn wrapping_signed_offset(self, val: u64, i: i64) -> u64 {
+        self.overflowing_signed_offset(val, i as i128).0
+    }
+}
+
+impl<'a> HasDataLayout<'a> for &'a TargetDataLayout {
+    #[inline]
+    fn data_layout(self) -> &'a TargetDataLayout {
+        self
+    }
+}
+
+impl<'a, 'b, 'tcx, T> HasDataLayout<'a> for &'b T
+    where T: HasMemory<'a, 'tcx> {
+    #[inline]
+    fn data_layout(self) -> &'a TargetDataLayout {
+        self.memory().layout
     }
 }

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -310,11 +310,11 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         Ok(match bin_op {
             Sub =>
                 // The only way this can overflow is by underflowing, so signdeness of the right operands does not matter
-                map_to_primval(left.overflowing_signed_offset(-right, self.memory.layout)),
+                map_to_primval(left.overflowing_signed_offset(-right, self)),
             Add if signed =>
-                map_to_primval(left.overflowing_signed_offset(right, self.memory.layout)),
+                map_to_primval(left.overflowing_signed_offset(right, self)),
             Add if !signed =>
-                map_to_primval(left.overflowing_offset(right as u64, self.memory.layout)),
+                map_to_primval(left.overflowing_offset(right as u64, self)),
 
             BitAnd if !signed => {
                 let base_mask : u64 = !(self.memory.get(left.alloc_id)?.align - 1);

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -101,7 +101,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                     Layout::StructWrappedNullablePointer { nndiscr, ref discrfield, .. } => {
                         if variant_index as u64 != nndiscr {
                             let (offset, ty) = self.nonnull_offset_and_ty(dest_ty, nndiscr, discrfield)?;
-                            let nonnull = self.force_allocation(dest)?.to_ptr()?.offset(offset.bytes(), self.memory.layout)?;
+                            let nonnull = self.force_allocation(dest)?.to_ptr()?.offset(offset.bytes(), &self)?;
                             trace!("struct wrapped nullable pointer type: {}", ty);
                             // only the pointer part of a fat pointer is used for this space optimization
                             let discr_size = self.type_size(ty)?.expect("bad StructWrappedNullablePointer discrfield");

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -316,7 +316,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                                     Value::ByRef(ptr, aligned) => {
                                         assert!(aligned, "Unaligned ByRef-values cannot occur as function arguments");
                                         for ((offset, ty), arg_local) in offsets.zip(fields).zip(arg_locals) {
-                                            let arg = Value::ByRef(ptr.offset(offset, self.memory.layout)?, true);
+                                            let arg = Value::ByRef(ptr.offset(offset, &self)?, true);
                                             let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
                                             trace!("writing arg {:?} to {:?} (type: {})", arg, dest, ty);
                                             self.write_value(arg, dest, ty)?;
@@ -398,7 +398,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
             ty::InstanceDef::Virtual(_, idx) => {
                 let ptr_size = self.memory.pointer_size();
                 let (_, vtable) = self.eval_operand(&arg_operands[0])?.into_ptr_vtable_pair(&mut self.memory)?;
-                let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3), self.memory.layout)?)?;
+                let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3), &self)?)?;
                 let instance = self.memory.get_fn(fn_ptr.to_ptr()?)?;
                 let mut arg_operands = arg_operands.to_vec();
                 let ty = self.operand_ty(&arg_operands[0]);
@@ -488,7 +488,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
 
             StructWrappedNullablePointer { nndiscr, ref discrfield, .. } => {
                 let (offset, ty) = self.nonnull_offset_and_ty(adt_ty, nndiscr, discrfield)?;
-                let nonnull = adt_ptr.offset(offset.bytes(), self.memory.layout)?;
+                let nonnull = adt_ptr.offset(offset.bytes(), self)?;
                 trace!("struct wrapped nullable pointer type: {}", ty);
                 // only the pointer part of a fat pointer is used for this space optimization
                 let discr_size = self.type_size(ty)?.expect("bad StructWrappedNullablePointer discrfield");
@@ -746,7 +746,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().rev().position(|&c| c == val) {
-                    let new_ptr = ptr.offset(num - idx as u64 - 1, self.memory.layout)?;
+                    let new_ptr = ptr.offset(num - idx as u64 - 1, &self)?;
                     self.write_ptr(dest, new_ptr, dest_ty)?;
                 } else {
                     self.write_null(dest, dest_ty)?;
@@ -758,7 +758,7 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
                 if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().position(|&c| c == val) {
-                    let new_ptr = ptr.offset(idx as u64, self.memory.layout)?;
+                    let new_ptr = ptr.offset(idx as u64, &self)?;
                     self.write_ptr(dest, new_ptr, dest_ty)?;
                 } else {
                     self.write_null(dest, dest_ty)?;
@@ -814,9 +814,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 if let Some((name, value)) = new {
                     // +1 for the null terminator
                     let value_copy = self.memory.allocate((value.len() + 1) as u64, 1, Kind::Env)?;
-                    let layout = self.memory.layout;
                     self.memory.write_bytes(value_copy.into(), &value)?;
-                    self.memory.write_bytes(value_copy.offset(value.len() as u64, layout)?.into(), &[0])?;
+                    let trailing_null = value_copy.offset(value.len() as u64, &self)?.into();
+                    self.memory.write_bytes(trailing_null, &[0])?;
                     if let Some(var) = self.env_vars.insert(name.to_owned(), value_copy) {
                         self.memory.deallocate(var, None, Kind::Env)?;
                     }

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -814,8 +814,9 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
                 if let Some((name, value)) = new {
                     // +1 for the null terminator
                     let value_copy = self.memory.allocate((value.len() + 1) as u64, 1, Kind::Env)?;
+                    let layout = self.memory.layout;
                     self.memory.write_bytes(value_copy.into(), &value)?;
-                    self.memory.write_bytes(value_copy.offset(value.len() as u64, self.memory.layout)?.into(), &[0])?;
+                    self.memory.write_bytes(value_copy.offset(value.len() as u64, layout)?.into(), &[0])?;
                     if let Some(var) = self.env_vars.insert(name.to_owned(), value_copy) {
                         self.memory.deallocate(var, None, Kind::Env)?;
                     }

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -57,14 +57,15 @@ impl<'a, 'tcx> EvalContext<'a, 'tcx> {
         let drop = self.memory.create_fn_alloc(drop);
         self.memory.write_ptr(vtable, drop)?;
 
-        self.memory.write_usize(vtable.offset(ptr_size, self.memory.layout)?, size)?;
-        self.memory.write_usize(vtable.offset(ptr_size * 2, self.memory.layout)?, align)?;
+        let layout = self.memory.layout;
+        self.memory.write_usize(vtable.offset(ptr_size, layout)?, size)?;
+        self.memory.write_usize(vtable.offset(ptr_size * 2, layout)?, align)?;
 
         for (i, method) in ::rustc::traits::get_vtable_methods(self.tcx, trait_ref).enumerate() {
             if let Some((def_id, substs)) = method {
                 let instance = eval_context::resolve(self.tcx, def_id, substs);
                 let fn_ptr = self.memory.create_fn_alloc(instance);
-                self.memory.write_ptr(vtable.offset(ptr_size * (3 + i as u64), self.memory.layout)?, fn_ptr)?;
+                self.memory.write_ptr(vtable.offset(ptr_size * (3 + i as u64), layout)?, fn_ptr)?;
             }
         }
 

--- a/src/librustc_mir/interpret/value.rs
+++ b/src/librustc_mir/interpret/value.rs
@@ -2,7 +2,7 @@
 #![allow(float_cmp)]
 
 use error::{EvalError, EvalResult};
-use memory::{Memory, MemoryPointer, HasMemory, HasDataLayout};
+use memory::{Memory, MemoryPointer, HasMemory, PointerArithmetic};
 
 pub(super) fn bytes_to_f32(bytes: u128) -> f32 {
     f32::from_bits(bytes as u32)
@@ -59,7 +59,7 @@ impl<'tcx> Pointer {
         self.primval
     }
 
-    pub(crate) fn signed_offset<'a, L: HasDataLayout<'a>>(self, i: i64, layout: L) -> EvalResult<'tcx, Self> {
+    pub(crate) fn signed_offset<L: PointerArithmetic>(self, i: i64, layout: L) -> EvalResult<'tcx, Self> {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
@@ -70,7 +70,7 @@ impl<'tcx> Pointer {
         }
     }
 
-    pub(crate) fn offset<'a, L: HasDataLayout<'a>>(self, i: u64, layout: L) -> EvalResult<'tcx, Self> {
+    pub(crate) fn offset<L: PointerArithmetic>(self, i: u64, layout: L) -> EvalResult<'tcx, Self> {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
@@ -81,7 +81,7 @@ impl<'tcx> Pointer {
         }
     }
 
-    pub(crate) fn wrapping_signed_offset<'a, L: HasDataLayout<'a>>(self, i: i64, layout: L) -> EvalResult<'tcx, Self> {
+    pub(crate) fn wrapping_signed_offset<L: PointerArithmetic>(self, i: i64, layout: L) -> EvalResult<'tcx, Self> {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);

--- a/src/librustc_mir/interpret/value.rs
+++ b/src/librustc_mir/interpret/value.rs
@@ -3,6 +3,7 @@
 
 use error::{EvalError, EvalResult};
 use memory::{Memory, MemoryPointer, HasMemory, PointerArithmetic};
+use rustc::ty::layout::HasDataLayout;
 
 pub(super) fn bytes_to_f32(bytes: u128) -> f32 {
     f32::from_bits(bytes as u32)
@@ -59,7 +60,8 @@ impl<'tcx> Pointer {
         self.primval
     }
 
-    pub(crate) fn signed_offset<L: PointerArithmetic>(self, i: i64, layout: L) -> EvalResult<'tcx, Self> {
+    pub(crate) fn signed_offset<C: HasDataLayout>(self, i: i64, cx: C) -> EvalResult<'tcx, Self> {
+        let layout = cx.data_layout();
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
@@ -70,7 +72,8 @@ impl<'tcx> Pointer {
         }
     }
 
-    pub(crate) fn offset<L: PointerArithmetic>(self, i: u64, layout: L) -> EvalResult<'tcx, Self> {
+    pub(crate) fn offset<C: HasDataLayout>(self, i: u64, cx: C) -> EvalResult<'tcx, Self> {
+        let layout = cx.data_layout();
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
@@ -81,7 +84,8 @@ impl<'tcx> Pointer {
         }
     }
 
-    pub(crate) fn wrapping_signed_offset<L: PointerArithmetic>(self, i: i64, layout: L) -> EvalResult<'tcx, Self> {
+    pub(crate) fn wrapping_signed_offset<C: HasDataLayout>(self, i: i64, cx: C) -> EvalResult<'tcx, Self> {
+        let layout = cx.data_layout();
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);

--- a/src/librustc_mir/interpret/value.rs
+++ b/src/librustc_mir/interpret/value.rs
@@ -1,10 +1,8 @@
 #![allow(unknown_lints)]
 #![allow(float_cmp)]
 
-use rustc::ty::layout::TargetDataLayout;
-
 use error::{EvalError, EvalResult};
-use memory::{Memory, MemoryPointer, HasMemory};
+use memory::{Memory, MemoryPointer, HasMemory, HasDataLayout};
 
 pub(super) fn bytes_to_f32(bytes: u128) -> f32 {
     f32::from_bits(bytes as u32)
@@ -61,33 +59,33 @@ impl<'tcx> Pointer {
         self.primval
     }
 
-    pub(crate) fn signed_offset(self, i: i64, layout: &TargetDataLayout) -> EvalResult<'tcx, Self> {
+    pub(crate) fn signed_offset<'a, L: HasDataLayout<'a>>(self, i: i64, layout: L) -> EvalResult<'tcx, Self> {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
-                Ok(Pointer::from(PrimVal::Bytes(signed_offset(b as u64, i, layout)? as u128)))
+                Ok(Pointer::from(PrimVal::Bytes(layout.signed_offset(b as u64, i)? as u128)))
             },
             PrimVal::Ptr(ptr) => ptr.signed_offset(i, layout).map(Pointer::from),
             PrimVal::Undef => Err(EvalError::ReadUndefBytes),
         }
     }
 
-    pub(crate) fn offset(self, i: u64, layout: &TargetDataLayout) -> EvalResult<'tcx, Self> {
+    pub(crate) fn offset<'a, L: HasDataLayout<'a>>(self, i: u64, layout: L) -> EvalResult<'tcx, Self> {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
-                Ok(Pointer::from(PrimVal::Bytes(offset(b as u64, i, layout)? as u128)))
+                Ok(Pointer::from(PrimVal::Bytes(layout.offset(b as u64, i)? as u128)))
             },
             PrimVal::Ptr(ptr) => ptr.offset(i, layout).map(Pointer::from),
             PrimVal::Undef => Err(EvalError::ReadUndefBytes),
         }
     }
 
-    pub(crate) fn wrapping_signed_offset(self, i: i64, layout: &TargetDataLayout) -> EvalResult<'tcx, Self> {
+    pub(crate) fn wrapping_signed_offset<'a, L: HasDataLayout<'a>>(self, i: i64, layout: L) -> EvalResult<'tcx, Self> {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
-                Ok(Pointer::from(PrimVal::Bytes(wrapping_signed_offset(b as u64, i, layout) as u128)))
+                Ok(Pointer::from(PrimVal::Bytes(layout.wrapping_signed_offset(b as u64, i) as u128)))
             },
             PrimVal::Ptr(ptr) => Ok(Pointer::from(ptr.wrapping_signed_offset(i, layout))),
             PrimVal::Undef => Err(EvalError::ReadUndefBytes),
@@ -321,47 +319,6 @@ impl<'tcx> PrimVal {
             _ => Err(EvalError::InvalidBool),
         }
     }
-}
-
-// Overflow checking only works properly on the range from -u64 to +u64.
-pub fn overflowing_signed_offset<'tcx>(val: u64, i: i128, layout: &TargetDataLayout) -> (u64, bool) {
-    // FIXME: is it possible to over/underflow here?
-    if i < 0 {
-        // trickery to ensure that i64::min_value() works fine
-        // this formula only works for true negative values, it panics for zero!
-        let n = u64::max_value() - (i as u64) + 1;
-        val.overflowing_sub(n)
-    } else {
-        overflowing_offset(val, i as u64, layout)
-    }
-}
-
-pub fn overflowing_offset<'tcx>(val: u64, i: u64, layout: &TargetDataLayout) -> (u64, bool) {
-    let (res, over) = val.overflowing_add(i);
-    ((res as u128 % (1u128 << layout.pointer_size.bits())) as u64,
-     over || res as u128 >= (1u128 << layout.pointer_size.bits()))
-}
-
-pub fn signed_offset<'tcx>(val: u64, i: i64, layout: &TargetDataLayout) -> EvalResult<'tcx, u64> {
-    let (res, over) = overflowing_signed_offset(val, i as i128, layout);
-    if over {
-        Err(EvalError::OverflowingMath)
-    } else {
-        Ok(res)
-    }
-}
-
-pub fn offset<'tcx>(val: u64, i: u64, layout: &TargetDataLayout) -> EvalResult<'tcx, u64> {
-    let (res, over) = overflowing_offset(val, i, layout);
-    if over {
-        Err(EvalError::OverflowingMath)
-    } else {
-        Ok(res)
-    }
-}
-
-pub fn wrapping_signed_offset<'tcx>(val: u64, i: i64, layout: &TargetDataLayout) -> u64 {
-    overflowing_signed_offset(val, i as i128, layout).0
 }
 
 impl PrimValKind {

--- a/tests/run-pass/ptr_int_casts.rs
+++ b/tests/run-pass/ptr_int_casts.rs
@@ -29,4 +29,7 @@ fn main() {
         let x : fn() -> i32 = unsafe { mem::transmute(y as *mut u8) };
         assert_eq!(x(), 42);
     }
+
+    // involving types other than usize
+    assert_eq!((-1i32) as usize as *const i32 as usize, (-1i32) as usize);
 }


### PR DESCRIPTION
`(-1i32) as usize as *const i32 as usize` would yield 0xff. That's clearly wrong. Not it yields what we would expect.

I also did some more refactoring of casting in general as I wasn't satisfied with how pointers were handled.