### PR TITLE
fix size_of_val on unsized tuples

### DIFF
--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -277,10 +277,13 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         self.tcx.erase_regions(&value)
     }
 
+    /// Return the size and aligment of the value at the given type.
+    /// Note that the value does not matter if the type is sized. For unsized types,
+    /// the value has to be a fat pointer, and we only care about the "extra" data in it.
     pub fn size_and_align_of_dst(
         &mut self,
         ty: ty::Ty<'tcx>,
-        value: Value, // This has to be a fat ptr; we only care about the "extra" data in it.
+        value: Value,
     ) -> EvalResult<'tcx, (u64, u64)> {
         if let Some(size) = self.type_size(ty)? {
             Ok((size as u64, self.type_align(ty)? as u64))

--- a/tests/run-pass-fullmir/unsized-tuple-impls.rs
+++ b/tests/run-pass-fullmir/unsized-tuple-impls.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 #![feature(unsized_tuple_coercion)]
+use std::mem;
 
 fn main() {
     let x : &(i32, i32, [i32]) = &(0, 1, [2, 3]);
@@ -18,4 +19,5 @@ fn main() {
     assert_eq!(a, [x, y]);
 
     assert_eq!(&format!("{:?}", a), "[(0, 1, [2, 3]), (0, 1, [2, 3, 4])]");
+    assert_eq!(mem::size_of_val(x), 16);
 }


### PR DESCRIPTION
I don't actually know what I am doing when I touch this unsized types code, but it makes the test suite pass. ;)