### PR TITLE
Upstream nits

### DIFF
--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -7,9 +7,7 @@ use helpers::*;
 
 #[bench]
 fn fib(bencher: &mut Bencher) {
-    bencher.iter(|| {
-        fibonacci_helper::main();
-    })
+    bencher.iter(|| { fibonacci_helper::main(); })
 }
 
 #[bench]
@@ -19,9 +17,7 @@ fn fib_miri(bencher: &mut Bencher) {
 
 #[bench]
 fn fib_iter(bencher: &mut Bencher) {
-    bencher.iter(|| {
-        fibonacci_helper_iterative::main();
-    })
+    bencher.iter(|| { fibonacci_helper_iterative::main(); })
 }
 
 #[bench]

--- a/benches/helpers/fibonacci_helper.rs
+++ b/benches/helpers/fibonacci_helper.rs
@@ -4,9 +4,5 @@ pub fn main() {
 }
 
 fn fib(n: usize) -> usize {
-    if n <= 2 {
-        1
-    } else {
-        fib(n - 1) + fib(n - 2)
-    }
+    if n <= 2 { 1 } else { fib(n - 1) + fib(n - 2) }
 }

--- a/benches/helpers/miri_helper.rs
+++ b/benches/helpers/miri_helper.rs
@@ -19,9 +19,13 @@ fn find_sysroot() -> String {
     let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
     match (home, toolchain) {
         (Some(home), Some(toolchain)) => format!("{}/toolchains/{}", home, toolchain),
-        _ => option_env!("RUST_SYSROOT")
-            .expect("need to specify RUST_SYSROOT env var or use rustup or multirust")
-            .to_owned(),
+        _ => {
+            option_env!("RUST_SYSROOT")
+                .expect(
+                    "need to specify RUST_SYSROOT env var or use rustup or multirust",
+                )
+                .to_owned()
+        }
     }
 }
 
@@ -30,7 +34,7 @@ pub fn run(filename: &str, bencher: &mut Bencher) {
         "miri".to_string(),
         format!("benches/helpers/{}.rs", filename),
         "--sysroot".to_string(),
-        find_sysroot()
+        find_sysroot(),
     ];
     let compiler_calls = &mut MiriCompilerCalls(Rc::new(RefCell::new(bencher)));
     rustc_driver::run_compiler(args, compiler_calls, None, None);
@@ -40,7 +44,7 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls<'a> {
     fn build_controller(
         &mut self,
         _: &Session,
-        _: &getopts::Matches
+        _: &getopts::Matches,
     ) -> driver::CompileController<'a> {
         let mut control: driver::CompileController<'a> = driver::CompileController::basic();
 
@@ -51,14 +55,17 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls<'a> {
             state.session.abort_if_errors();
 
             let tcx = state.tcx.unwrap();
-            let (entry_node_id, _) = state.session.entry_fn.borrow()
-                .expect("no main or start function found");
+            let (entry_node_id, _) = state.session.entry_fn.borrow().expect(
+                "no main or start function found",
+            );
             let entry_def_id = tcx.map.local_def_id(entry_node_id);
 
-            let memory_size = 100*1024*1024; // 100MB
+            let memory_size = 100 * 1024 * 1024; // 100MB
             let step_limit = 1000_000;
             let stack_limit = 100;
-            bencher.borrow_mut().iter(|| { eval_main(tcx, entry_def_id, memory_size, step_limit, stack_limit); });
+            bencher.borrow_mut().iter(|| {
+                eval_main(tcx, entry_def_id, memory_size, step_limit, stack_limit);
+            });
 
             state.session.abort_if_errors();
         });

--- a/benches/helpers/smoke_helper.rs
+++ b/benches/helpers/smoke_helper.rs
@@ -1,3 +1,2 @@
 #[inline(never)]
-pub fn main() {
-}
+pub fn main() {}

--- a/benches/smoke.rs
+++ b/benches/smoke.rs
@@ -7,9 +7,7 @@ use helpers::*;
 
 #[bench]
 fn noop(bencher: &mut Bencher) {
-    bencher.iter(|| {
-        smoke_helper::main();
-    })
+    bencher.iter(|| { smoke_helper::main(); })
 }
 
 /*

--- a/miri/bin/cargo-miri.rs
+++ b/miri/bin/cargo-miri.rs
@@ -117,7 +117,8 @@ fn main() {
             }
         }
     } else {
-        // this arm is executed when cargo-miri runs `cargo rustc` with the `RUSTC` env var set to itself
+        // this arm is executed when cargo-miri runs
+        // `cargo rustc` with the `RUSTC` env var set to itself
 
         let home = option_env!("RUSTUP_HOME").or(option_env!("MULTIRUST_HOME"));
         let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
@@ -135,11 +136,14 @@ fn main() {
                         .and_then(|out| String::from_utf8(out.stdout).ok())
                         .map(|s| s.trim().to_owned())
                 })
-                .expect("need to specify RUST_SYSROOT env var during miri compilation, or use rustup or multirust")
+                .expect(
+                    "need to specify RUST_SYSROOT env var during \
+                         miri compilation, or use rustup or multirust",
+                )
         };
 
-        // this conditional check for the --sysroot flag is there so users can call `cargo-miri` directly
-        // without having to pass --sysroot or anything
+        // this conditional check for the --sysroot flag is there so users can call `cargo-miri`
+        // directly without having to pass --sysroot or anything
         let mut args: Vec<String> = if std::env::args().any(|s| s == "--sysroot") {
             std::env::args().skip(1).collect()
         } else {
@@ -150,8 +154,8 @@ fn main() {
                 .collect()
         };
 
-        // this check ensures that dependencies are built but not interpreted and the final crate is
-        // interpreted but not built
+        // this check ensures that dependencies are built but not interpreted and the final crate
+        // is interpreted but not built
         let miri_enabled = std::env::args().any(|s| s == "-Zno-trans");
 
         let mut command = if miri_enabled {

--- a/miri/fn_call.rs
+++ b/miri/fn_call.rs
@@ -126,7 +126,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             }
 
             "syscall" => {
-                // TODO: read `syscall` ids like `sysconf` ids and
+                // FIXME: read `syscall` ids like `sysconf` ids and
                 // figure out some way to actually process some of them
                 //
                 // libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)
@@ -156,7 +156,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let f_instance = self.memory.get_fn(f)?;
                 self.write_null(dest, dest_ty)?;
 
-                // Now we make a function call.  TODO: Consider making this re-usable?  EvalContext::step does sth. similar for the TLS dtors,
+                // Now we make a function call.  FIXME: Consider making this re-usable?  EvalContext::step does sth. similar for the TLS dtors,
                 // and of course eval_main.
                 let mir = self.load_mir(f_instance.def)?;
                 self.push_stack_frame(
@@ -371,7 +371,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 if key_size.bits() < 128 && key >= (1u128 << key_size.bits() as u128) {
                     return err!(OutOfTls);
                 }
-                // TODO: Does this need checking for alignment?
+                // FIXME: Does this need checking for alignment?
                 self.memory.write_uint(key_ptr.to_ptr()?, key, key_size.bytes())?;
 
                 // Return success (0)
@@ -476,7 +476,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
 
         if sig.abi == Abi::C {
             // An external C function
-            // TODO: That functions actually has a similar preamble to what follows here.  May make sense to
+            // FIXME: That functions actually has a similar preamble to what follows here.  May make sense to
             // unify these two mechanisms for "hooking into missing functions".
             self.call_c_abi(instance.def_id(), arg_operands, dest, dest_ty, dest_block)?;
             return Ok(());

--- a/miri/fn_call.rs
+++ b/miri/fn_call.rs
@@ -9,10 +9,7 @@ use std::mem;
 
 use rustc_miri::interpret::*;
 
-use super::{
-    TlsKey,
-    EvalContext,
-};
+use super::{TlsKey, EvalContext};
 
 use tls::MemoryExt;
 
@@ -62,13 +59,19 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
 
         let mir = match self.load_mir(instance.def) {
             Ok(mir) => mir,
-            Err(EvalError{ kind: EvalErrorKind::NoMirFor(path), ..} ) => {
-                self.call_missing_fn(instance, destination, arg_operands, sig, path)?;
+            Err(EvalError { kind: EvalErrorKind::NoMirFor(path), .. }) => {
+                self.call_missing_fn(
+                    instance,
+                    destination,
+                    arg_operands,
+                    sig,
+                    path,
+                )?;
                 return Ok(true);
-            },
+            }
             Err(other) => return Err(other),
         };
-        
+
         let (return_lvalue, return_to_block) = match destination {
             Some((lvalue, block)) => (lvalue, StackPopCleanup::Goto(block)),
             None => (Lvalue::undef(), StackPopCleanup::None),
@@ -99,7 +102,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             .unwrap_or(name)
             .as_str();
 
-        let args_res: EvalResult<Vec<Value>> = arg_operands.iter()
+        let args_res: EvalResult<Vec<Value>> = arg_operands
+            .iter()
             .map(|arg| self.eval_operand(arg))
             .collect();
         let args = args_res?;
@@ -132,9 +136,16 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 // libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)
                 // is called if a `HashMap` is created the regular way.
                 match self.value_to_primval(args[0], usize)?.to_u64()? {
-                    318 |
-                    511 => return err!(Unimplemented("miri does not support random number generators".to_owned())),
-                    id => return err!(Unimplemented(format!("miri does not support syscall id {}", id))),
+                    318 | 511 => {
+                        return err!(Unimplemented(
+                            "miri does not support random number generators".to_owned(),
+                        ))
+                    }
+                    id => {
+                        return err!(Unimplemented(
+                            format!("miri does not support syscall id {}", id),
+                        ))
+                    }
                 }
             }
 
@@ -144,7 +155,10 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let symbol_name = self.memory.read_c_str(symbol)?;
                 let err = format!("bad c unicode symbol: {:?}", symbol_name);
                 let symbol_name = ::std::str::from_utf8(symbol_name).unwrap_or(&err);
-                return err!(Unimplemented(format!("miri does not support dynamically loading libraries (requested symbol: {})", symbol_name)));
+                return err!(Unimplemented(format!(
+                    "miri does not support dynamically loading libraries (requested symbol: {})",
+                    symbol_name
+                )));
             }
 
             "__rust_maybe_catch_panic" => {
@@ -167,7 +181,12 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                     StackPopCleanup::Goto(dest_block),
                 )?;
 
-                let arg_local = self.frame().mir.args_iter().next().ok_or(EvalErrorKind::AbiViolation("Argument to __rust_maybe_catch_panic does not take enough arguments.".to_owned()))?;
+                let arg_local = self.frame().mir.args_iter().next().ok_or(
+                    EvalErrorKind::AbiViolation(
+                        "Argument to __rust_maybe_catch_panic does not take enough arguments."
+                            .to_owned(),
+                    ),
+                )?;
                 let arg_dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
                 self.write_ptr(arg_dest, data, u8_ptr_ty)?;
 
@@ -199,14 +218,21 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                     }
                 };
 
-                self.write_primval(dest, PrimVal::Bytes(result as u128), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::Bytes(result as u128),
+                    dest_ty,
+                )?;
             }
 
             "memrchr" => {
                 let ptr = args[0].into_ptr(&mut self.memory)?;
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
-                if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().rev().position(|&c| c == val) {
+                if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().rev().position(
+                    |&c| c == val,
+                )
+                {
                     let new_ptr = ptr.offset(num - idx as u64 - 1, &self)?;
                     self.write_ptr(dest, new_ptr, dest_ty)?;
                 } else {
@@ -218,7 +244,10 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let ptr = args[0].into_ptr(&mut self.memory)?;
                 let val = self.value_to_primval(args[1], usize)?.to_u64()? as u8;
                 let num = self.value_to_primval(args[2], usize)?.to_u64()?;
-                if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().position(|&c| c == val) {
+                if let Some(idx) = self.memory.read_bytes(ptr, num)?.iter().position(
+                    |&c| c == val,
+                )
+                {
                     let new_ptr = ptr.offset(idx as u64, &self)?;
                     self.write_ptr(dest, new_ptr, dest_ty)?;
                 } else {
@@ -274,11 +303,19 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 }
                 if let Some((name, value)) = new {
                     // +1 for the null terminator
-                    let value_copy = self.memory.allocate((value.len() + 1) as u64, 1, Kind::Env.into())?;
+                    let value_copy = self.memory.allocate(
+                        (value.len() + 1) as u64,
+                        1,
+                        Kind::Env.into(),
+                    )?;
                     self.memory.write_bytes(value_copy.into(), &value)?;
                     let trailing_zero_ptr = value_copy.offset(value.len() as u64, &self)?.into();
                     self.memory.write_bytes(trailing_zero_ptr, &[0])?;
-                    if let Some(var) = self.machine_data.env_vars.insert(name.to_owned(), value_copy) {
+                    if let Some(var) = self.machine_data.env_vars.insert(
+                        name.to_owned(),
+                        value_copy,
+                    )
+                    {
                         self.memory.deallocate(var, None, Kind::Env.into())?;
                     }
                     self.write_null(dest, dest_ty)?;
@@ -292,17 +329,29 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let buf = args[1].into_ptr(&mut self.memory)?;
                 let n = self.value_to_primval(args[2], usize)?.to_u64()?;
                 trace!("Called write({:?}, {:?}, {:?})", fd, buf, n);
-                let result = if fd == 1 || fd == 2 { // stdout/stderr
+                let result = if fd == 1 || fd == 2 {
+                    // stdout/stderr
                     use std::io::{self, Write};
-                
+
                     let buf_cont = self.memory.read_bytes(buf, n)?;
-                    let res = if fd == 1 { io::stdout().write(buf_cont) } else { io::stderr().write(buf_cont) };
-                    match res { Ok(n) => n as isize, Err(_) => -1 }
+                    let res = if fd == 1 {
+                        io::stdout().write(buf_cont)
+                    } else {
+                        io::stderr().write(buf_cont)
+                    };
+                    match res {
+                        Ok(n) => n as isize,
+                        Err(_) => -1,
+                    }
                 } else {
                     info!("Ignored output to FD {}", fd);
                     n as isize // pretend it all went well
                 }; // now result is the value we return back to the program
-                self.write_primval(dest, PrimVal::Bytes(result as u128), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::Bytes(result as u128),
+                    dest_ty,
+                )?;
             }
 
             "strlen" => {
@@ -327,7 +376,10 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let mut result = None;
                 for &(path, path_value) in paths {
                     if let Ok(instance) = self.resolve_path(path) {
-                        let cid = GlobalId { instance, promoted: None };
+                        let cid = GlobalId {
+                            instance,
+                            promoted: None,
+                        };
                         // compute global if not cached
                         let val = match self.globals.get(&cid).map(|glob| glob.value) {
                             Some(value) => self.value_to_primval(value, usize)?.to_u64()?,
@@ -342,7 +394,9 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 if let Some(result) = result {
                     self.write_primval(dest, result, dest_ty)?;
                 } else {
-                    return err!(Unimplemented(format!("Unimplemented sysconf name: {}", name)));
+                    return err!(Unimplemented(
+                        format!("Unimplemented sysconf name: {}", name),
+                    ));
                 }
             }
 
@@ -372,7 +426,11 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                     return err!(OutOfTls);
                 }
                 // FIXME: Does this need checking for alignment?
-                self.memory.write_uint(key_ptr.to_ptr()?, key, key_size.bytes())?;
+                self.memory.write_uint(
+                    key_ptr.to_ptr()?,
+                    key,
+                    key_size.bytes(),
+                )?;
 
                 // Return success (0)
                 self.write_null(dest, dest_ty)?;
@@ -395,7 +453,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let key = self.value_to_primval(args[0], usize)?.to_u64()? as TlsKey;
                 let new_ptr = args[1].into_ptr(&mut self.memory)?;
                 self.memory.store_tls(key, new_ptr)?;
-                
+
                 // Return success (0)
                 self.write_null(dest, dest_ty)?;
             }
@@ -404,10 +462,12 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             link_name if link_name.starts_with("pthread_") => {
                 warn!("ignoring C ABI call: {}", link_name);
                 self.write_null(dest, dest_ty)?;
-            },
+            }
 
             _ => {
-                return err!(Unimplemented(format!("can't call C ABI function: {}", link_name)));
+                return err!(Unimplemented(
+                    format!("can't call C ABI function: {}", link_name),
+                ));
             }
         }
 
@@ -424,7 +484,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
         let cstore = &self.tcx.sess.cstore;
 
         let crates = cstore.crates();
-        crates.iter()
+        crates
+            .iter()
             .find(|&&krate| cstore.crate_name(krate) == path[0])
             .and_then(|krate| {
                 let krate = DefId {
@@ -449,9 +510,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 None
             })
             .ok_or_else(|| {
-                let path = path.iter()
-                    .map(|&s| s.to_owned())
-                    .collect();
+                let path = path.iter().map(|&s| s.to_owned()).collect();
                 EvalErrorKind::PathNotFound(path).into()
             })
     }
@@ -468,27 +527,36 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
         match &path[..] {
             "std::panicking::rust_panic_with_hook" |
             "std::rt::begin_panic_fmt" => return err!(Panic),
-            _ => {},
+            _ => {}
         }
 
         let dest_ty = sig.output();
-        let (dest, dest_block) = destination.ok_or_else(|| EvalErrorKind::NoMirFor(path.clone()))?;
+        let (dest, dest_block) = destination.ok_or_else(
+            || EvalErrorKind::NoMirFor(path.clone()),
+        )?;
 
         if sig.abi == Abi::C {
             // An external C function
             // FIXME: That functions actually has a similar preamble to what follows here.  May make sense to
             // unify these two mechanisms for "hooking into missing functions".
-            self.call_c_abi(instance.def_id(), arg_operands, dest, dest_ty, dest_block)?;
+            self.call_c_abi(
+                instance.def_id(),
+                arg_operands,
+                dest,
+                dest_ty,
+                dest_block,
+            )?;
             return Ok(());
         }
 
-        let args_res: EvalResult<Vec<Value>> = arg_operands.iter()
+        let args_res: EvalResult<Vec<Value>> = arg_operands
+            .iter()
             .map(|arg| self.eval_operand(arg))
             .collect();
         let args = args_res?;
 
         let usize = self.tcx.types.usize;
-    
+
         match &path[..] {
             // Allocators are magic.  They have no MIR, even when the rest of libstd does.
             "alloc::heap::::__rust_alloc" => {
@@ -526,7 +594,11 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 if !align.is_power_of_two() {
                     return err!(HeapAllocNonPowerOfTwoAlignment(align));
                 }
-                self.memory.deallocate(ptr, Some((old_size, align)), Kind::Rust.into())?;
+                self.memory.deallocate(
+                    ptr,
+                    Some((old_size, align)),
+                    Kind::Rust.into(),
+                )?;
             }
             "alloc::heap::::__rust_realloc" => {
                 let ptr = args[0].into_ptr(&mut self.memory)?.to_ptr()?;
@@ -543,17 +615,32 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 if !new_align.is_power_of_two() {
                     return err!(HeapAllocNonPowerOfTwoAlignment(new_align));
                 }
-                let new_ptr = self.memory.reallocate(ptr, old_size, old_align, new_size, new_align, Kind::Rust.into())?;
+                let new_ptr = self.memory.reallocate(
+                    ptr,
+                    old_size,
+                    old_align,
+                    new_size,
+                    new_align,
+                    Kind::Rust.into(),
+                )?;
                 self.write_primval(dest, PrimVal::Ptr(new_ptr), dest_ty)?;
             }
 
             // A Rust function is missing, which means we are running with MIR missing for libstd (or other dependencies).
             // Still, we can make many things mostly work by "emulating" or ignoring some functions.
             "std::io::_print" => {
-                trace!("Ignoring output.  To run programs that print, make sure you have a libstd with full MIR.");
+                trace!(
+                    "Ignoring output.  To run programs that print, make sure you have a libstd with full MIR."
+                );
             }
-            "std::thread::Builder::new" => return err!(Unimplemented("miri does not support threading".to_owned())),
-            "std::env::args" => return err!(Unimplemented("miri does not support program arguments".to_owned())),
+            "std::thread::Builder::new" => {
+                return err!(Unimplemented("miri does not support threading".to_owned()))
+            }
+            "std::env::args" => {
+                return err!(Unimplemented(
+                    "miri does not support program arguments".to_owned(),
+                ))
+            }
             "std::panicking::panicking" |
             "std::rt::panicking" => {
                 // we abort on panic -> `std::rt::panicking` always returns false

--- a/miri/helpers.rs
+++ b/miri/helpers.rs
@@ -1,9 +1,4 @@
-use rustc_miri::interpret::{
-    Pointer,
-    EvalResult,
-    PrimVal,
-    EvalContext,
-};
+use rustc_miri::interpret::{Pointer, EvalResult, PrimVal, EvalContext};
 
 use rustc::ty::Ty;
 
@@ -31,7 +26,9 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
         offset: i64,
     ) -> EvalResult<'tcx, Pointer> {
         // FIXME: assuming here that type size is < i64::max_value()
-        let pointee_size = self.type_size(pointee_ty)?.expect("cannot offset a pointer to an unsized type") as i64;
+        let pointee_size = self.type_size(pointee_ty)?.expect(
+            "cannot offset a pointer to an unsized type",
+        ) as i64;
         let offset = offset.overflowing_mul(pointee_size).0;
         ptr.wrapping_signed_offset(offset, self)
     }
@@ -47,11 +44,18 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
         // We also consider the NULL pointer its own separate allocation, and all the remaining integers pointers their own
         // allocation.
 
-        if ptr.is_null()? { // NULL pointers must only be offset by 0
-            return if offset == 0 { Ok(ptr) } else { err!(InvalidNullPointerUsage) };
+        if ptr.is_null()? {
+            // NULL pointers must only be offset by 0
+            return if offset == 0 {
+                Ok(ptr)
+            } else {
+                err!(InvalidNullPointerUsage)
+            };
         }
         // FIXME: assuming here that type size is < i64::max_value()
-        let pointee_size = self.type_size(pointee_ty)?.expect("cannot offset a pointer to an unsized type") as i64;
+        let pointee_size = self.type_size(pointee_ty)?.expect(
+            "cannot offset a pointer to an unsized type",
+        ) as i64;
         return if let Some(offset) = offset.checked_mul(pointee_size) {
             let ptr = ptr.signed_offset(offset, self)?;
             // Do not do bounds-checking for integers; they can never alias a normal pointer anyway.
@@ -64,6 +68,6 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             Ok(ptr)
         } else {
             err!(OverflowingMath)
-        }
+        };
     }
 }

--- a/miri/helpers.rs
+++ b/miri/helpers.rs
@@ -39,10 +39,11 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
         pointee_ty: Ty<'tcx>,
         offset: i64,
     ) -> EvalResult<'tcx, Pointer> {
-        // This function raises an error if the offset moves the pointer outside of its allocation.  We consider
-        // ZSTs their own huge allocation that doesn't overlap with anything (and nothing moves in there because the size is 0).
-        // We also consider the NULL pointer its own separate allocation, and all the remaining integers pointers their own
-        // allocation.
+        // This function raises an error if the offset moves the pointer outside of its allocation.
+        // We consider ZSTs their own huge allocation that doesn't overlap with anything
+        // (and nothing moves in there because the size is 0).
+        // We also consider the NULL pointer its own separate allocation,
+        // and all the remaining integers pointers their own allocation.
 
         if ptr.is_null()? {
             // NULL pointers must only be offset by 0
@@ -62,7 +63,9 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             if let PrimVal::Ptr(ptr) = ptr.into_inner_primval() {
                 self.memory.check_bounds(ptr, false)?;
             } else if ptr.is_null()? {
-                // We moved *to* a NULL pointer.  That seems wrong, LLVM considers the NULL pointer its own small allocation.  Reject this, for now.
+                // We moved *to* a NULL pointer.
+                // That seems wrong, LLVM considers the NULL pointer its own small allocation.
+                // Reject this, for now.
                 return err!(InvalidNullPointerUsage);
             }
             Ok(ptr)

--- a/miri/intrinsic.rs
+++ b/miri/intrinsic.rs
@@ -3,13 +3,8 @@ use rustc::traits::Reveal;
 use rustc::ty::layout::Layout;
 use rustc::ty::{self, Ty};
 
-use rustc_miri::interpret::{
-    EvalResult,
-    Lvalue, LvalueExtra,
-    PrimVal, PrimValKind, Value, Pointer,
-    HasMemory,
-    EvalContext,
-};
+use rustc_miri::interpret::{EvalResult, Lvalue, LvalueExtra, PrimVal, PrimValKind, Value, Pointer,
+                            HasMemory, EvalContext};
 
 use helpers::EvalContextExt as HelperEvalContextExt;
 
@@ -35,9 +30,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
         dest_layout: &'tcx Layout,
         target: mir::BasicBlock,
     ) -> EvalResult<'tcx> {
-        let arg_vals: EvalResult<Vec<Value>> = args.iter()
-            .map(|arg| self.eval_operand(arg))
-            .collect();
+        let arg_vals: EvalResult<Vec<Value>> =
+            args.iter().map(|arg| self.eval_operand(arg)).collect();
         let arg_vals = arg_vals?;
         let i32 = self.tcx.types.i32;
         let isize = self.tcx.types.isize;
@@ -48,15 +42,35 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
 
         let intrinsic_name = &self.tcx.item_name(instance.def_id()).as_str()[..];
         match intrinsic_name {
-            "add_with_overflow" =>
-                self.intrinsic_with_overflow(mir::BinOp::Add, &args[0], &args[1], dest, dest_ty)?,
+            "add_with_overflow" => {
+                self.intrinsic_with_overflow(
+                    mir::BinOp::Add,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?
+            }
 
-            "sub_with_overflow" =>
-                self.intrinsic_with_overflow(mir::BinOp::Sub, &args[0], &args[1], dest, dest_ty)?,
+            "sub_with_overflow" => {
+                self.intrinsic_with_overflow(
+                    mir::BinOp::Sub,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?
+            }
 
-            "mul_with_overflow" =>
-                self.intrinsic_with_overflow(mir::BinOp::Mul, &args[0], &args[1], dest, dest_ty)?,
-
+            "mul_with_overflow" => {
+                self.intrinsic_with_overflow(
+                    mir::BinOp::Mul,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?
+            }
 
             "arith_offset" => {
                 let offset = self.value_to_primval(arg_vals[1], isize)?.to_i128()? as i64;
@@ -68,7 +82,9 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             "assume" => {
                 let bool = self.tcx.types.bool;
                 let cond = self.value_to_primval(arg_vals[0], bool)?.to_bool()?;
-                if !cond { return err!(AssumptionNotHeld); }
+                if !cond {
+                    return err!(AssumptionNotHeld);
+                }
             }
 
             "atomic_load" |
@@ -104,7 +120,11 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                     Value::ByValPair(..) => bug!("atomic_xchg doesn't work with nonprimitives"),
                 };
                 self.write_primval(dest, old, ty)?;
-                self.write_primval(Lvalue::from_primval_ptr(ptr), change, ty)?;
+                self.write_primval(
+                    Lvalue::from_primval_ptr(ptr),
+                    change,
+                    ty,
+                )?;
             }
 
             _ if intrinsic_name.starts_with("atomic_cxchg") => {
@@ -121,14 +141,38 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let (val, _) = self.binary_op(mir::BinOp::Eq, old, ty, expect_old, ty)?;
                 let dest = self.force_allocation(dest)?.to_ptr()?;
                 self.write_pair_to_ptr(old, val, dest, dest_ty)?;
-                self.write_primval(Lvalue::from_primval_ptr(ptr), change, ty)?;
+                self.write_primval(
+                    Lvalue::from_primval_ptr(ptr),
+                    change,
+                    ty,
+                )?;
             }
 
-            "atomic_or" | "atomic_or_acq" | "atomic_or_rel" | "atomic_or_acqrel" | "atomic_or_relaxed" |
-            "atomic_xor" | "atomic_xor_acq" | "atomic_xor_rel" | "atomic_xor_acqrel" | "atomic_xor_relaxed" |
-            "atomic_and" | "atomic_and_acq" | "atomic_and_rel" | "atomic_and_acqrel" | "atomic_and_relaxed" |
-            "atomic_xadd" | "atomic_xadd_acq" | "atomic_xadd_rel" | "atomic_xadd_acqrel" | "atomic_xadd_relaxed" |
-            "atomic_xsub" | "atomic_xsub_acq" | "atomic_xsub_rel" | "atomic_xsub_acqrel" | "atomic_xsub_relaxed" => {
+            "atomic_or" |
+            "atomic_or_acq" |
+            "atomic_or_rel" |
+            "atomic_or_acqrel" |
+            "atomic_or_relaxed" |
+            "atomic_xor" |
+            "atomic_xor_acq" |
+            "atomic_xor_rel" |
+            "atomic_xor_acqrel" |
+            "atomic_xor_relaxed" |
+            "atomic_and" |
+            "atomic_and_acq" |
+            "atomic_and_rel" |
+            "atomic_and_acqrel" |
+            "atomic_and_relaxed" |
+            "atomic_xadd" |
+            "atomic_xadd_acq" |
+            "atomic_xadd_rel" |
+            "atomic_xadd_acqrel" |
+            "atomic_xadd_relaxed" |
+            "atomic_xsub" |
+            "atomic_xsub_acq" |
+            "atomic_xsub_rel" |
+            "atomic_xsub_acqrel" |
+            "atomic_xsub_relaxed" => {
                 let ty = substs.type_at(0);
                 let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 let change = self.value_to_primval(arg_vals[1], ty)?;
@@ -136,7 +180,9 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let old = match old {
                     Value::ByVal(val) => val,
                     Value::ByRef { .. } => bug!("just read the value, can't be byref"),
-                    Value::ByValPair(..) => bug!("atomic_xadd_relaxed doesn't work with nonprimitives"),
+                    Value::ByValPair(..) => {
+                        bug!("atomic_xadd_relaxed doesn't work with nonprimitives")
+                    }
                 };
                 self.write_primval(dest, old, ty)?;
                 let op = match intrinsic_name.split('_').nth(1).unwrap() {
@@ -150,7 +196,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 // FIXME: what do atomics do on overflow?
                 let (val, _) = self.binary_op(op, old, ty, change, ty)?;
                 self.write_primval(Lvalue::from_primval_ptr(ptr), val, ty)?;
-            },
+            }
 
             "breakpoint" => unimplemented!(), // halt miri
 
@@ -165,22 +211,23 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                     let elem_align = self.type_align(elem_ty)?;
                     let src = arg_vals[0].into_ptr(&self.memory)?;
                     let dest = arg_vals[1].into_ptr(&self.memory)?;
-                    self.memory.copy(src, dest, count * elem_size, elem_align, intrinsic_name.ends_with("_nonoverlapping"))?;
+                    self.memory.copy(
+                        src,
+                        dest,
+                        count * elem_size,
+                        elem_align,
+                        intrinsic_name.ends_with("_nonoverlapping"),
+                    )?;
                 }
             }
 
-            "ctpop" |
-            "cttz" |
-            "cttz_nonzero" |
-            "ctlz" |
-            "ctlz_nonzero" |
-            "bswap" => {
+            "ctpop" | "cttz" | "cttz_nonzero" | "ctlz" | "ctlz_nonzero" | "bswap" => {
                 let ty = substs.type_at(0);
                 let num = self.value_to_primval(arg_vals[0], ty)?.to_bytes()?;
                 let kind = self.ty_to_primval_kind(ty)?;
                 let num = if intrinsic_name.ends_with("_nonzero") {
                     if num == 0 {
-                        return err!(Intrinsic(format!("{} called on 0", intrinsic_name)))
+                        return err!(Intrinsic(format!("{} called on 0", intrinsic_name)));
                     }
                     numeric_intrinsic(intrinsic_name.trim_right_matches("_nonzero"), num, kind)?
                 } else {
@@ -196,10 +243,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 self.write_primval(dest, PrimVal::Bytes(discr_val), dest_ty)?;
             }
 
-            "sinf32" | "fabsf32" | "cosf32" |
-            "sqrtf32" | "expf32" | "exp2f32" |
-            "logf32" | "log10f32" | "log2f32" |
-            "floorf32" | "ceilf32" | "truncf32" => {
+            "sinf32" | "fabsf32" | "cosf32" | "sqrtf32" | "expf32" | "exp2f32" | "logf32" |
+            "log10f32" | "log2f32" | "floorf32" | "ceilf32" | "truncf32" => {
                 let f = self.value_to_primval(arg_vals[0], f32)?.to_f32()?;
                 let f = match intrinsic_name {
                     "sinf32" => f.sin(),
@@ -219,10 +264,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 self.write_primval(dest, PrimVal::from_f32(f), dest_ty)?;
             }
 
-            "sinf64" | "fabsf64" | "cosf64" |
-            "sqrtf64" | "expf64" | "exp2f64" |
-            "logf64" | "log10f64" | "log2f64" |
-            "floorf64" | "ceilf64" | "truncf64" => {
+            "sinf64" | "fabsf64" | "cosf64" | "sqrtf64" | "expf64" | "exp2f64" | "logf64" |
+            "log10f64" | "log2f64" | "floorf64" | "ceilf64" | "truncf64" => {
                 let f = self.value_to_primval(arg_vals[0], f64)?.to_f64()?;
                 let f = match intrinsic_name {
                     "sinf64" => f.sin(),
@@ -258,9 +301,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 self.write_primval(dest, result.0, dest_ty)?;
             }
 
-            "likely" |
-            "unlikely" |
-            "forget" => {}
+            "likely" | "unlikely" | "forget" => {}
 
             "init" => {
                 let size = self.type_size(dest_ty)?.expect("cannot zero unsized value");
@@ -270,27 +311,36 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                             // These writes have no alignment restriction anyway.
                             this.memory.write_repeat(ptr, 0, size)?;
                             Value::ByRef { ptr, aligned }
-                        },
+                        }
                         // FIXME(solson): Revisit this, it's fishy to check for Undef here.
-                        Value::ByVal(PrimVal::Undef) => match this.ty_to_primval_kind(dest_ty) {
-                            Ok(_) => Value::ByVal(PrimVal::Bytes(0)),
-                            Err(_) => {
-                                let ptr = this.alloc_ptr_with_substs(dest_ty, substs)?;
-                                let ptr = Pointer::from(PrimVal::Ptr(ptr));
-                                this.memory.write_repeat(ptr, 0, size)?;
-                                Value::by_ref(ptr)
+                        Value::ByVal(PrimVal::Undef) => {
+                            match this.ty_to_primval_kind(dest_ty) {
+                                Ok(_) => Value::ByVal(PrimVal::Bytes(0)),
+                                Err(_) => {
+                                    let ptr = this.alloc_ptr_with_substs(dest_ty, substs)?;
+                                    let ptr = Pointer::from(PrimVal::Ptr(ptr));
+                                    this.memory.write_repeat(ptr, 0, size)?;
+                                    Value::by_ref(ptr)
+                                }
                             }
-                        },
+                        }
                         Value::ByVal(_) => Value::ByVal(PrimVal::Bytes(0)),
-                        Value::ByValPair(..) =>
-                            Value::ByValPair(PrimVal::Bytes(0), PrimVal::Bytes(0)),
+                        Value::ByValPair(..) => {
+                            Value::ByValPair(PrimVal::Bytes(0), PrimVal::Bytes(0))
+                        }
                     };
                     Ok(zero_val)
                 };
                 match dest {
                     Lvalue::Local { frame, local } => self.modify_local(frame, local, init)?,
-                    Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true } => self.memory.write_repeat(ptr, 0, size)?,
-                    Lvalue::Ptr { .. } => bug!("init intrinsic tried to write to fat or unaligned ptr target"),
+                    Lvalue::Ptr {
+                        ptr,
+                        extra: LvalueExtra::None,
+                        aligned: true,
+                    } => self.memory.write_repeat(ptr, 0, size)?,
+                    Lvalue::Ptr { .. } => {
+                        bug!("init intrinsic tried to write to fat or unaligned ptr target")
+                    }
                     Lvalue::Global(cid) => self.modify_global(cid, init)?,
                 }
             }
@@ -320,7 +370,11 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let ty = substs.type_at(0);
                 let env = ty::ParamEnv::empty(Reveal::All);
                 let needs_drop = ty.needs_drop(self.tcx, env);
-                self.write_primval(dest, PrimVal::from_bool(needs_drop), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_bool(needs_drop),
+                    dest_ty,
+                )?;
             }
 
             "offset" => {
@@ -331,72 +385,124 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             }
 
             "overflowing_sub" => {
-                self.intrinsic_overflowing(mir::BinOp::Sub, &args[0], &args[1], dest, dest_ty)?;
+                self.intrinsic_overflowing(
+                    mir::BinOp::Sub,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?;
             }
 
             "overflowing_mul" => {
-                self.intrinsic_overflowing(mir::BinOp::Mul, &args[0], &args[1], dest, dest_ty)?;
+                self.intrinsic_overflowing(
+                    mir::BinOp::Mul,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?;
             }
 
             "overflowing_add" => {
-                self.intrinsic_overflowing(mir::BinOp::Add, &args[0], &args[1], dest, dest_ty)?;
+                self.intrinsic_overflowing(
+                    mir::BinOp::Add,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?;
             }
 
             "powf32" => {
                 let f = self.value_to_primval(arg_vals[0], f32)?.to_f32()?;
                 let f2 = self.value_to_primval(arg_vals[1], f32)?.to_f32()?;
-                self.write_primval(dest, PrimVal::from_f32(f.powf(f2)), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_f32(f.powf(f2)),
+                    dest_ty,
+                )?;
             }
 
             "powf64" => {
                 let f = self.value_to_primval(arg_vals[0], f64)?.to_f64()?;
                 let f2 = self.value_to_primval(arg_vals[1], f64)?.to_f64()?;
-                self.write_primval(dest, PrimVal::from_f64(f.powf(f2)), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_f64(f.powf(f2)),
+                    dest_ty,
+                )?;
             }
 
             "fmaf32" => {
                 let a = self.value_to_primval(arg_vals[0], f32)?.to_f32()?;
                 let b = self.value_to_primval(arg_vals[1], f32)?.to_f32()?;
                 let c = self.value_to_primval(arg_vals[2], f32)?.to_f32()?;
-                self.write_primval(dest, PrimVal::from_f32(a * b + c), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_f32(a * b + c),
+                    dest_ty,
+                )?;
             }
 
             "fmaf64" => {
                 let a = self.value_to_primval(arg_vals[0], f64)?.to_f64()?;
                 let b = self.value_to_primval(arg_vals[1], f64)?.to_f64()?;
                 let c = self.value_to_primval(arg_vals[2], f64)?.to_f64()?;
-                self.write_primval(dest, PrimVal::from_f64(a * b + c), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_f64(a * b + c),
+                    dest_ty,
+                )?;
             }
 
             "powif32" => {
                 let f = self.value_to_primval(arg_vals[0], f32)?.to_f32()?;
                 let i = self.value_to_primval(arg_vals[1], i32)?.to_i128()?;
-                self.write_primval(dest, PrimVal::from_f32(f.powi(i as i32)), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_f32(f.powi(i as i32)),
+                    dest_ty,
+                )?;
             }
 
             "powif64" => {
                 let f = self.value_to_primval(arg_vals[0], f64)?.to_f64()?;
                 let i = self.value_to_primval(arg_vals[1], i32)?.to_i128()?;
-                self.write_primval(dest, PrimVal::from_f64(f.powi(i as i32)), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_f64(f.powi(i as i32)),
+                    dest_ty,
+                )?;
             }
 
             "size_of" => {
                 let ty = substs.type_at(0);
-                let size = self.type_size(ty)?.expect("size_of intrinsic called on unsized value") as u128;
+                let size = self.type_size(ty)?.expect(
+                    "size_of intrinsic called on unsized value",
+                ) as u128;
                 self.write_primval(dest, PrimVal::from_u128(size), dest_ty)?;
             }
 
             "size_of_val" => {
                 let ty = substs.type_at(0);
                 let (size, _) = self.size_and_align_of_dst(ty, arg_vals[0])?;
-                self.write_primval(dest, PrimVal::from_u128(size as u128), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_u128(size as u128),
+                    dest_ty,
+                )?;
             }
 
             "min_align_of_val" |
             "align_of_val" => {
                 let ty = substs.type_at(0);
                 let (_, align) = self.size_and_align_of_dst(ty, arg_vals[0])?;
-                self.write_primval(dest, PrimVal::from_u128(align as u128), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_u128(align as u128),
+                    dest_ty,
+                )?;
             }
 
             "type_name" => {
@@ -414,61 +520,104 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             "transmute" => {
                 let src_ty = substs.type_at(0);
                 let ptr = self.force_allocation(dest)?.to_ptr()?;
-                self.write_maybe_aligned_mut(/*aligned*/false, |ectx| {
-                    ectx.write_value_to_ptr(arg_vals[0], ptr.into(), src_ty)
-                })?;
+                self.write_maybe_aligned_mut(
+                    /*aligned*/
+                    false,
+                    |ectx| {
+                        ectx.write_value_to_ptr(arg_vals[0], ptr.into(), src_ty)
+                    },
+                )?;
             }
 
             "unchecked_shl" => {
-                let bits = self.type_size(dest_ty)?.expect("intrinsic can't be called on unsized type") as u128 * 8;
-                let rhs = self.value_to_primval(arg_vals[1], substs.type_at(0))?.to_bytes()?;
+                let bits = self.type_size(dest_ty)?.expect(
+                    "intrinsic can't be called on unsized type",
+                ) as u128 * 8;
+                let rhs = self.value_to_primval(arg_vals[1], substs.type_at(0))?
+                    .to_bytes()?;
                 if rhs >= bits {
-                    return err!(Intrinsic(format!("Overflowing shift by {} in unchecked_shl", rhs)));
+                    return err!(Intrinsic(
+                        format!("Overflowing shift by {} in unchecked_shl", rhs),
+                    ));
                 }
-                self.intrinsic_overflowing(mir::BinOp::Shl, &args[0], &args[1], dest, dest_ty)?;
+                self.intrinsic_overflowing(
+                    mir::BinOp::Shl,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?;
             }
 
             "unchecked_shr" => {
-                let bits = self.type_size(dest_ty)?.expect("intrinsic can't be called on unsized type") as u128 * 8;
-                let rhs = self.value_to_primval(arg_vals[1], substs.type_at(0))?.to_bytes()?;
+                let bits = self.type_size(dest_ty)?.expect(
+                    "intrinsic can't be called on unsized type",
+                ) as u128 * 8;
+                let rhs = self.value_to_primval(arg_vals[1], substs.type_at(0))?
+                    .to_bytes()?;
                 if rhs >= bits {
-                    return err!(Intrinsic(format!("Overflowing shift by {} in unchecked_shr", rhs)));
+                    return err!(Intrinsic(
+                        format!("Overflowing shift by {} in unchecked_shr", rhs),
+                    ));
                 }
-                self.intrinsic_overflowing(mir::BinOp::Shr, &args[0], &args[1], dest, dest_ty)?;
+                self.intrinsic_overflowing(
+                    mir::BinOp::Shr,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?;
             }
 
             "unchecked_div" => {
-                let rhs = self.value_to_primval(arg_vals[1], substs.type_at(0))?.to_bytes()?;
+                let rhs = self.value_to_primval(arg_vals[1], substs.type_at(0))?
+                    .to_bytes()?;
                 if rhs == 0 {
                     return err!(Intrinsic(format!("Division by 0 in unchecked_div")));
                 }
-                self.intrinsic_overflowing(mir::BinOp::Div, &args[0], &args[1], dest, dest_ty)?;
+                self.intrinsic_overflowing(
+                    mir::BinOp::Div,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?;
             }
 
             "unchecked_rem" => {
-                let rhs = self.value_to_primval(arg_vals[1], substs.type_at(0))?.to_bytes()?;
+                let rhs = self.value_to_primval(arg_vals[1], substs.type_at(0))?
+                    .to_bytes()?;
                 if rhs == 0 {
                     return err!(Intrinsic(format!("Division by 0 in unchecked_rem")));
                 }
-                self.intrinsic_overflowing(mir::BinOp::Rem, &args[0], &args[1], dest, dest_ty)?;
+                self.intrinsic_overflowing(
+                    mir::BinOp::Rem,
+                    &args[0],
+                    &args[1],
+                    dest,
+                    dest_ty,
+                )?;
             }
 
             "uninit" => {
                 let size = dest_layout.size(&self.tcx.data_layout).bytes();
-                let uninit = |this: &mut Self, val: Value| {
-                    match val {
-                        Value::ByRef { ptr, aligned } => {
-                            this.memory.mark_definedness(ptr, size, false)?;
-                            Ok(Value::ByRef { ptr, aligned })
-                        },
-                        _ => Ok(Value::ByVal(PrimVal::Undef)),
+                let uninit = |this: &mut Self, val: Value| match val {
+                    Value::ByRef { ptr, aligned } => {
+                        this.memory.mark_definedness(ptr, size, false)?;
+                        Ok(Value::ByRef { ptr, aligned })
                     }
+                    _ => Ok(Value::ByVal(PrimVal::Undef)),
                 };
                 match dest {
                     Lvalue::Local { frame, local } => self.modify_local(frame, local, uninit)?,
-                    Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true } =>
-                        self.memory.mark_definedness(ptr, size, false)?,
-                    Lvalue::Ptr { .. } => bug!("uninit intrinsic tried to write to fat or unaligned ptr target"),
+                    Lvalue::Ptr {
+                        ptr,
+                        extra: LvalueExtra::None,
+                        aligned: true,
+                    } => self.memory.mark_definedness(ptr, size, false)?,
+                    Lvalue::Ptr { .. } => {
+                        bug!("uninit intrinsic tried to write to fat or unaligned ptr target")
+                    }
                     Lvalue::Global(cid) => self.modify_global(cid, uninit)?,
                 }
             }
@@ -478,7 +627,9 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let ty = substs.type_at(0);
                 let ty_align = self.type_align(ty)?;
                 let val_byte = self.value_to_primval(arg_vals[1], u8)?.to_u128()? as u8;
-                let size = self.type_size(ty)?.expect("write_bytes() type must be sized");
+                let size = self.type_size(ty)?.expect(
+                    "write_bytes() type must be sized",
+                );
                 let ptr = arg_vals[0].into_ptr(&self.memory)?;
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                 if count > 0 {
@@ -504,7 +655,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
 fn numeric_intrinsic<'tcx>(
     name: &str,
     bytes: u128,
-    kind: PrimValKind
+    kind: PrimValKind,
 ) -> EvalResult<'tcx, PrimVal> {
     macro_rules! integer_intrinsic {
         ($method:ident) => ({
@@ -529,10 +680,10 @@ fn numeric_intrinsic<'tcx>(
 
     let result_val = match name {
         "bswap" => integer_intrinsic!(swap_bytes),
-        "ctlz"  => integer_intrinsic!(leading_zeros),
+        "ctlz" => integer_intrinsic!(leading_zeros),
         "ctpop" => integer_intrinsic!(count_ones),
-        "cttz"  => integer_intrinsic!(trailing_zeros),
-        _       => bug!("not a numeric intrinsic: {}", name),
+        "cttz" => integer_intrinsic!(trailing_zeros),
+        _ => bug!("not a numeric intrinsic: {}", name),
     };
 
     Ok(result_val)

--- a/miri/intrinsic.rs
+++ b/miri/intrinsic.rs
@@ -206,7 +206,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let elem_size = self.type_size(elem_ty)?.expect("cannot copy unsized value");
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                 if count * elem_size != 0 {
-                    // FIXME: We do not even validate alignment for the 0-bytes case.  libstd relies on this in vec::IntoIter::next.
+                    // FIXME: We do not even validate alignment for the 0-bytes case.
+                    // libstd relies on this in vec::IntoIter::next.
                     // Also see the write_bytes intrinsic.
                     let elem_align = self.type_align(elem_ty)?;
                     let src = arg_vals[0].into_ptr(&self.memory)?;
@@ -634,7 +635,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                 if count > 0 {
                     // HashMap relies on write_bytes on a NULL ptr with count == 0 to work
-                    // FIXME: Should we, at least, validate the alignment? (Also see the copy intrinsic)
+                    // FIXME: Should we, at least, validate the alignment?
+                    // (Also see the copy intrinsic)
                     self.memory.check_align(ptr, ty_align)?;
                     self.memory.write_repeat(ptr, val_byte, size * count)?;
                 }

--- a/miri/intrinsic.rs
+++ b/miri/intrinsic.rs
@@ -160,7 +160,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let elem_size = self.type_size(elem_ty)?.expect("cannot copy unsized value");
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                 if count * elem_size != 0 {
-                    // TODO: We do not even validate alignment for the 0-bytes case.  libstd relies on this in vec::IntoIter::next.
+                    // FIXME: We do not even validate alignment for the 0-bytes case.  libstd relies on this in vec::IntoIter::next.
                     // Also see the write_bytes intrinsic.
                     let elem_align = self.type_align(elem_ty)?;
                     let src = arg_vals[0].into_ptr(&self.memory)?;
@@ -271,7 +271,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                             this.memory.write_repeat(ptr, 0, size)?;
                             Value::ByRef { ptr, aligned }
                         },
-                        // TODO(solson): Revisit this, it's fishy to check for Undef here.
+                        // FIXME(solson): Revisit this, it's fishy to check for Undef here.
                         Value::ByVal(PrimVal::Undef) => match this.ty_to_primval_kind(dest_ty) {
                             Ok(_) => Value::ByVal(PrimVal::Bytes(0)),
                             Err(_) => {
@@ -483,7 +483,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let count = self.value_to_primval(arg_vals[2], usize)?.to_u64()?;
                 if count > 0 {
                     // HashMap relies on write_bytes on a NULL ptr with count == 0 to work
-                    // TODO: Should we, at least, validate the alignment? (Also see the copy intrinsic)
+                    // FIXME: Should we, at least, validate the alignment? (Also see the copy intrinsic)
                     self.memory.check_align(ptr, ty_align)?;
                     self.memory.write_repeat(ptr, val_byte, size * count)?;
                 }

--- a/miri/lib.rs
+++ b/miri/lib.rs
@@ -20,10 +20,7 @@ use rustc::mir;
 
 use syntax::codemap::Span;
 
-use std::collections::{
-    HashMap,
-    BTreeMap,
-};
+use std::collections::{HashMap, BTreeMap};
 
 #[macro_use]
 extern crate rustc_miri;
@@ -57,7 +54,10 @@ pub fn eval_main<'a, 'tcx: 'a>(
         let mut cleanup_ptr = None; // Pointer to be deallocated when we are done
 
         if !main_mir.return_ty.is_nil() || main_mir.arg_count != 0 {
-            return err!(Unimplemented("miri does not support main functions without `fn()` type signatures".to_owned()));
+            return err!(Unimplemented(
+                "miri does not support main functions without `fn()` type signatures"
+                    .to_owned(),
+            ));
         }
 
         if let Some(start_id) = start_wrapper {
@@ -65,7 +65,10 @@ pub fn eval_main<'a, 'tcx: 'a>(
             let start_mir = ecx.load_mir(start_instance.def)?;
 
             if start_mir.arg_count != 3 {
-                return err!(AbiViolation(format!("'start' lang item should have three arguments, but has {}", start_mir.arg_count)));
+                return err!(AbiViolation(format!(
+                    "'start' lang item should have three arguments, but has {}",
+                    start_mir.arg_count
+                )));
             }
 
             // Return value
@@ -90,7 +93,11 @@ pub fn eval_main<'a, 'tcx: 'a>(
             let dest = ecx.eval_lvalue(&mir::Lvalue::Local(args.next().unwrap()))?;
             let main_ty = main_instance.def.def_ty(ecx.tcx);
             let main_ptr_ty = ecx.tcx.mk_fn_ptr(main_ty.fn_sig(ecx.tcx));
-            ecx.write_value(Value::ByVal(PrimVal::Ptr(main_ptr)), dest, main_ptr_ty)?;
+            ecx.write_value(
+                Value::ByVal(PrimVal::Ptr(main_ptr)),
+                dest,
+                main_ptr_ty,
+            )?;
 
             // Second argument (argc): 0
             let dest = ecx.eval_lvalue(&mir::Lvalue::Local(args.next().unwrap()))?;

--- a/miri/lib.rs
+++ b/miri/lib.rs
@@ -152,7 +152,9 @@ pub type TlsKey = usize;
 
 #[derive(Copy, Clone, Debug)]
 pub struct TlsEntry<'tcx> {
-    data: Pointer, // Will eventually become a map from thread IDs to `Pointer`s, if we ever support more than one thread.
+    // Will eventually become a map from thread IDs to `Pointer`s,
+    // if we ever support more than one thread.
+    data: Pointer,
     dtor: Option<ty::Instance<'tcx>>,
 }
 

--- a/miri/operator.rs
+++ b/miri/operator.rs
@@ -145,7 +145,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
 
         Ok(match bin_op {
             Sub =>
-                // The only way this can overflow is by underflowing, so signdeness of the right operands does not matter
+                // The only way this can overflow is by underflowing,
+                // so signdeness of the right operands does not matter
                 map_to_primval(left.overflowing_signed_offset(-right, self)),
             Add if signed =>
                 map_to_primval(left.overflowing_signed_offset(right, self)),
@@ -167,7 +168,12 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             }
 
             _ => {
-                let msg = format!("unimplemented binary op on pointer {:?}: {:?}, {:?} ({})", bin_op, left, right, if signed { "signed" } else { "unsigned" });
+                let msg = format!(
+                    "unimplemented binary op on pointer {:?}: {:?}, {:?} ({})",
+                    bin_op,
+                    left, right,
+                    if signed { "signed" } else { "unsigned" },
+                );
                 return err!(Unimplemented(msg));
             }
         })

--- a/miri/tls.rs
+++ b/miri/tls.rs
@@ -105,7 +105,7 @@ impl<'a, 'tcx: 'a> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, Evaluator> {
         // FIXME: replace loop by some structure that works with stepping
         while let Some((instance, ptr, key)) = dtor {
             trace!("Running TLS dtor {:?} on {:?}", instance, ptr);
-            // TODO: Potentially, this has to support all the other possible instances?
+            // FIXME: Potentially, this has to support all the other possible instances?
             // See eval_fn_call in interpret/terminator/mod.rs
             let mir = self.load_mir(instance.def)?;
             self.push_stack_frame(

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -78,7 +78,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             TyChar if v as u8 as u128 == v => Ok(PrimVal::Bytes(v)),
             TyChar => err!(InvalidChar(v)),
 
-            // No alignment check needed for raw pointers.  But we have to truncate to target ptr size.
+            // No alignment check needed for raw pointers.
+            // But we have to truncate to target ptr size.
             TyRawPtr(_) => Ok(PrimVal::Bytes(self.memory.truncate_to_ptr(v).0 as u128)),
 
             _ => err!(Unimplemented(format!("int to {:?} cast", ty))),
@@ -103,7 +104,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     fn cast_from_ptr(&self, ptr: MemoryPointer, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
         use rustc::ty::TypeVariants::*;
         match ty.sty {
-            // Casting to a reference or fn pointer is not permitted by rustc, no need to support it here.
+            // Casting to a reference or fn pointer is not permitted by rustc,
+            // no need to support it here.
             TyRawPtr(_) |
             TyInt(IntTy::Is) |
             TyUint(UintTy::Us) => Ok(PrimVal::Ptr(ptr)),

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -5,12 +5,8 @@ use rustc::mir;
 use syntax::ast::Mutability;
 use syntax::codemap::Span;
 
-use super::{
-    EvalResult, EvalError, EvalErrorKind,
-    Global, GlobalId, Lvalue,
-    PrimVal,
-    EvalContext, StackPopCleanup,
-};
+use super::{EvalResult, EvalError, EvalErrorKind, Global, GlobalId, Lvalue, PrimVal, EvalContext,
+            StackPopCleanup};
 
 use rustc_const_math::ConstInt;
 
@@ -23,18 +19,25 @@ pub fn eval_body_as_primval<'a, 'tcx>(
 ) -> EvalResult<'tcx, (PrimVal, Ty<'tcx>)> {
     let limits = super::ResourceLimits::default();
     let mut ecx = EvalContext::<CompileTimeFunctionEvaluator>::new(tcx, limits, (), ());
-    let cid = GlobalId { instance, promoted: None };
+    let cid = GlobalId {
+        instance,
+        promoted: None,
+    };
     if ecx.tcx.has_attr(instance.def_id(), "linkage") {
         return Err(ConstEvalError::NotConst("extern global".to_string()).into());
     }
-    
+
     let mir = ecx.load_mir(instance.def)?;
     if !ecx.globals.contains_key(&cid) {
-        ecx.globals.insert(cid, Global::uninitialized(mir.return_ty));
+        ecx.globals.insert(
+            cid,
+            Global::uninitialized(mir.return_ty),
+        );
         let mutable = !mir.return_ty.is_freeze(
-                ecx.tcx,
-                ty::ParamEnv::empty(Reveal::All),
-                mir.span);
+            ecx.tcx,
+            ty::ParamEnv::empty(Reveal::All),
+            mir.span,
+        );
         let mutability = if mutable {
             Mutability::Mutable
         } else {
@@ -72,14 +75,26 @@ pub fn eval_body_as_integer<'a, 'tcx>(
         TyInt(IntTy::I32) => ConstInt::I32(prim as i128 as i32),
         TyInt(IntTy::I64) => ConstInt::I64(prim as i128 as i64),
         TyInt(IntTy::I128) => ConstInt::I128(prim as i128),
-        TyInt(IntTy::Is) => ConstInt::Isize(ConstIsize::new(prim as i128 as i64, tcx.sess.target.int_type).expect("miri should already have errored")),
+        TyInt(IntTy::Is) => ConstInt::Isize(
+            ConstIsize::new(prim as i128 as i64, tcx.sess.target.int_type)
+                .expect("miri should already have errored"),
+        ),
         TyUint(UintTy::U8) => ConstInt::U8(prim as u8),
         TyUint(UintTy::U16) => ConstInt::U16(prim as u16),
         TyUint(UintTy::U32) => ConstInt::U32(prim as u32),
         TyUint(UintTy::U64) => ConstInt::U64(prim as u64),
         TyUint(UintTy::U128) => ConstInt::U128(prim),
-        TyUint(UintTy::Us) => ConstInt::Usize(ConstUsize::new(prim as u64, tcx.sess.target.uint_type).expect("miri should already have errored")),
-        _ => return Err(ConstEvalError::NeedsRfc("evaluating anything other than isize/usize during typeck".to_string()).into()),
+        TyUint(UintTy::Us) => ConstInt::Usize(
+            ConstUsize::new(prim as u64, tcx.sess.target.uint_type)
+                .expect("miri should already have errored"),
+        ),
+        _ => {
+            return Err(
+                ConstEvalError::NeedsRfc(
+                    "evaluating anything other than isize/usize during typeck".to_string(),
+                ).into(),
+            )
+        }
     })
 }
 
@@ -101,10 +116,14 @@ impl fmt::Display for ConstEvalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::ConstEvalError::*;
         match *self {
-            NeedsRfc(ref msg) =>
-                write!(f, "\"{}\" needs an rfc before being allowed inside constants", msg),
-            NotConst(ref msg) =>
-                write!(f, "Cannot evaluate within constants: \"{}\"", msg),
+            NeedsRfc(ref msg) => {
+                write!(
+                    f,
+                    "\"{}\" needs an rfc before being allowed inside constants",
+                    msg
+                )
+            }
+            NotConst(ref msg) => write!(f, "Cannot evaluate within constants: \"{}\"", msg),
         }
     }
 }
@@ -113,10 +132,8 @@ impl Error for ConstEvalError {
     fn description(&self) -> &str {
         use self::ConstEvalError::*;
         match *self {
-            NeedsRfc(_) =>
-                "this feature needs an rfc before being allowed inside constants",
-            NotConst(_) =>
-                "this feature is not compatible with constant evaluation",
+            NeedsRfc(_) => "this feature needs an rfc before being allowed inside constants",
+            NotConst(_) => "this feature is not compatible with constant evaluation",
         }
     }
 
@@ -138,14 +155,19 @@ impl<'tcx> super::Machine<'tcx> for CompileTimeFunctionEvaluator {
         _sig: ty::FnSig<'tcx>,
     ) -> EvalResult<'tcx, bool> {
         if !ecx.tcx.is_const_fn(instance.def_id()) {
-            return Err(ConstEvalError::NotConst(format!("calling non-const fn `{}`", instance)).into());
+            return Err(
+                ConstEvalError::NotConst(format!("calling non-const fn `{}`", instance)).into(),
+            );
         }
         let mir = match ecx.load_mir(instance.def) {
             Ok(mir) => mir,
-            Err(EvalError{ kind: EvalErrorKind::NoMirFor(path), ..} ) => {
+            Err(EvalError { kind: EvalErrorKind::NoMirFor(path), .. }) => {
                 // some simple things like `malloc` might get accepted in the future
-                return Err(ConstEvalError::NeedsRfc(format!("calling extern function `{}`", path)).into());
-            },
+                return Err(
+                    ConstEvalError::NeedsRfc(format!("calling extern function `{}`", path))
+                        .into(),
+                );
+            }
             Err(other) => return Err(other),
         };
         let (return_lvalue, return_to_block) = match destination {
@@ -173,7 +195,9 @@ impl<'tcx> super::Machine<'tcx> for CompileTimeFunctionEvaluator {
         _dest_layout: &'tcx layout::Layout,
         _target: mir::BasicBlock,
     ) -> EvalResult<'tcx> {
-        Err(ConstEvalError::NeedsRfc("calling intrinsics".to_string()).into())
+        Err(
+            ConstEvalError::NeedsRfc("calling intrinsics".to_string()).into(),
+        )
     }
 
     fn try_ptr_op<'a>(
@@ -187,7 +211,9 @@ impl<'tcx> super::Machine<'tcx> for CompileTimeFunctionEvaluator {
         if left.is_bytes() && right.is_bytes() {
             Ok(None)
         } else {
-            Err(ConstEvalError::NeedsRfc("Pointer arithmetic or comparison".to_string()).into())
+            Err(
+                ConstEvalError::NeedsRfc("Pointer arithmetic or comparison".to_string()).into(),
+            )
         }
     }
 
@@ -199,6 +225,8 @@ impl<'tcx> super::Machine<'tcx> for CompileTimeFunctionEvaluator {
         _ecx: &mut EvalContext<'a, 'tcx, Self>,
         _ty: ty::Ty<'tcx>,
     ) -> EvalResult<'tcx, PrimVal> {
-        Err(ConstEvalError::NeedsRfc("Heap allocations via `box` keyword".to_string()).into())
+        Err(
+            ConstEvalError::NeedsRfc("Heap allocations via `box` keyword".to_string()).into(),
+        )
     }
 }

--- a/src/librustc_mir/interpret/error.rs
+++ b/src/librustc_mir/interpret/error.rs
@@ -142,7 +142,8 @@ impl<'tcx> Error for EvalError<'tcx> {
             }
             ReadBytesAsPointer => "a memory access tried to interpret some bytes as a pointer",
             InvalidPointerMath => {
-                "attempted to do invalid arithmetic on pointers that would leak base addresses, e.g. comparing pointers into different allocations"
+                "attempted to do invalid arithmetic on pointers that would leak base addresses, \
+                e.g. comparing pointers into different allocations"
             }
             ReadUndefBytes => "attempted to read undefined bytes",
             DeadLocal => "tried to access a dead local variable",
@@ -184,11 +185,13 @@ impl<'tcx> Error for EvalError<'tcx> {
             }
             Layout(_) => "rustc layout computation failed",
             UnterminatedCString(_) => {
-                "attempted to get length of a null terminated string, but no null found before end of allocation"
+                "attempted to get length of a null terminated string, \
+                but no null found before end of allocation"
             }
             HeapAllocZeroBytes => "tried to re-, de- or allocate zero bytes on the heap",
             HeapAllocNonPowerOfTwoAlignment(_) => {
-                "tried to re-, de-, or allocate heap memory with alignment that is not a power of two"
+                "tried to re-, de-, or allocate heap memory with \
+                alignment that is not a power of two"
             }
             Unreachable => "entered unreachable code",
             Panic => "the evaluated program panicked",
@@ -270,7 +273,8 @@ impl<'tcx> fmt::Display for EvalError<'tcx> {
             } => {
                 write!(
                     f,
-                    "frame {} tried to release memory write lock at {:?}, size {}, but cannot release lock {:?}",
+                    "frame {} tried to release memory write lock at {:?}, \
+                    size {}, but cannot release lock {:?}",
                     frame,
                     ptr,
                     len,
@@ -331,7 +335,8 @@ impl<'tcx> fmt::Display for EvalError<'tcx> {
             } => {
                 write!(
                     f,
-                    "tried to allocate {} more bytes, but only {} bytes are free of the {} byte memory",
+                    "tried to allocate {} more bytes, but only {} \
+                    bytes are free of the {} byte memory",
                     allocation_size,
                     memory_size - memory_usage,
                     memory_size

--- a/src/librustc_mir/interpret/error.rs
+++ b/src/librustc_mir/interpret/error.rs
@@ -61,7 +61,7 @@ pub enum EvalErrorKind<'tcx> {
     DerefFunctionPointer,
     ExecuteMemory,
     ArrayIndexOutOfBounds(Span, u64, u64),
-    Math(Span, ConstMathErr),
+    Math(Option<Span>, ConstMathErr),
     Intrinsic(String),
     OverflowingMath,
     InvalidChar(u128),
@@ -287,7 +287,7 @@ impl<'tcx> fmt::Display for EvalError<'tcx> {
                 write!(f, "tried to reallocate memory from {} to {}", old, new),
             DeallocatedWrongMemoryKind(ref old, ref new) =>
                 write!(f, "tried to deallocate {} memory but gave {} as the kind", old, new),
-            Math(span, ref err) =>
+            Math(Some(span), ref err) =>
                 write!(f, "{:?} at {:?}", err, span),
             Intrinsic(ref err) =>
                 write!(f, "{}", err),

--- a/src/librustc_mir/interpret/error.rs
+++ b/src/librustc_mir/interpret/error.rs
@@ -4,9 +4,7 @@ use std::{fmt, env};
 use rustc::mir;
 use rustc::ty::{FnSig, Ty, layout};
 
-use super::{
-    MemoryPointer, LockInfo, AccessKind
-};
+use super::{MemoryPointer, LockInfo, AccessKind};
 
 use rustc_const_math::ConstMathErr;
 use syntax::codemap::Span;
@@ -22,12 +20,9 @@ impl<'tcx> From<EvalErrorKind<'tcx>> for EvalError<'tcx> {
     fn from(kind: EvalErrorKind<'tcx>) -> Self {
         let backtrace = match env::var("RUST_BACKTRACE") {
             Ok(ref val) if !val.is_empty() => Some(Backtrace::new_unresolved()),
-            _ => None
+            _ => None,
         };
-        EvalError {
-            kind,
-            backtrace,
-        }
+        EvalError { kind, backtrace }
     }
 }
 
@@ -75,10 +70,7 @@ pub enum EvalErrorKind<'tcx> {
     OutOfTls,
     TlsOutOfBounds,
     AbiViolation(String),
-    AlignmentCheckFailed {
-        required: u64,
-        has: u64,
-    },
+    AlignmentCheckFailed { required: u64, has: u64 },
     MemoryLockViolation {
         ptr: MemoryPointer,
         len: u64,
@@ -98,10 +90,7 @@ pub enum EvalErrorKind<'tcx> {
         frame: usize,
         lock: LockInfo,
     },
-    DeallocatedLockedMemory {
-        ptr: MemoryPointer,
-        lock: LockInfo,
-    },
+    DeallocatedLockedMemory { ptr: MemoryPointer, lock: LockInfo },
     ValidationFailure(String),
     CalledClosureAsFunction,
     VtableForArgumentlessMethod,
@@ -130,114 +119,83 @@ impl<'tcx> Error for EvalError<'tcx> {
         use self::EvalErrorKind::*;
         match self.kind {
             MachineError(ref inner) => inner.description(),
-            FunctionPointerTyMismatch(..) =>
-                "tried to call a function through a function pointer of a different type",
-            InvalidMemoryAccess =>
-                "tried to access memory through an invalid pointer",
-            DanglingPointerDeref =>
-                "dangling pointer was dereferenced",
-            DoubleFree =>
-                "tried to deallocate dangling pointer",
-            InvalidFunctionPointer =>
-                "tried to use an integer pointer or a dangling pointer as a function pointer",
-            InvalidBool =>
-                "invalid boolean value read",
-            InvalidDiscriminant =>
-                "invalid enum discriminant value read",
-            PointerOutOfBounds { .. } =>
-                "pointer offset outside bounds of allocation",
-            InvalidNullPointerUsage =>
-                "invalid use of NULL pointer",
-            MemoryLockViolation { .. } =>
-                "memory access conflicts with lock",
-            MemoryAcquireConflict { .. } =>
-                "new memory lock conflicts with existing lock",
-            ValidationFailure(..) =>
-                "type validation failed",
-            InvalidMemoryLockRelease { .. } =>
-                "invalid attempt to release write lock",
-            DeallocatedLockedMemory { .. } =>
-                "tried to deallocate memory in conflict with a lock",
-            ReadPointerAsBytes =>
-                "a raw memory access tried to access part of a pointer value as raw bytes",
-            ReadBytesAsPointer =>
-                "a memory access tried to interpret some bytes as a pointer",
-            InvalidPointerMath =>
-                "attempted to do invalid arithmetic on pointers that would leak base addresses, e.g. comparing pointers into different allocations",
-            ReadUndefBytes =>
-                "attempted to read undefined bytes",
-            DeadLocal =>
-                "tried to access a dead local variable",
-            InvalidBoolOp(_) =>
-                "invalid boolean operation",
+            FunctionPointerTyMismatch(..) => {
+                "tried to call a function through a function pointer of a different type"
+            }
+            InvalidMemoryAccess => "tried to access memory through an invalid pointer",
+            DanglingPointerDeref => "dangling pointer was dereferenced",
+            DoubleFree => "tried to deallocate dangling pointer",
+            InvalidFunctionPointer => {
+                "tried to use an integer pointer or a dangling pointer as a function pointer"
+            }
+            InvalidBool => "invalid boolean value read",
+            InvalidDiscriminant => "invalid enum discriminant value read",
+            PointerOutOfBounds { .. } => "pointer offset outside bounds of allocation",
+            InvalidNullPointerUsage => "invalid use of NULL pointer",
+            MemoryLockViolation { .. } => "memory access conflicts with lock",
+            MemoryAcquireConflict { .. } => "new memory lock conflicts with existing lock",
+            ValidationFailure(..) => "type validation failed",
+            InvalidMemoryLockRelease { .. } => "invalid attempt to release write lock",
+            DeallocatedLockedMemory { .. } => "tried to deallocate memory in conflict with a lock",
+            ReadPointerAsBytes => {
+                "a raw memory access tried to access part of a pointer value as raw bytes"
+            }
+            ReadBytesAsPointer => "a memory access tried to interpret some bytes as a pointer",
+            InvalidPointerMath => {
+                "attempted to do invalid arithmetic on pointers that would leak base addresses, e.g. comparing pointers into different allocations"
+            }
+            ReadUndefBytes => "attempted to read undefined bytes",
+            DeadLocal => "tried to access a dead local variable",
+            InvalidBoolOp(_) => "invalid boolean operation",
             Unimplemented(ref msg) => msg,
-            DerefFunctionPointer =>
-                "tried to dereference a function pointer",
-            ExecuteMemory =>
-                "tried to treat a memory pointer as a function pointer",
-            ArrayIndexOutOfBounds(..) =>
-                "array index out of bounds",
-            Math(..) =>
-                "mathematical operation failed",
-            Intrinsic(..) =>
-                "intrinsic failed",
-            OverflowingMath =>
-                "attempted to do overflowing math",
-            NoMirFor(..) =>
-                "mir not found",
-            InvalidChar(..) =>
-                "tried to interpret an invalid 32-bit value as a char",
-            OutOfMemory{..} =>
-                "could not allocate more memory",
-            ExecutionTimeLimitReached =>
-                "reached the configured maximum execution time",
-            StackFrameLimitReached =>
-                "reached the configured maximum number of stack frames",
-            OutOfTls =>
-                "reached the maximum number of representable TLS keys",
-            TlsOutOfBounds =>
-                "accessed an invalid (unallocated) TLS key",
+            DerefFunctionPointer => "tried to dereference a function pointer",
+            ExecuteMemory => "tried to treat a memory pointer as a function pointer",
+            ArrayIndexOutOfBounds(..) => "array index out of bounds",
+            Math(..) => "mathematical operation failed",
+            Intrinsic(..) => "intrinsic failed",
+            OverflowingMath => "attempted to do overflowing math",
+            NoMirFor(..) => "mir not found",
+            InvalidChar(..) => "tried to interpret an invalid 32-bit value as a char",
+            OutOfMemory { .. } => "could not allocate more memory",
+            ExecutionTimeLimitReached => "reached the configured maximum execution time",
+            StackFrameLimitReached => "reached the configured maximum number of stack frames",
+            OutOfTls => "reached the maximum number of representable TLS keys",
+            TlsOutOfBounds => "accessed an invalid (unallocated) TLS key",
             AbiViolation(ref msg) => msg,
-            AlignmentCheckFailed{..} =>
-                "tried to execute a misaligned read or write",
-            CalledClosureAsFunction =>
-                "tried to call a closure through a function pointer",
-            VtableForArgumentlessMethod =>
-                "tried to call a vtable function without arguments",
-            ModifiedConstantMemory =>
-                "tried to modify constant memory",
-            AssumptionNotHeld =>
-                "`assume` argument was false",
-            InlineAsm =>
-                "miri does not support inline assembly",
-            TypeNotPrimitive(_) =>
-                "expected primitive type, got nonprimitive",
-            ReallocatedWrongMemoryKind(_, _) =>
-                "tried to reallocate memory from one kind to another",
-            DeallocatedWrongMemoryKind(_, _) =>
-                "tried to deallocate memory of the wrong kind",
-            ReallocateNonBasePtr =>
-                "tried to reallocate with a pointer not to the beginning of an existing object",
-            DeallocateNonBasePtr =>
-                "tried to deallocate with a pointer not to the beginning of an existing object",
-            IncorrectAllocationInformation =>
-                "tried to deallocate or reallocate using incorrect alignment or size",
-            Layout(_) =>
-                "rustc layout computation failed",
-            UnterminatedCString(_) =>
-                "attempted to get length of a null terminated string, but no null found before end of allocation",
-            HeapAllocZeroBytes =>
-                "tried to re-, de- or allocate zero bytes on the heap",
-            HeapAllocNonPowerOfTwoAlignment(_) =>
-                "tried to re-, de-, or allocate heap memory with alignment that is not a power of two",
-            Unreachable =>
-                "entered unreachable code",
-            Panic =>
-                "the evaluated program panicked",
-            ReadFromReturnPointer =>
-                "tried to read from the return pointer",
-            EvalErrorKind::PathNotFound(_) =>
-                "a path could not be resolved, maybe the crate is not loaded",
+            AlignmentCheckFailed { .. } => "tried to execute a misaligned read or write",
+            CalledClosureAsFunction => "tried to call a closure through a function pointer",
+            VtableForArgumentlessMethod => "tried to call a vtable function without arguments",
+            ModifiedConstantMemory => "tried to modify constant memory",
+            AssumptionNotHeld => "`assume` argument was false",
+            InlineAsm => "miri does not support inline assembly",
+            TypeNotPrimitive(_) => "expected primitive type, got nonprimitive",
+            ReallocatedWrongMemoryKind(_, _) => {
+                "tried to reallocate memory from one kind to another"
+            }
+            DeallocatedWrongMemoryKind(_, _) => "tried to deallocate memory of the wrong kind",
+            ReallocateNonBasePtr => {
+                "tried to reallocate with a pointer not to the beginning of an existing object"
+            }
+            DeallocateNonBasePtr => {
+                "tried to deallocate with a pointer not to the beginning of an existing object"
+            }
+            IncorrectAllocationInformation => {
+                "tried to deallocate or reallocate using incorrect alignment or size"
+            }
+            Layout(_) => "rustc layout computation failed",
+            UnterminatedCString(_) => {
+                "attempted to get length of a null terminated string, but no null found before end of allocation"
+            }
+            HeapAllocZeroBytes => "tried to re-, de- or allocate zero bytes on the heap",
+            HeapAllocNonPowerOfTwoAlignment(_) => {
+                "tried to re-, de-, or allocate heap memory with alignment that is not a power of two"
+            }
+            Unreachable => "entered unreachable code",
+            Panic => "the evaluated program panicked",
+            ReadFromReturnPointer => "tried to read from the return pointer",
+            EvalErrorKind::PathNotFound(_) => {
+                "a path could not be resolved, maybe the crate is not loaded"
+            }
         }
     }
 
@@ -254,59 +212,143 @@ impl<'tcx> fmt::Display for EvalError<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::EvalErrorKind::*;
         match self.kind {
-            PointerOutOfBounds { ptr, access, allocation_size } => {
-                write!(f, "{} at offset {}, outside bounds of allocation {} which has size {}",
-                       if access { "memory access" } else { "pointer computed" },
-                       ptr.offset, ptr.alloc_id, allocation_size)
-            },
-            MemoryLockViolation { ptr, len, frame, access, ref lock } => {
-                write!(f, "{:?} access by frame {} at {:?}, size {}, is in conflict with lock {:?}",
-                       access, frame, ptr, len, lock)
+            PointerOutOfBounds {
+                ptr,
+                access,
+                allocation_size,
+            } => {
+                write!(
+                    f,
+                    "{} at offset {}, outside bounds of allocation {} which has size {}",
+                    if access {
+                        "memory access"
+                    } else {
+                        "pointer computed"
+                    },
+                    ptr.offset,
+                    ptr.alloc_id,
+                    allocation_size
+                )
             }
-            MemoryAcquireConflict { ptr, len, kind, ref lock } => {
-                write!(f, "new {:?} lock at {:?}, size {}, is in conflict with lock {:?}",
-                       kind, ptr, len, lock)
+            MemoryLockViolation {
+                ptr,
+                len,
+                frame,
+                access,
+                ref lock,
+            } => {
+                write!(
+                    f,
+                    "{:?} access by frame {} at {:?}, size {}, is in conflict with lock {:?}",
+                    access,
+                    frame,
+                    ptr,
+                    len,
+                    lock
+                )
             }
-            InvalidMemoryLockRelease { ptr, len, frame, ref lock } => {
-                write!(f, "frame {} tried to release memory write lock at {:?}, size {}, but cannot release lock {:?}",
-                       frame, ptr, len, lock)
+            MemoryAcquireConflict {
+                ptr,
+                len,
+                kind,
+                ref lock,
+            } => {
+                write!(
+                    f,
+                    "new {:?} lock at {:?}, size {}, is in conflict with lock {:?}",
+                    kind,
+                    ptr,
+                    len,
+                    lock
+                )
+            }
+            InvalidMemoryLockRelease {
+                ptr,
+                len,
+                frame,
+                ref lock,
+            } => {
+                write!(
+                    f,
+                    "frame {} tried to release memory write lock at {:?}, size {}, but cannot release lock {:?}",
+                    frame,
+                    ptr,
+                    len,
+                    lock
+                )
             }
             DeallocatedLockedMemory { ptr, ref lock } => {
-                write!(f, "tried to deallocate memory at {:?} in conflict with lock {:?}",
-                       ptr, lock)
+                write!(
+                    f,
+                    "tried to deallocate memory at {:?} in conflict with lock {:?}",
+                    ptr,
+                    lock
+                )
             }
-            ValidationFailure(ref err) => {
-                write!(f, "type validation failed: {}", err)
-            }
+            ValidationFailure(ref err) => write!(f, "type validation failed: {}", err),
             NoMirFor(ref func) => write!(f, "no mir for `{}`", func),
-            FunctionPointerTyMismatch(sig, got) =>
-                write!(f, "tried to call a function with sig {} through a function pointer of type {}", sig, got),
-            ArrayIndexOutOfBounds(span, len, index) =>
-                write!(f, "index out of bounds: the len is {} but the index is {} at {:?}", len, index, span),
-            ReallocatedWrongMemoryKind(ref old, ref new) =>
-                write!(f, "tried to reallocate memory from {} to {}", old, new),
-            DeallocatedWrongMemoryKind(ref old, ref new) =>
-                write!(f, "tried to deallocate {} memory but gave {} as the kind", old, new),
-            Math(Some(span), ref err) =>
-                write!(f, "{:?} at {:?}", err, span),
-            Intrinsic(ref err) =>
-                write!(f, "{}", err),
-            InvalidChar(c) =>
-                write!(f, "tried to interpret an invalid 32-bit value as a char: {}", c),
-            OutOfMemory { allocation_size, memory_size, memory_usage } =>
-                write!(f, "tried to allocate {} more bytes, but only {} bytes are free of the {} byte memory",
-                       allocation_size, memory_size - memory_usage, memory_size),
-            AlignmentCheckFailed { required, has } =>
-               write!(f, "tried to access memory with alignment {}, but alignment {} is required",
-                      has, required),
-            TypeNotPrimitive(ty) =>
-                write!(f, "expected primitive type, got {}", ty),
-            Layout(ref err) =>
-                write!(f, "rustc layout computation failed: {:?}", err),
-            PathNotFound(ref path) =>
-                write!(f, "Cannot find path {:?}", path),
-            MachineError(ref inner) =>
-                write!(f, "machine error: {}", inner),
+            FunctionPointerTyMismatch(sig, got) => {
+                write!(
+                    f,
+                    "tried to call a function with sig {} through a function pointer of type {}",
+                    sig,
+                    got
+                )
+            }
+            ArrayIndexOutOfBounds(span, len, index) => {
+                write!(
+                    f,
+                    "index out of bounds: the len is {} but the index is {} at {:?}",
+                    len,
+                    index,
+                    span
+                )
+            }
+            ReallocatedWrongMemoryKind(ref old, ref new) => {
+                write!(f, "tried to reallocate memory from {} to {}", old, new)
+            }
+            DeallocatedWrongMemoryKind(ref old, ref new) => {
+                write!(
+                    f,
+                    "tried to deallocate {} memory but gave {} as the kind",
+                    old,
+                    new
+                )
+            }
+            Math(Some(span), ref err) => write!(f, "{:?} at {:?}", err, span),
+            Intrinsic(ref err) => write!(f, "{}", err),
+            InvalidChar(c) => {
+                write!(
+                    f,
+                    "tried to interpret an invalid 32-bit value as a char: {}",
+                    c
+                )
+            }
+            OutOfMemory {
+                allocation_size,
+                memory_size,
+                memory_usage,
+            } => {
+                write!(
+                    f,
+                    "tried to allocate {} more bytes, but only {} bytes are free of the {} byte memory",
+                    allocation_size,
+                    memory_size - memory_usage,
+                    memory_size
+                )
+            }
+            AlignmentCheckFailed { required, has } => {
+                write!(
+                    f,
+                    "tried to access memory with alignment {}, but alignment {} is required",
+                    has,
+                    required
+                )
+            }
+            TypeNotPrimitive(ty) => write!(f, "expected primitive type, got {}", ty),
+            Layout(ref err) => write!(f, "rustc layout computation failed: {:?}", err),
+            PathNotFound(ref path) => write!(f, "Cannot find path {:?}", path),
+            MachineError(ref inner) => write!(f, "machine error: {}", inner),
             _ => write!(f, "{}", self.description()),
         }
     }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -216,13 +216,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
     pub(super) fn const_to_value(&mut self, const_val: &ConstVal<'tcx>) -> EvalResult<'tcx, Value> {
         use rustc::middle::const_val::ConstVal::*;
-        use rustc_const_math::ConstFloat;
 
         let primval = match *const_val {
             Integral(const_int) => PrimVal::Bytes(const_int.to_u128_unchecked()),
 
-            Float(ConstFloat::F32(f)) => PrimVal::from_f32(f),
-            Float(ConstFloat::F64(f)) => PrimVal::from_f64(f),
+            Float(val) => PrimVal::Bytes(val.bits),
 
             Bool(b) => PrimVal::from_bool(b),
             Char(c) => PrimVal::from_char(c),

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -16,16 +16,9 @@ use syntax::codemap::{self, DUMMY_SP, Span};
 use syntax::ast::{self, Mutability};
 use syntax::abi::Abi;
 
-use super::{
-    EvalError, EvalResult, EvalErrorKind,
-    Global, GlobalId, Lvalue, LvalueExtra,
-    Memory, MemoryPointer, HasMemory,
-    Kind as MemoryKind,
-    operator,
-    PrimVal, PrimValKind, Value, Pointer,
-    ValidationQuery,
-    Machine,
-};
+use super::{EvalError, EvalResult, EvalErrorKind, Global, GlobalId, Lvalue, LvalueExtra, Memory,
+            MemoryPointer, HasMemory, Kind as MemoryKind, operator, PrimVal, PrimValKind, Value,
+            Pointer, ValidationQuery, Machine};
 
 pub struct EvalContext<'a, 'tcx: 'a, M: Machine<'tcx>> {
     /// Stores data required by the `Machine`
@@ -60,7 +53,6 @@ pub struct Frame<'tcx> {
     ////////////////////////////////////////////////////////////////////////////////
     // Function and callsite information
     ////////////////////////////////////////////////////////////////////////////////
-
     /// The MIR for the function called on this frame.
     pub mir: &'tcx mir::Mir<'tcx>,
 
@@ -73,7 +65,6 @@ pub struct Frame<'tcx> {
     ////////////////////////////////////////////////////////////////////////////////
     // Return lvalue and locals
     ////////////////////////////////////////////////////////////////////////////////
-
     /// The block to return to when returning from the current stack frame
     pub return_to_block: StackPopCleanup,
 
@@ -91,7 +82,6 @@ pub struct Frame<'tcx> {
     ////////////////////////////////////////////////////////////////////////////////
     // Current position within the function
     ////////////////////////////////////////////////////////////////////////////////
-
     /// The block that is currently executed (or will be executed after the above call stacks
     /// return).
     pub block: mir::BasicBlock,
@@ -170,9 +160,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     pub fn alloc_ptr_with_substs(
         &mut self,
         ty: Ty<'tcx>,
-        substs: &'tcx Substs<'tcx>
+        substs: &'tcx Substs<'tcx>,
     ) -> EvalResult<'tcx, MemoryPointer> {
-        let size = self.type_size_with_substs(ty, substs)?.expect("cannot alloc memory for unsized type");
+        let size = self.type_size_with_substs(ty, substs)?.expect(
+            "cannot alloc memory for unsized type",
+        );
         let align = self.type_align_with_substs(ty, substs)?;
         self.memory.allocate(size, align, MemoryKind::Stack)
     }
@@ -211,7 +203,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
     pub fn str_to_value(&mut self, s: &str) -> EvalResult<'tcx, Value> {
         let ptr = self.memory.allocate_cached(s.as_bytes())?;
-        Ok(Value::ByValPair(PrimVal::Ptr(ptr), PrimVal::from_u128(s.len() as u128)))
+        Ok(Value::ByValPair(
+            PrimVal::Ptr(ptr),
+            PrimVal::from_u128(s.len() as u128),
+        ))
     }
 
     pub(super) fn const_to_value(&mut self, const_val: &ConstVal<'tcx>) -> EvalResult<'tcx, Value> {
@@ -232,12 +227,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 PrimVal::Ptr(ptr)
             }
 
-            Variant(_)   => unimplemented!(),
-            Struct(_)    => unimplemented!(),
-            Tuple(_)     => unimplemented!(),
+            Variant(_) => unimplemented!(),
+            Struct(_) => unimplemented!(),
+            Tuple(_) => unimplemented!(),
             // function items are zero sized and thus have no readable value
-            Function(..)  => PrimVal::Undef,
-            Array(_)     => unimplemented!(),
+            Function(..) => PrimVal::Undef,
+            Array(_) => unimplemented!(),
             Repeat(_, _) => unimplemented!(),
         };
 
@@ -250,10 +245,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         ty.is_sized(self.tcx, ty::ParamEnv::empty(Reveal::All), DUMMY_SP)
     }
 
-    pub fn load_mir(&self, instance: ty::InstanceDef<'tcx>) -> EvalResult<'tcx, &'tcx mir::Mir<'tcx>> {
+    pub fn load_mir(
+        &self,
+        instance: ty::InstanceDef<'tcx>,
+    ) -> EvalResult<'tcx, &'tcx mir::Mir<'tcx>> {
         trace!("load mir {:?}", instance);
         match instance {
-            ty::InstanceDef::Item(def_id) => self.tcx.maybe_optimized_mir(def_id).ok_or_else(|| EvalErrorKind::NoMirFor(self.tcx.item_path_str(def_id)).into()),
+            ty::InstanceDef::Item(def_id) => {
+                self.tcx.maybe_optimized_mir(def_id).ok_or_else(|| {
+                    EvalErrorKind::NoMirFor(self.tcx.item_path_str(def_id)).into()
+                })
+            }
             _ => Ok(self.tcx.instance_mir(instance)),
         }
     }
@@ -267,7 +269,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     pub fn erase_lifetimes<T>(&self, value: &Binder<T>) -> T
-        where T : TypeFoldable<'tcx>
+    where
+        T: TypeFoldable<'tcx>,
     {
         let value = self.tcx.erase_late_bound_regions(value);
         self.tcx.erase_regions(&value)
@@ -296,15 +299,25 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
                     let (sized_size, sized_align) = match *layout {
                         ty::layout::Layout::Univariant { ref variant, .. } => {
-                            (variant.offsets.last().map_or(0, |o| o.bytes()), variant.align)
+                            (
+                                variant.offsets.last().map_or(0, |o| o.bytes()),
+                                variant.align,
+                            )
                         }
                         _ => {
-                            bug!("size_and_align_of_dst: expcted Univariant for `{}`, found {:#?}",
-                                 ty, layout);
+                            bug!(
+                                "size_and_align_of_dst: expcted Univariant for `{}`, found {:#?}",
+                                ty,
+                                layout
+                            );
                         }
                     };
-                    debug!("DST {} statically sized prefix size: {} align: {:?}",
-                           ty, sized_size, sized_align);
+                    debug!(
+                        "DST {} statically sized prefix size: {} align: {:?}",
+                        ty,
+                        sized_size,
+                        sized_align
+                    );
 
                     // Recurse to get the size of the dynamically sized field (must be
                     // the last field).
@@ -334,7 +347,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
                     // Choose max of two known alignments (combined value must
                     // be aligned according to more restrictive of the two).
-                    let align = sized_align.max(Align::from_bytes(unsized_align, unsized_align).unwrap());
+                    let align =
+                        sized_align.max(Align::from_bytes(unsized_align, unsized_align).unwrap());
 
                     // Issue #27023: must add any necessary padding to `size`
                     // (to make it a multiple of `align`) before returning it.
@@ -358,7 +372,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
                 ty::TySlice(_) | ty::TyStr => {
                     let elem_ty = ty.sequence_element_type(self.tcx);
-                    let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized") as u64;
+                    let elem_size = self.type_size(elem_ty)?.expect(
+                        "slice element must be sized",
+                    ) as u64;
                     let (_, len) = value.into_slice(&mut self.memory)?;
                     let align = self.type_align(elem_ty)?;
                     Ok((len * elem_size, align as u64))
@@ -370,12 +386,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     /// Returns the normalized type of a struct field
-    fn field_ty(
-        &self,
-        param_substs: &Substs<'tcx>,
-        f: &ty::FieldDef,
-    ) -> ty::Ty<'tcx> {
-        self.tcx.normalize_associated_type(&f.ty(self.tcx, param_substs))
+    fn field_ty(&self, param_substs: &Substs<'tcx>, f: &ty::FieldDef) -> ty::Ty<'tcx> {
+        self.tcx.normalize_associated_type(
+            &f.ty(self.tcx, param_substs),
+        )
     }
 
     pub fn type_size(&self, ty: Ty<'tcx>) -> EvalResult<'tcx, Option<u64>> {
@@ -399,19 +413,30 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         }
     }
 
-    fn type_align_with_substs(&self, ty: Ty<'tcx>, substs: &'tcx Substs<'tcx>) -> EvalResult<'tcx, u64> {
-        self.type_layout_with_substs(ty, substs).map(|layout| layout.align(&self.tcx.data_layout).abi())
+    fn type_align_with_substs(
+        &self,
+        ty: Ty<'tcx>,
+        substs: &'tcx Substs<'tcx>,
+    ) -> EvalResult<'tcx, u64> {
+        self.type_layout_with_substs(ty, substs).map(|layout| {
+            layout.align(&self.tcx.data_layout).abi()
+        })
     }
 
     pub fn type_layout(&self, ty: Ty<'tcx>) -> EvalResult<'tcx, &'tcx Layout> {
         self.type_layout_with_substs(ty, self.substs())
     }
 
-    fn type_layout_with_substs(&self, ty: Ty<'tcx>, substs: &'tcx Substs<'tcx>) -> EvalResult<'tcx, &'tcx Layout> {
+    fn type_layout_with_substs(
+        &self,
+        ty: Ty<'tcx>,
+        substs: &'tcx Substs<'tcx>,
+    ) -> EvalResult<'tcx, &'tcx Layout> {
         // FIXME(solson): Is this inefficient? Needs investigation.
         let ty = self.monomorphize(ty, substs);
 
-        ty.layout(self.tcx, ty::ParamEnv::empty(Reveal::All)).map_err(|layout| EvalErrorKind::Layout(layout).into())
+        ty.layout(self.tcx, ty::ParamEnv::empty(Reveal::All))
+            .map_err(|layout| EvalErrorKind::Layout(layout).into())
     }
 
     pub fn push_stack_frame(
@@ -432,13 +457,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             for block in mir.basic_blocks() {
                 for stmt in block.statements.iter() {
                     match stmt.kind {
-                        StorageLive(mir::Lvalue::Local(local)) | StorageDead(mir::Lvalue::Local(local)) => {
+                        StorageLive(mir::Lvalue::Local(local)) |
+                        StorageDead(mir::Lvalue::Local(local)) => {
                             set.insert(local);
                         }
                         _ => {}
                     }
                 }
-            };
+            }
             set
         }
 
@@ -448,7 +474,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         let num_locals = mir.local_decls.len() - 1;
         let mut locals = vec![None; num_locals];
         for i in 0..num_locals {
-            let local = mir::Local::new(i+1);
+            let local = mir::Local::new(i + 1);
             if !annotated_locals.contains(&local) {
                 locals[i] = Some(Value::ByVal(PrimVal::Undef));
             }
@@ -478,17 +504,21 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     pub(super) fn pop_stack_frame(&mut self) -> EvalResult<'tcx> {
         ::log_settings::settings().indentation -= 1;
         self.memory.locks_lifetime_ended(None);
-        let frame = self.stack.pop().expect("tried to pop a stack frame, but there were none");
+        let frame = self.stack.pop().expect(
+            "tried to pop a stack frame, but there were none",
+        );
         if !self.stack.is_empty() {
             // FIXME: IS this the correct time to start considering these accesses as originating from the returned-to stack frame?
             let cur_frame = self.cur_frame();
             self.memory.set_cur_frame(cur_frame);
         }
         match frame.return_to_block {
-            StackPopCleanup::MarkStatic(mutable) => if let Lvalue::Global(id) = frame.return_lvalue {
-                let global_value = self.globals.get_mut(&id)
-                    .expect("global should have been cached (static)");
-                match global_value.value {
+            StackPopCleanup::MarkStatic(mutable) => {
+                if let Lvalue::Global(id) = frame.return_lvalue {
+                    let global_value = self.globals.get_mut(&id).expect(
+                        "global should have been cached (static)",
+                    );
+                    match global_value.value {
                     // FIXME: to_ptr()? might be too extreme here, static zsts might reach this under certain conditions
                     Value::ByRef { ptr, aligned: _aligned } =>
                         // Alignment does not matter for this call
@@ -505,16 +535,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         }
                     },
                 }
-                // see comment on `initialized` field
-                assert!(!global_value.initialized);
-                global_value.initialized = true;
-                assert_eq!(global_value.mutable, Mutability::Mutable);
-                global_value.mutable = mutable;
-            } else {
-                bug!("StackPopCleanup::MarkStatic on: {:?}", frame.return_lvalue);
-            },
+                    // see comment on `initialized` field
+                    assert!(!global_value.initialized);
+                    global_value.initialized = true;
+                    assert_eq!(global_value.mutable, Mutability::Mutable);
+                    global_value.mutable = mutable;
+                } else {
+                    bug!("StackPopCleanup::MarkStatic on: {:?}", frame.return_lvalue);
+                }
+            }
             StackPopCleanup::Goto(target) => self.goto_block(target),
-            StackPopCleanup::None => {},
+            StackPopCleanup::None => {}
         }
         // deallocate all locals that are backed by an allocation
         for local in frame.locals {
@@ -612,7 +643,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             }
 
             BinaryOp(bin_op, ref left, ref right) => {
-                if self.intrinsic_overflowing(bin_op, left, right, dest, dest_ty)? {
+                if self.intrinsic_overflowing(
+                    bin_op,
+                    left,
+                    right,
+                    dest,
+                    dest_ty,
+                )?
+                {
                     // There was an overflow in an unchecked binop.  Right now, we consider this an error and bail out.
                     // The rationale is that the reason rustc emits unchecked binops in release mode (vs. the checked binops
                     // it emits in debug mode) is performance, but it doesn't cost us any performance in miri.
@@ -623,13 +661,23 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             }
 
             CheckedBinaryOp(bin_op, ref left, ref right) => {
-                self.intrinsic_with_overflow(bin_op, left, right, dest, dest_ty)?;
+                self.intrinsic_with_overflow(
+                    bin_op,
+                    left,
+                    right,
+                    dest,
+                    dest_ty,
+                )?;
             }
 
             UnaryOp(un_op, ref operand) => {
                 let val = self.eval_operand_to_primval(operand)?;
                 let kind = self.ty_to_primval_kind(dest_ty)?;
-                self.write_primval(dest, operator::unary_op(un_op, val, kind)?, dest_ty)?;
+                self.write_primval(
+                    dest,
+                    operator::unary_op(un_op, val, kind)?,
+                    dest_ty,
+                )?;
             }
 
             // Skip everything for zsts
@@ -639,13 +687,19 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 self.inc_step_counter_and_check_limit(operands.len() as u64)?;
                 use rustc::ty::layout::Layout::*;
                 match *dest_layout {
-                    Univariant { .. } | Array { .. } => {
+                    Univariant { .. } |
+                    Array { .. } => {
                         self.assign_fields(dest, dest_ty, operands)?;
                     }
 
-                    General { discr, ref variants, .. } => {
+                    General {
+                        discr,
+                        ref variants,
+                        ..
+                    } => {
                         if let mir::AggregateKind::Adt(adt_def, variant, _, _) = **kind {
-                            let discr_val = adt_def.discriminants(self.tcx)
+                            let discr_val = adt_def
+                                .discriminants(self.tcx)
                                 .nth(variant)
                                 .expect("broken mir: Adt variant id invalid")
                                 .to_u128_unchecked();
@@ -686,7 +740,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         }
                     }
 
-                    StructWrappedNullablePointer { nndiscr, ref discrfield_source, .. } => {
+                    StructWrappedNullablePointer {
+                        nndiscr,
+                        ref discrfield_source,
+                        ..
+                    } => {
                         if let mir::AggregateKind::Adt(_, variant, _, _) = **kind {
                             if nndiscr == variant as u64 {
                                 self.assign_fields(dest, dest_ty, operands)?;
@@ -695,15 +753,21 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                                     let operand_ty = self.operand_ty(operand);
                                     assert_eq!(self.type_size(operand_ty)?, Some(0));
                                 }
-                                let (offset, TyAndPacked { ty, packed: _}) = self.nonnull_offset_and_ty(dest_ty, nndiscr, discrfield_source)?;
+                                let (offset, TyAndPacked { ty, packed: _ }) =
+                                    self.nonnull_offset_and_ty(
+                                        dest_ty,
+                                        nndiscr,
+                                        discrfield_source,
+                                    )?;
                                 // FIXME: The packed flag is ignored
 
                                 // FIXME(solson)
                                 let dest = self.force_allocation(dest)?.to_ptr()?;
 
                                 let dest = dest.offset(offset.bytes(), &self)?;
-                                let dest_size = self.type_size(ty)?
-                                    .expect("bad StructWrappedNullablePointer discrfield");
+                                let dest_size = self.type_size(ty)?.expect(
+                                    "bad StructWrappedNullablePointer discrfield",
+                                );
                                 self.memory.write_int(dest, 0, dest_size)?;
                             }
                         } else {
@@ -714,7 +778,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     CEnum { .. } => {
                         assert_eq!(operands.len(), 0);
                         if let mir::AggregateKind::Adt(adt_def, variant, _, _) = **kind {
-                            let n = adt_def.discriminants(self.tcx)
+                            let n = adt_def
+                                .discriminants(self.tcx)
                                 .nth(variant)
                                 .expect("broken mir: Adt variant index invalid")
                                 .to_u128_unchecked();
@@ -750,11 +815,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             Repeat(ref operand, _) => {
                 let (elem_ty, length) = match dest_ty.sty {
                     ty::TyArray(elem_ty, n) => (elem_ty, n as u64),
-                    _ => bug!("tried to assign array-repeat to non-array type {:?}", dest_ty),
+                    _ => {
+                        bug!(
+                            "tried to assign array-repeat to non-array type {:?}",
+                            dest_ty
+                        )
+                    }
                 };
                 self.inc_step_counter_and_check_limit(length)?;
-                let elem_size = self.type_size(elem_ty)?
-                    .expect("repeat element type must be sized");
+                let elem_size = self.type_size(elem_ty)?.expect(
+                    "repeat element type must be sized",
+                );
                 let value = self.eval_operand(operand)?;
 
                 // FIXME(solson)
@@ -771,7 +842,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 let src = self.eval_lvalue(lvalue)?;
                 let ty = self.lvalue_ty(lvalue);
                 let (_, len) = src.elem_ty_and_len(ty);
-                self.write_primval(dest, PrimVal::from_u128(len as u128), dest_ty)?;
+                self.write_primval(
+                    dest,
+                    PrimVal::from_u128(len as u128),
+                    dest_ty,
+                )?;
             }
 
             Ref(_, _, ref lvalue) => {
@@ -784,8 +859,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     LvalueExtra::None => ptr.to_value(),
                     LvalueExtra::Length(len) => ptr.to_value_with_len(len),
                     LvalueExtra::Vtable(vtable) => ptr.to_value_with_vtable(vtable),
-                    LvalueExtra::DowncastVariant(..) =>
-                        bug!("attempted to take a reference to an enum downcast lvalue"),
+                    LvalueExtra::DowncastVariant(..) => {
+                        bug!("attempted to take a reference to an enum downcast lvalue")
+                    }
                 };
                 self.write_value(val, dest, dest_ty)?;
             }
@@ -796,8 +872,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             }
 
             NullaryOp(mir::NullOp::SizeOf, ty) => {
-                let size = self.type_size(ty)?.expect("SizeOf nullary MIR operator called for unsized type");
-                self.write_primval(dest, PrimVal::from_u128(size as u128), dest_ty)?;
+                let size = self.type_size(ty)?.expect(
+                    "SizeOf nullary MIR operator called for unsized type",
+                );
+                self.write_primval(
+                    dest,
+                    PrimVal::from_u128(size as u128),
+                    dest_ty,
+                )?;
             }
 
             Cast(kind, ref operand, cast_ty) => {
@@ -815,13 +897,13 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         let src_ty = self.operand_ty(operand);
                         if self.type_is_fat_ptr(src_ty) {
                             match (src, self.type_is_fat_ptr(dest_ty)) {
-                                (Value::ByRef{..}, _) |
+                                (Value::ByRef { .. }, _) |
                                 (Value::ByValPair(..), true) => {
                                     self.write_value(src, dest, dest_ty)?;
-                                },
+                                }
                                 (Value::ByValPair(data, _), false) => {
                                     self.write_value(Value::ByVal(data), dest, dest_ty)?;
-                                },
+                                }
                                 (Value::ByVal(_), _) => bug!("expected fat ptr"),
                             }
                         } else {
@@ -831,31 +913,50 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         }
                     }
 
-                    ReifyFnPointer => match self.operand_ty(operand).sty {
-                        ty::TyFnDef(def_id, substs) => {
-                            let instance = resolve(self.tcx, def_id, substs);
-                            let fn_ptr = self.memory.create_fn_alloc(instance);
-                            self.write_value(Value::ByVal(PrimVal::Ptr(fn_ptr)), dest, dest_ty)?;
-                        },
-                        ref other => bug!("reify fn pointer on {:?}", other),
-                    },
+                    ReifyFnPointer => {
+                        match self.operand_ty(operand).sty {
+                            ty::TyFnDef(def_id, substs) => {
+                                let instance = resolve(self.tcx, def_id, substs);
+                                let fn_ptr = self.memory.create_fn_alloc(instance);
+                                self.write_value(
+                                    Value::ByVal(PrimVal::Ptr(fn_ptr)),
+                                    dest,
+                                    dest_ty,
+                                )?;
+                            }
+                            ref other => bug!("reify fn pointer on {:?}", other),
+                        }
+                    }
 
-                    UnsafeFnPointer => match dest_ty.sty {
-                        ty::TyFnPtr(_) => {
-                            let src = self.eval_operand(operand)?;
-                            self.write_value(src, dest, dest_ty)?;
-                        },
-                        ref other => bug!("fn to unsafe fn cast on {:?}", other),
-                    },
+                    UnsafeFnPointer => {
+                        match dest_ty.sty {
+                            ty::TyFnPtr(_) => {
+                                let src = self.eval_operand(operand)?;
+                                self.write_value(src, dest, dest_ty)?;
+                            }
+                            ref other => bug!("fn to unsafe fn cast on {:?}", other),
+                        }
+                    }
 
-                    ClosureFnPointer => match self.operand_ty(operand).sty {
-                        ty::TyClosure(def_id, substs) => {
-                            let instance = resolve_closure(self.tcx, def_id, substs, ty::ClosureKind::FnOnce);
-                            let fn_ptr = self.memory.create_fn_alloc(instance);
-                            self.write_value(Value::ByVal(PrimVal::Ptr(fn_ptr)), dest, dest_ty)?;
-                        },
-                        ref other => bug!("closure fn pointer on {:?}", other),
-                    },
+                    ClosureFnPointer => {
+                        match self.operand_ty(operand).sty {
+                            ty::TyClosure(def_id, substs) => {
+                                let instance = resolve_closure(
+                                    self.tcx,
+                                    def_id,
+                                    substs,
+                                    ty::ClosureKind::FnOnce,
+                                );
+                                let fn_ptr = self.memory.create_fn_alloc(instance);
+                                self.write_value(
+                                    Value::ByVal(PrimVal::Ptr(fn_ptr)),
+                                    dest,
+                                    dest_ty,
+                                )?;
+                            }
+                            ref other => bug!("closure fn pointer on {:?}", other),
+                        }
+                    }
                 }
             }
 
@@ -865,14 +966,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 let ptr = self.force_allocation(lval)?.to_ptr()?;
                 let discr_val = self.read_discriminant_value(ptr, ty)?;
                 if let ty::TyAdt(adt_def, _) = ty.sty {
-                    if adt_def.discriminants(self.tcx).all(|v| discr_val != v.to_u128_unchecked()) {
+                    if adt_def.discriminants(self.tcx).all(|v| {
+                        discr_val != v.to_u128_unchecked()
+                    })
+                    {
                         return err!(InvalidDiscriminant);
                     }
                 } else {
                     bug!("rustc only generates Rvalue::Discriminant for enums");
                 }
                 self.write_primval(dest, PrimVal::Bytes(discr_val), dest_ty)?;
-            },
+            }
         }
 
         if log_enabled!(::log::LogLevel::Trace) {
@@ -906,7 +1010,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 let variant = &adt_def.variants[nndiscr as usize];
                 let index = discrfield[1];
                 let field = &variant.fields[index as usize];
-                (self.get_field_offset(ty, index as usize)?, field.ty(self.tcx, substs))
+                (
+                    self.get_field_offset(ty, index as usize)?,
+                    field.ty(self.tcx, substs),
+                )
             }
             _ => bug!("non-enum for StructWrappedNullablePointer: {}", ty),
         };
@@ -924,16 +1031,28 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         let mut packed = false;
         for field_index in path {
             let field_offset = self.get_field_offset(ty, field_index)?;
-            trace!("field_path_offset_and_ty: {}, {}, {:?}, {:?}", field_index, ty, field_offset, offset);
+            trace!(
+                "field_path_offset_and_ty: {}, {}, {:?}, {:?}",
+                field_index,
+                ty,
+                field_offset,
+                offset
+            );
             let field_ty = self.get_field_ty(ty, field_index)?;
             ty = field_ty.ty;
             packed = packed || field_ty.packed;
-            offset = offset.checked_add(field_offset, &self.tcx.data_layout).unwrap();
+            offset = offset
+                .checked_add(field_offset, &self.tcx.data_layout)
+                .unwrap();
         }
 
         Ok((offset, TyAndPacked { ty, packed }))
     }
-    fn get_fat_field(&self, pointee_ty: Ty<'tcx>, field_index: usize) -> EvalResult<'tcx, Ty<'tcx>> {
+    fn get_fat_field(
+        &self,
+        pointee_ty: Ty<'tcx>,
+        field_index: usize,
+    ) -> EvalResult<'tcx, Ty<'tcx>> {
         match (field_index, &self.tcx.struct_tail(pointee_ty).sty) {
             (1, &ty::TyStr) |
             (1, &ty::TySlice(_)) => Ok(self.tcx.types.usize),
@@ -944,42 +1063,92 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     /// Returns the field type and whether the field is packed
-    pub fn get_field_ty(&self, ty: Ty<'tcx>, field_index: usize) -> EvalResult<'tcx, TyAndPacked<'tcx>> {
+    pub fn get_field_ty(
+        &self,
+        ty: Ty<'tcx>,
+        field_index: usize,
+    ) -> EvalResult<'tcx, TyAndPacked<'tcx>> {
         match ty.sty {
-            ty::TyAdt(adt_def, _) if adt_def.is_box() =>
-                Ok(TyAndPacked { ty: self.get_fat_field(ty.boxed_ty(), field_index)?, packed: false }),
+            ty::TyAdt(adt_def, _) if adt_def.is_box() => Ok(TyAndPacked {
+                ty: self.get_fat_field(ty.boxed_ty(), field_index)?,
+                packed: false,
+            }),
             ty::TyAdt(adt_def, substs) if adt_def.is_enum() => {
                 use rustc::ty::layout::Layout::*;
                 match *self.type_layout(ty)? {
-                    RawNullablePointer { nndiscr, .. } =>
-                        Ok(TyAndPacked { ty: adt_def.variants[nndiscr as usize].fields[field_index].ty(self.tcx, substs), packed: false }),
-                    StructWrappedNullablePointer { nndiscr, ref nonnull, .. } => {
-                        let ty = adt_def.variants[nndiscr as usize].fields[field_index].ty(self.tcx, substs);
-                        Ok(TyAndPacked { ty, packed: nonnull.packed })
-                    },
-                    _ => err!(Unimplemented(format!("get_field_ty can't handle enum type: {:?}, {:?}", ty, ty.sty))),
+                    RawNullablePointer { nndiscr, .. } => Ok(TyAndPacked {
+                        ty: adt_def.variants[nndiscr as usize].fields[field_index].ty(
+                            self.tcx,
+                            substs,
+                        ),
+                        packed: false,
+                    }),
+                    StructWrappedNullablePointer {
+                        nndiscr,
+                        ref nonnull,
+                        ..
+                    } => {
+                        let ty = adt_def.variants[nndiscr as usize].fields[field_index].ty(
+                            self.tcx,
+                            substs,
+                        );
+                        Ok(TyAndPacked {
+                            ty,
+                            packed: nonnull.packed,
+                        })
+                    }
+                    _ => {
+                        err!(Unimplemented(format!(
+                            "get_field_ty can't handle enum type: {:?}, {:?}",
+                            ty,
+                            ty.sty
+                        )))
+                    }
                 }
             }
             ty::TyAdt(adt_def, substs) => {
                 let variant_def = adt_def.struct_variant();
                 use rustc::ty::layout::Layout::*;
                 match *self.type_layout(ty)? {
-                    UntaggedUnion { ref variants } => 
-                        Ok(TyAndPacked { ty: variant_def.fields[field_index].ty(self.tcx, substs), packed: variants.packed }),
-                    Univariant { ref variant, .. } =>
-                        Ok(TyAndPacked { ty: variant_def.fields[field_index].ty(self.tcx, substs), packed: variant.packed }),
-                    _ => err!(Unimplemented(format!("get_field_ty can't handle struct type: {:?}, {:?}", ty, ty.sty))),
+                    UntaggedUnion { ref variants } => Ok(TyAndPacked {
+                        ty: variant_def.fields[field_index].ty(self.tcx, substs),
+                        packed: variants.packed,
+                    }),
+                    Univariant { ref variant, .. } => Ok(TyAndPacked {
+                        ty: variant_def.fields[field_index].ty(self.tcx, substs),
+                        packed: variant.packed,
+                    }),
+                    _ => {
+                        err!(Unimplemented(format!(
+                            "get_field_ty can't handle struct type: {:?}, {:?}",
+                            ty,
+                            ty.sty
+                        )))
+                    }
                 }
             }
 
-            ty::TyTuple(fields, _) => Ok(TyAndPacked { ty: fields[field_index], packed: false }),
+            ty::TyTuple(fields, _) => Ok(TyAndPacked {
+                ty: fields[field_index],
+                packed: false,
+            }),
 
             ty::TyRef(_, ref tam) |
-            ty::TyRawPtr(ref tam) => Ok(TyAndPacked { ty: self.get_fat_field(tam.ty, field_index)?, packed: false }),
+            ty::TyRawPtr(ref tam) => Ok(TyAndPacked {
+                ty: self.get_fat_field(tam.ty, field_index)?,
+                packed: false,
+            }),
 
-            ty::TyArray(ref inner, _) => Ok(TyAndPacked { ty: inner, packed: false }),
+            ty::TyArray(ref inner, _) => Ok(TyAndPacked {
+                ty: inner,
+                packed: false,
+            }),
 
-            _ => err!(Unimplemented(format!("can't handle type: {:?}, {:?}", ty, ty.sty))),
+            _ => {
+                err!(Unimplemented(
+                    format!("can't handle type: {:?}, {:?}", ty, ty.sty),
+                ))
+            }
         }
     }
 
@@ -989,19 +1158,19 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
         use rustc::ty::layout::Layout::*;
         match *layout {
-            Univariant { ref variant, .. } => {
-                Ok(variant.offsets[field_index])
-            }
+            Univariant { ref variant, .. } => Ok(variant.offsets[field_index]),
             FatPointer { .. } => {
                 let bytes = field_index as u64 * self.memory.pointer_size();
                 Ok(Size::from_bytes(bytes))
             }
-            StructWrappedNullablePointer { ref nonnull, .. } => {
-                Ok(nonnull.offsets[field_index])
-            }
+            StructWrappedNullablePointer { ref nonnull, .. } => Ok(nonnull.offsets[field_index]),
             UntaggedUnion { .. } => Ok(Size::from_bytes(0)),
             _ => {
-                let msg = format!("get_field_offset: can't handle type: {:?}, with layout: {:?}", ty, layout);
+                let msg = format!(
+                    "get_field_offset: can't handle type: {:?}, with layout: {:?}",
+                    ty,
+                    layout
+                );
                 err!(Unimplemented(msg))
             }
         }
@@ -1015,18 +1184,25 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             Univariant { ref variant, .. } => Ok(variant.offsets.len() as u64),
             FatPointer { .. } => Ok(2),
             StructWrappedNullablePointer { ref nonnull, .. } => Ok(nonnull.offsets.len() as u64),
-            Vector { count , .. } |
+            Vector { count, .. } |
             Array { count, .. } => Ok(count),
             Scalar { .. } => Ok(0),
             UntaggedUnion { .. } => Ok(1),
             _ => {
-                let msg = format!("get_field_count: can't handle type: {:?}, with layout: {:?}", ty, layout);
+                let msg = format!(
+                    "get_field_count: can't handle type: {:?}, with layout: {:?}",
+                    ty,
+                    layout
+                );
                 err!(Unimplemented(msg))
             }
         }
     }
 
-    pub(super) fn eval_operand_to_primval(&mut self, op: &mir::Operand<'tcx>) -> EvalResult<'tcx, PrimVal> {
+    pub(super) fn eval_operand_to_primval(
+        &mut self,
+        op: &mir::Operand<'tcx>,
+    ) -> EvalResult<'tcx, PrimVal> {
         let value = self.eval_operand(op)?;
         let ty = self.operand_ty(op);
         self.value_to_primval(value, ty)
@@ -1045,8 +1221,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
                     Literal::Item { def_id, substs } => {
                         let instance = self.resolve_associated_const(def_id, substs);
-                        let cid = GlobalId { instance, promoted: None };
-                        self.globals.get(&cid).expect("static/const not cached").value
+                        let cid = GlobalId {
+                            instance,
+                            promoted: None,
+                        };
+                        self.globals
+                            .get(&cid)
+                            .expect("static/const not cached")
+                            .value
                     }
 
                     Literal::Promoted { index } => {
@@ -1068,30 +1250,34 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     fn copy(&mut self, src: Pointer, dest: Pointer, ty: Ty<'tcx>) -> EvalResult<'tcx> {
-        let size = self.type_size(ty)?.expect("cannot copy from an unsized type");
+        let size = self.type_size(ty)?.expect(
+            "cannot copy from an unsized type",
+        );
         let align = self.type_align(ty)?;
         self.memory.copy(src, dest, size, align, false)?;
         Ok(())
     }
 
-    pub fn force_allocation(
-        &mut self,
-        lvalue: Lvalue<'tcx>,
-    ) -> EvalResult<'tcx, Lvalue<'tcx>> {
+    pub fn force_allocation(&mut self, lvalue: Lvalue<'tcx>) -> EvalResult<'tcx, Lvalue<'tcx>> {
         let new_lvalue = match lvalue {
             Lvalue::Local { frame, local } => {
                 // -1 since we don't store the return value
                 match self.stack[frame].locals[local.index() - 1] {
                     None => return err!(DeadLocal),
                     Some(Value::ByRef { ptr, aligned }) => {
-                        Lvalue::Ptr { ptr, aligned, extra: LvalueExtra::None }
-                    },
+                        Lvalue::Ptr {
+                            ptr,
+                            aligned,
+                            extra: LvalueExtra::None,
+                        }
+                    }
                     Some(val) => {
                         let ty = self.stack[frame].mir.local_decls[local].ty;
                         let ty = self.monomorphize(ty, self.stack[frame].instance.substs);
                         let substs = self.stack[frame].instance.substs;
                         let ptr = self.alloc_ptr_with_substs(ty, substs)?;
-                        self.stack[frame].locals[local.index() - 1] = Some(Value::by_ref(ptr.into())); // it stays live
+                        self.stack[frame].locals[local.index() - 1] =
+                            Some(Value::by_ref(ptr.into())); // it stays live
                         self.write_value_to_ptr(val, ptr.into(), ty)?;
                         Lvalue::from_ptr(ptr)
                     }
@@ -1101,23 +1287,36 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             Lvalue::Global(cid) => {
                 let global_val = self.globals.get(&cid).expect("global not cached").clone();
                 match global_val.value {
-                    Value::ByRef { ptr, aligned } =>
-                        Lvalue::Ptr { ptr, aligned, extra: LvalueExtra::None },
+                    Value::ByRef { ptr, aligned } => Lvalue::Ptr {
+                        ptr,
+                        aligned,
+                        extra: LvalueExtra::None,
+                    },
                     _ => {
-                        let ptr = self.alloc_ptr_with_substs(global_val.ty, cid.instance.substs)?;
+                        let ptr = self.alloc_ptr_with_substs(
+                            global_val.ty,
+                            cid.instance.substs,
+                        )?;
                         self.memory.mark_static(ptr.alloc_id);
-                        self.write_value_to_ptr(global_val.value, ptr.into(), global_val.ty)?;
+                        self.write_value_to_ptr(
+                            global_val.value,
+                            ptr.into(),
+                            global_val.ty,
+                        )?;
                         // see comment on `initialized` field
                         if global_val.initialized {
-                            self.memory.mark_static_initalized(ptr.alloc_id, global_val.mutable)?;
+                            self.memory.mark_static_initalized(
+                                ptr.alloc_id,
+                                global_val.mutable,
+                            )?;
                         }
                         let lval = self.globals.get_mut(&cid).expect("already checked");
                         *lval = Global {
                             value: Value::by_ref(ptr.into()),
-                            .. global_val
+                            ..global_val
                         };
                         Lvalue::from_ptr(ptr)
-                    },
+                    }
                 }
             }
         };
@@ -1125,7 +1324,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     /// ensures this Value is not a ByRef
-    pub(super) fn follow_by_ref_value(&mut self, value: Value, ty: Ty<'tcx>) -> EvalResult<'tcx, Value> {
+    pub(super) fn follow_by_ref_value(
+        &mut self,
+        value: Value,
+        ty: Ty<'tcx>,
+    ) -> EvalResult<'tcx, Value> {
         match value {
             Value::ByRef { ptr, aligned } => {
                 self.read_maybe_aligned(aligned, |ectx| ectx.read_value(ptr, ty))
@@ -1136,7 +1339,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
     pub fn value_to_primval(&mut self, value: Value, ty: Ty<'tcx>) -> EvalResult<'tcx, PrimVal> {
         match self.follow_by_ref_value(value, ty)? {
-            Value::ByRef{..} => bug!("follow_by_ref_value can't result in `ByRef`"),
+            Value::ByRef { .. } => bug!("follow_by_ref_value can't result in `ByRef`"),
 
             Value::ByVal(primval) => {
                 self.ensure_valid_value(primval, ty)?;
@@ -1147,11 +1350,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         }
     }
 
-    pub fn write_null(
-        &mut self,
-        dest: Lvalue<'tcx>,
-        dest_ty: Ty<'tcx>,
-    ) -> EvalResult<'tcx> {
+    pub fn write_null(&mut self, dest: Lvalue<'tcx>, dest_ty: Ty<'tcx>) -> EvalResult<'tcx> {
         self.write_primval(dest, PrimVal::Bytes(0), dest_ty)
     }
 
@@ -1186,24 +1385,31 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
         match dest {
             Lvalue::Global(cid) => {
-                let dest = self.globals.get_mut(&cid).expect("global should be cached").clone();
+                let dest = self.globals
+                    .get_mut(&cid)
+                    .expect("global should be cached")
+                    .clone();
                 if dest.mutable == Mutability::Immutable {
                     return err!(ModifiedConstantMemory);
                 }
                 let write_dest = |this: &mut Self, val| {
-                    *this.globals.get_mut(&cid).expect("already checked") = Global {
-                        value: val,
-                        ..dest
-                    };
+                    *this.globals.get_mut(&cid).expect("already checked") =
+                        Global { value: val, ..dest };
                     Ok(())
                 };
                 self.write_value_possibly_by_val(src_val, write_dest, dest.value, dest_ty)
-            },
+            }
 
-            Lvalue::Ptr { ptr, extra, aligned } => {
+            Lvalue::Ptr {
+                ptr,
+                extra,
+                aligned,
+            } => {
                 assert_eq!(extra, LvalueExtra::None);
-                self.write_maybe_aligned_mut(aligned,
-                    |ectx| ectx.write_value_to_ptr(src_val, ptr, dest_ty))
+                self.write_maybe_aligned_mut(
+                    aligned,
+                    |ectx| ectx.write_value_to_ptr(src_val, ptr, dest_ty),
+                )
             }
 
             Lvalue::Local { frame, local } => {
@@ -1226,7 +1432,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         old_dest_val: Value,
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
-        if let Value::ByRef { ptr: dest_ptr, aligned } = old_dest_val {
+        if let Value::ByRef {
+            ptr: dest_ptr,
+            aligned,
+        } = old_dest_val
+        {
             // If the value is already `ByRef` (that is, backed by an `Allocation`),
             // then we must write the new value into this allocation, because there may be
             // other pointers into the allocation. These other pointers are logically
@@ -1234,10 +1444,15 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             //
             // Thus, it would be an error to replace the `ByRef` with a `ByVal`, unless we
             // knew for certain that there were no outstanding pointers to this allocation.
-            self.write_maybe_aligned_mut(aligned,
-                |ectx| ectx.write_value_to_ptr(src_val, dest_ptr, dest_ty))?;
+            self.write_maybe_aligned_mut(aligned, |ectx| {
+                ectx.write_value_to_ptr(src_val, dest_ptr, dest_ty)
+            })?;
 
-        } else if let Value::ByRef { ptr: src_ptr, aligned } = src_val {
+        } else if let Value::ByRef {
+                   ptr: src_ptr,
+                   aligned,
+               } = src_val
+        {
             // If the value is not `ByRef`, then we know there are no pointers to it
             // and we can simply overwrite the `Value` in the locals array directly.
             //
@@ -1277,7 +1492,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         match value {
             Value::ByRef { ptr, aligned } => {
                 self.read_maybe_aligned_mut(aligned, |ectx| ectx.copy(ptr, dest, dest_ty))
-            },
+            }
             Value::ByVal(primval) => {
                 let size = self.type_size(dest_ty)?.expect("dest type must be sized");
                 self.memory.write_primval(dest, primval, size)
@@ -1291,7 +1506,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         a: PrimVal,
         b: PrimVal,
         ptr: MemoryPointer,
-        mut ty: Ty<'tcx>
+        mut ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
         let mut packed = false;
         while self.get_field_count(ty)? == 1 {
@@ -1304,16 +1519,26 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         let field_1 = self.get_field_offset(ty, 1)?;
         let field_0_ty = self.get_field_ty(ty, 0)?;
         let field_1_ty = self.get_field_ty(ty, 1)?;
-        assert_eq!(field_0_ty.packed, field_1_ty.packed, "the two fields must agree on being packed");
+        assert_eq!(
+            field_0_ty.packed,
+            field_1_ty.packed,
+            "the two fields must agree on being packed"
+        );
         packed = packed || field_0_ty.packed;
-        let field_0_size = self.type_size(field_0_ty.ty)?.expect("pair element type must be sized");
-        let field_1_size = self.type_size(field_1_ty.ty)?.expect("pair element type must be sized");
+        let field_0_size = self.type_size(field_0_ty.ty)?.expect(
+            "pair element type must be sized",
+        );
+        let field_1_size = self.type_size(field_1_ty.ty)?.expect(
+            "pair element type must be sized",
+        );
         let field_0_ptr = ptr.offset(field_0.bytes(), &self)?.into();
         let field_1_ptr = ptr.offset(field_1.bytes(), &self)?.into();
-        self.write_maybe_aligned_mut(!packed,
-            |ectx| ectx.memory.write_primval(field_0_ptr, a, field_0_size))?;
-        self.write_maybe_aligned_mut(!packed,
-            |ectx| ectx.memory.write_primval(field_1_ptr, b, field_1_size))?;
+        self.write_maybe_aligned_mut(!packed, |ectx| {
+            ectx.memory.write_primval(field_0_ptr, a, field_0_size)
+        })?;
+        self.write_maybe_aligned_mut(!packed, |ectx| {
+            ectx.memory.write_primval(field_1_ptr, b, field_1_size)
+        })?;
         Ok(())
     }
 
@@ -1409,8 +1634,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         match ty.sty {
             ty::TyBool if val.to_bytes()? > 1 => err!(InvalidBool),
 
-            ty::TyChar if ::std::char::from_u32(val.to_bytes()? as u32).is_none()
-                => err!(InvalidChar(val.to_bytes()? as u32 as u128)),
+            ty::TyChar if ::std::char::from_u32(val.to_bytes()? as u32).is_none() => {
+                err!(InvalidChar(val.to_bytes()? as u32 as u128))
+            }
 
             _ => Ok(()),
         }
@@ -1424,7 +1650,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         }
     }
 
-    pub(crate) fn read_ptr(&self, ptr: MemoryPointer, pointee_ty: Ty<'tcx>) -> EvalResult<'tcx, Value> {
+    pub(crate) fn read_ptr(
+        &self,
+        ptr: MemoryPointer,
+        pointee_ty: Ty<'tcx>,
+    ) -> EvalResult<'tcx, Value> {
         let p = self.memory.read_ptr(ptr)?;
         if self.type_is_sized(pointee_ty) {
             Ok(p.to_value())
@@ -1432,9 +1662,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             trace!("reading fat pointer extra of type {}", pointee_ty);
             let extra = ptr.offset(self.memory.pointer_size(), self)?;
             match self.tcx.struct_tail(pointee_ty).sty {
-                ty::TyDynamic(..) => Ok(p.to_value_with_vtable(self.memory.read_ptr(extra)?.to_ptr()?)),
-                ty::TySlice(..) |
-                ty::TyStr => Ok(p.to_value_with_len(self.memory.read_usize(extra)?)),
+                ty::TyDynamic(..) => Ok(p.to_value_with_vtable(
+                    self.memory.read_ptr(extra)?.to_ptr()?,
+                )),
+                ty::TySlice(..) | ty::TyStr => Ok(
+                    p.to_value_with_len(self.memory.read_usize(extra)?),
+                ),
                 _ => bug!("unsized primval ptr read from {:?}", pointee_ty),
             }
         }
@@ -1487,7 +1720,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 // if we transmute a ptr to an usize, reading it back into a primval shouldn't panic
                 // for consistency's sake, we use the same code as above
                 match self.memory.read_uint(ptr.to_ptr()?, size) {
-                    Err(EvalError { kind: EvalErrorKind::ReadPointerAsBytes, .. }) if size == self.memory.pointer_size() => self.memory.read_ptr(ptr.to_ptr()?)?.into_inner_primval(),
+                    Err(EvalError { kind: EvalErrorKind::ReadPointerAsBytes, .. })
+                        if size == self.memory.pointer_size() => {
+                        self.memory.read_ptr(ptr.to_ptr()?)?.into_inner_primval()
+                    }
                     other => PrimVal::from_u128(other?),
                 }
             }
@@ -1514,7 +1750,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 } else {
                     return Ok(None);
                 }
-            },
+            }
 
             _ => return Ok(None),
         };
@@ -1561,14 +1797,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 // traits, and hence never actually require an actual
                 // change to the vtable.
                 self.write_value(src, dest, dest_ty)
-            },
+            }
             (_, &ty::TyDynamic(ref data, _)) => {
-                let trait_ref = data.principal().unwrap().with_self_ty(self.tcx, src_pointee_ty);
+                let trait_ref = data.principal().unwrap().with_self_ty(
+                    self.tcx,
+                    src_pointee_ty,
+                );
                 let trait_ref = self.tcx.erase_regions(&trait_ref);
                 let vtable = self.get_vtable(src_pointee_ty, trait_ref)?;
                 let ptr = src.into_ptr(&self.memory)?;
                 self.write_value(ptr.to_value_with_vtable(vtable), dest, dest_ty)
-            },
+            }
 
             _ => bug!("invalid unsizing {:?} -> {:?}", src_ty, dest_ty),
         }
@@ -1584,13 +1823,22 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         match (&src_ty.sty, &dest_ty.sty) {
             (&ty::TyRef(_, ref s), &ty::TyRef(_, ref d)) |
             (&ty::TyRef(_, ref s), &ty::TyRawPtr(ref d)) |
-            (&ty::TyRawPtr(ref s), &ty::TyRawPtr(ref d)) => self.unsize_into_ptr(src, src_ty, dest, dest_ty, s.ty, d.ty),
+            (&ty::TyRawPtr(ref s), &ty::TyRawPtr(ref d)) => {
+                self.unsize_into_ptr(src, src_ty, dest, dest_ty, s.ty, d.ty)
+            }
             (&ty::TyAdt(def_a, substs_a), &ty::TyAdt(def_b, substs_b)) => {
                 if def_a.is_box() || def_b.is_box() {
                     if !def_a.is_box() || !def_b.is_box() {
                         panic!("invalid unsizing between {:?} -> {:?}", src_ty, dest_ty);
                     }
-                    return self.unsize_into_ptr(src, src_ty, dest, dest_ty, src_ty.boxed_ty(), dest_ty.boxed_ty());
+                    return self.unsize_into_ptr(
+                        src,
+                        src_ty,
+                        dest,
+                        dest_ty,
+                        src_ty.boxed_ty(),
+                        dest_ty.boxed_ty(),
+                    );
                 }
                 if self.ty_to_primval_kind(src_ty).is_ok() {
                     // FIXME: We ignore the packed flag here
@@ -1631,12 +1879,23 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     if src_fty == dst_fty {
                         self.copy(src_f_ptr, dst_f_ptr.into(), src_fty)?;
                     } else {
-                        self.unsize_into(Value::by_ref(src_f_ptr), src_fty, Lvalue::from_ptr(dst_f_ptr), dst_fty)?;
+                        self.unsize_into(
+                            Value::by_ref(src_f_ptr),
+                            src_fty,
+                            Lvalue::from_ptr(dst_f_ptr),
+                            dst_fty,
+                        )?;
                     }
                 }
                 Ok(())
             }
-            _ => bug!("unsize_into: invalid conversion: {:?} -> {:?}", src_ty, dest_ty),
+            _ => {
+                bug!(
+                    "unsize_into: invalid conversion: {:?} -> {:?}",
+                    src_ty,
+                    dest_ty
+                )
+            }
         }
     }
 
@@ -1651,27 +1910,36 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             write!(msg, ":").unwrap();
 
             match self.stack[frame].get_local(local) {
-                Err(EvalError{ kind: EvalErrorKind::DeadLocal, ..} ) => {
+                Err(EvalError { kind: EvalErrorKind::DeadLocal, .. }) => {
                     write!(msg, " is dead").unwrap();
                 }
                 Err(err) => {
                     panic!("Failed to access local: {:?}", err);
                 }
-                Ok(Value::ByRef { ptr, aligned }) => match ptr.into_inner_primval() {
-                    PrimVal::Ptr(ptr) => {
-                        write!(msg, " by {}ref:", if aligned { "" } else { "unaligned " }).unwrap();
-                        allocs.push(ptr.alloc_id);
-                    },
-                    ptr => write!(msg, " integral by ref: {:?}", ptr).unwrap(),
-                },
+                Ok(Value::ByRef { ptr, aligned }) => {
+                    match ptr.into_inner_primval() {
+                        PrimVal::Ptr(ptr) => {
+                            write!(msg, " by {}ref:", if aligned { "" } else { "unaligned " })
+                                .unwrap();
+                            allocs.push(ptr.alloc_id);
+                        }
+                        ptr => write!(msg, " integral by ref: {:?}", ptr).unwrap(),
+                    }
+                }
                 Ok(Value::ByVal(val)) => {
                     write!(msg, " {:?}", val).unwrap();
-                    if let PrimVal::Ptr(ptr) = val { allocs.push(ptr.alloc_id); }
+                    if let PrimVal::Ptr(ptr) = val {
+                        allocs.push(ptr.alloc_id);
+                    }
                 }
                 Ok(Value::ByValPair(val1, val2)) => {
                     write!(msg, " ({:?}, {:?})", val1, val2).unwrap();
-                    if let PrimVal::Ptr(ptr) = val1 { allocs.push(ptr.alloc_id); }
-                    if let PrimVal::Ptr(ptr) = val2 { allocs.push(ptr.alloc_id); }
+                    if let PrimVal::Ptr(ptr) = val1 {
+                        allocs.push(ptr.alloc_id);
+                    }
+                    if let PrimVal::Ptr(ptr) = val2 {
+                        allocs.push(ptr.alloc_id);
+                    }
                 }
             }
 
@@ -1682,7 +1950,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
     /// Convenience function to ensure correct usage of globals and code-sharing with locals.
     pub fn modify_global<F>(&mut self, cid: GlobalId<'tcx>, f: F) -> EvalResult<'tcx>
-        where F: FnOnce(&mut Self, Value) -> EvalResult<'tcx, Value>,
+    where
+        F: FnOnce(&mut Self, Value) -> EvalResult<'tcx, Value>,
     {
         let mut val = self.globals.get(&cid).expect("global not cached").clone();
         if val.mutable == Mutability::Immutable {
@@ -1694,13 +1963,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     /// Convenience function to ensure correct usage of locals and code-sharing with globals.
-    pub fn modify_local<F>(
-        &mut self,
-        frame: usize,
-        local: mir::Local,
-        f: F,
-    ) -> EvalResult<'tcx>
-        where F: FnOnce(&mut Self, Value) -> EvalResult<'tcx, Value>,
+    pub fn modify_local<F>(&mut self, frame: usize, local: mir::Local, f: F) -> EvalResult<'tcx>
+    where
+        F: FnOnce(&mut Self, Value) -> EvalResult<'tcx, Value>,
     {
         let val = self.stack[frame].get_local(local)?;
         let new_val = f(self, val)?;
@@ -1727,7 +1992,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                             break 'frames;
                         } else if name.starts_with("backtrace::capture::Backtrace::new")
                             // debug mode produces funky symbol names
-                            || name.starts_with("backtrace::capture::{{impl}}::new") {
+                            || name.starts_with("backtrace::capture::{{impl}}::new")
+                        {
                             // don't report backtrace internals
                             skip_init = false;
                             continue 'frames;
@@ -1738,7 +2004,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     continue;
                 }
                 for symbol in frame.symbols() {
-                    write!(trace_text, "{}: " , i).unwrap();
+                    write!(trace_text, "{}: ", i).unwrap();
                     if let Some(name) = symbol.name() {
                         write!(trace_text, "{}\n", name).unwrap();
                     } else {
@@ -1768,7 +2034,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             };
             let mut err = self.tcx.sess.struct_span_err(span, &e.to_string());
             for &Frame { instance, span, .. } in self.stack().iter().rev() {
-                if self.tcx.def_key(instance.def_id()).disambiguated_data.data == DefPathData::ClosureExpr {
+                if self.tcx.def_key(instance.def_id()).disambiguated_data.data ==
+                    DefPathData::ClosureExpr
+                {
                     err.span_note(span, "inside call to closure");
                     continue;
                 }
@@ -1840,7 +2108,7 @@ pub fn is_inhabited<'a, 'tcx: 'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> 
 }
 
 /// FIXME: expose trans::monomorphize::resolve_closure
-pub fn resolve_closure<'a, 'tcx> (
+pub fn resolve_closure<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     def_id: DefId,
     substs: ty::ClosureSubsts<'tcx>,
@@ -1849,7 +2117,7 @@ pub fn resolve_closure<'a, 'tcx> (
     let actual_kind = tcx.closure_kind(def_id);
     match needs_fn_once_adapter_shim(actual_kind, requested_kind) {
         Ok(true) => fn_once_adapter_instance(tcx, def_id, substs),
-        _ => ty::Instance::new(def_id, substs.substs)
+        _ => ty::Instance::new(def_id, substs.substs),
     }
 }
 
@@ -1858,40 +2126,39 @@ fn fn_once_adapter_instance<'a, 'tcx>(
     closure_did: DefId,
     substs: ty::ClosureSubsts<'tcx>,
 ) -> ty::Instance<'tcx> {
-    debug!("fn_once_adapter_shim({:?}, {:?})",
-           closure_did,
-           substs);
+    debug!("fn_once_adapter_shim({:?}, {:?})", closure_did, substs);
     let fn_once = tcx.lang_items.fn_once_trait().unwrap();
     let call_once = tcx.associated_items(fn_once)
         .find(|it| it.kind == ty::AssociatedKind::Method)
-        .unwrap().def_id;
+        .unwrap()
+        .def_id;
     let def = ty::InstanceDef::ClosureOnceShim { call_once };
 
-    let self_ty = tcx.mk_closure_from_closure_substs(
-        closure_did, substs);
+    let self_ty = tcx.mk_closure_from_closure_substs(closure_did, substs);
 
     let sig = tcx.fn_sig(closure_did).subst(tcx, substs.substs);
     let sig = tcx.erase_late_bound_regions_and_normalize(&sig);
     assert_eq!(sig.inputs().len(), 1);
-    let substs = tcx.mk_substs([
-        Kind::from(self_ty),
-        Kind::from(sig.inputs()[0]),
-    ].iter().cloned());
+    let substs = tcx.mk_substs(
+        [Kind::from(self_ty), Kind::from(sig.inputs()[0])]
+            .iter()
+            .cloned(),
+    );
 
     debug!("fn_once_adapter_shim: self_ty={:?} sig={:?}", self_ty, sig);
     ty::Instance { def, substs }
 }
 
-fn needs_fn_once_adapter_shim(actual_closure_kind: ty::ClosureKind,
-                              trait_closure_kind: ty::ClosureKind)
-                              -> Result<bool, ()>
-{
+fn needs_fn_once_adapter_shim(
+    actual_closure_kind: ty::ClosureKind,
+    trait_closure_kind: ty::ClosureKind,
+) -> Result<bool, ()> {
     match (actual_closure_kind, trait_closure_kind) {
         (ty::ClosureKind::Fn, ty::ClosureKind::Fn) |
         (ty::ClosureKind::FnMut, ty::ClosureKind::FnMut) |
         (ty::ClosureKind::FnOnce, ty::ClosureKind::FnOnce) => {
             // No adapter needed.
-           Ok(false)
+            Ok(false)
         }
         (ty::ClosureKind::Fn, ty::ClosureKind::FnMut) => {
             // The closure fn `llfn` is a `fn(&self, ...)`.  We want a
@@ -1920,10 +2187,9 @@ fn needs_fn_once_adapter_shim(actual_closure_kind: ty::ClosureKind,
 pub fn resolve<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     def_id: DefId,
-    substs: &'tcx Substs<'tcx>
+    substs: &'tcx Substs<'tcx>,
 ) -> ty::Instance<'tcx> {
-    debug!("resolve(def_id={:?}, substs={:?})",
-           def_id, substs);
+    debug!("resolve(def_id={:?}, substs={:?})", def_id, substs);
     let result = if let Some(trait_def_id) = tcx.trait_of_item(def_id) {
         debug!(" => associated item, attempting to find impl");
         let item = tcx.associated_item(def_id);
@@ -1931,12 +2197,11 @@ pub fn resolve<'a, 'tcx>(
     } else {
         let item_type = def_ty(tcx, def_id, substs);
         let def = match item_type.sty {
-            ty::TyFnDef(..) if {
-                    let f = item_type.fn_sig(tcx);
-                    f.abi() == Abi::RustIntrinsic ||
-                    f.abi() == Abi::PlatformIntrinsic
-                } =>
-            {
+            ty::TyFnDef(..)
+                if {
+                       let f = item_type.fn_sig(tcx);
+                       f.abi() == Abi::RustIntrinsic || f.abi() == Abi::PlatformIntrinsic
+                   } => {
                 debug!(" => intrinsic");
                 ty::InstanceDef::Intrinsic(def_id)
             }
@@ -1958,8 +2223,12 @@ pub fn resolve<'a, 'tcx>(
         };
         ty::Instance { def, substs }
     };
-    debug!("resolve(def_id={:?}, substs={:?}) = {}",
-           def_id, substs, result);
+    debug!(
+        "resolve(def_id={:?}, substs={:?}) = {}",
+        def_id,
+        substs,
+        result
+    );
     result
 }
 
@@ -1992,7 +2261,7 @@ pub fn needs_drop_glue<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, t: Ty<'tcx>) -> bo
                 true
             }
         }
-        _ => true
+        _ => true,
     }
 }
 
@@ -2000,13 +2269,17 @@ fn resolve_associated_item<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     trait_item: &ty::AssociatedItem,
     trait_id: DefId,
-    rcvr_substs: &'tcx Substs<'tcx>
+    rcvr_substs: &'tcx Substs<'tcx>,
 ) -> ty::Instance<'tcx> {
     let def_id = trait_item.def_id;
-    debug!("resolve_associated_item(trait_item={:?}, \
+    debug!(
+        "resolve_associated_item(trait_item={:?}, \
                                     trait_id={:?}, \
                                     rcvr_substs={:?})",
-           def_id, trait_id, rcvr_substs);
+        def_id,
+        trait_id,
+        rcvr_substs
+    );
 
     let trait_ref = ty::TraitRef::from_method(tcx, trait_id, rcvr_substs);
     let vtbl = fulfill_obligation(tcx, DUMMY_SP, ty::Binder(trait_ref));
@@ -2015,56 +2288,64 @@ fn resolve_associated_item<'a, 'tcx>(
     // the actual function:
     match vtbl {
         ::rustc::traits::VtableImpl(impl_data) => {
-            let (def_id, substs) = ::rustc::traits::find_associated_item(
-                tcx, trait_item, rcvr_substs, &impl_data);
+            let (def_id, substs) =
+                ::rustc::traits::find_associated_item(tcx, trait_item, rcvr_substs, &impl_data);
             let substs = tcx.erase_regions(&substs);
             ty::Instance::new(def_id, substs)
         }
         ::rustc::traits::VtableClosure(closure_data) => {
             let trait_closure_kind = tcx.lang_items.fn_trait_kind(trait_id).unwrap();
-            resolve_closure(tcx, closure_data.closure_def_id, closure_data.substs,
-                            trait_closure_kind)
+            resolve_closure(
+                tcx,
+                closure_data.closure_def_id,
+                closure_data.substs,
+                trait_closure_kind,
+            )
         }
         ::rustc::traits::VtableFnPointer(ref data) => {
             ty::Instance {
                 def: ty::InstanceDef::FnPtrShim(trait_item.def_id, data.fn_ty),
-                substs: rcvr_substs
+                substs: rcvr_substs,
             }
         }
         ::rustc::traits::VtableObject(ref data) => {
             let index = tcx.get_vtable_index_of_object_method(data, def_id);
             ty::Instance {
                 def: ty::InstanceDef::Virtual(def_id, index),
-                substs: rcvr_substs
+                substs: rcvr_substs,
             }
         }
-        _ => {
-            bug!("static call to invalid vtable: {:?}", vtbl)
-        }
+        _ => bug!("static call to invalid vtable: {:?}", vtbl),
     }
 }
 
-pub fn def_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                        def_id: DefId,
-                        substs: &'tcx Substs<'tcx>)
-                        -> Ty<'tcx>
-{
+pub fn def_ty<'a, 'tcx>(
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
+    def_id: DefId,
+    substs: &'tcx Substs<'tcx>,
+) -> Ty<'tcx> {
     let ty = tcx.type_of(def_id);
     apply_param_substs(tcx, substs, &ty)
 }
 
 /// Monomorphizes a type from the AST by first applying the in-scope
 /// substitutions and then normalizing any associated types.
-pub fn apply_param_substs<'a, 'tcx, T>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                       param_substs: &Substs<'tcx>,
-                                       value: &T)
-                                       -> T
-    where T: ::rustc::infer::TransNormalize<'tcx>
+pub fn apply_param_substs<'a, 'tcx, T>(
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
+    param_substs: &Substs<'tcx>,
+    value: &T,
+) -> T
+where
+    T: ::rustc::infer::TransNormalize<'tcx>,
 {
-    debug!("apply_param_substs(param_substs={:?}, value={:?})", param_substs, value);
+    debug!(
+        "apply_param_substs(param_substs={:?}, value={:?})",
+        param_substs,
+        value
+    );
     let substituted = value.subst(tcx, param_substs);
     let substituted = tcx.erase_regions(&substituted);
-    AssociatedTypeNormalizer{ tcx }.fold(&substituted)
+    AssociatedTypeNormalizer { tcx }.fold(&substituted)
 }
 
 
@@ -2105,27 +2386,31 @@ fn type_is_sized<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> bool {
 /// Attempts to resolve an obligation. The result is a shallow vtable resolution -- meaning that we
 /// do not (necessarily) resolve all nested obligations on the impl. Note that type check should
 /// guarantee to us that all nested obligations *could be* resolved if we wanted to.
-fn fulfill_obligation<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
-                                span: Span,
-                                trait_ref: ty::PolyTraitRef<'tcx>)
-                                -> traits::Vtable<'tcx, ()>
-{
+fn fulfill_obligation<'a, 'tcx>(
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
+    span: Span,
+    trait_ref: ty::PolyTraitRef<'tcx>,
+) -> traits::Vtable<'tcx, ()> {
     // Remove any references to regions; this helps improve caching.
     let trait_ref = tcx.erase_regions(&trait_ref);
 
-    debug!("trans::fulfill_obligation(trait_ref={:?}, def_id={:?})",
-            trait_ref, trait_ref.def_id());
+    debug!(
+        "trans::fulfill_obligation(trait_ref={:?}, def_id={:?})",
+        trait_ref,
+        trait_ref.def_id()
+    );
 
     // Do the initial selection for the obligation. This yields the
     // shallow result we are looking for -- that is, what specific impl.
     tcx.infer_ctxt().enter(|infcx| {
         let mut selcx = traits::SelectionContext::new(&infcx);
 
-        let obligation_cause = traits::ObligationCause::misc(span,
-                                                            ast::DUMMY_NODE_ID);
-        let obligation = traits::Obligation::new(obligation_cause,
-                                                 ty::ParamEnv::empty(Reveal::All),
-                                                 trait_ref.to_poly_trait_predicate());
+        let obligation_cause = traits::ObligationCause::misc(span, ast::DUMMY_NODE_ID);
+        let obligation = traits::Obligation::new(
+            obligation_cause,
+            ty::ParamEnv::empty(Reveal::All),
+            trait_ref.to_poly_trait_predicate(),
+        );
 
         let selection = match selcx.select(&obligation) {
             Ok(Some(selection)) => selection,
@@ -2136,16 +2421,24 @@ fn fulfill_obligation<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 // leading to an ambiguous result. So report this as an
                 // overflow bug, since I believe this is the only case
                 // where ambiguity can result.
-                debug!("Encountered ambiguity selecting `{:?}` during trans, \
+                debug!(
+                    "Encountered ambiguity selecting `{:?}` during trans, \
                         presuming due to overflow",
-                        trait_ref);
-                tcx.sess.span_fatal(span,
+                    trait_ref
+                );
+                tcx.sess.span_fatal(
+                    span,
                     "reached the recursion limit during monomorphization \
-                        (selection ambiguity)");
+                        (selection ambiguity)",
+                );
             }
             Err(e) => {
-                span_bug!(span, "Encountered error `{:?}` selecting `{:?}` during trans",
-                            e, trait_ref)
+                span_bug!(
+                    span,
+                    "Encountered error `{:?}` selecting `{:?}` during trans",
+                    e,
+                    trait_ref
+                )
             }
         };
 
@@ -2156,7 +2449,10 @@ fn fulfill_obligation<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         // inference of the impl's type parameters.
         let mut fulfill_cx = traits::FulfillmentContext::new();
         let vtable = selection.map(|predicate| {
-            debug!("fulfill_obligation: register_predicate_obligation {:?}", predicate);
+            debug!(
+                "fulfill_obligation: register_predicate_obligation {:?}",
+                predicate
+            );
             fulfill_cx.register_predicate_obligation(&infcx, predicate);
         });
         let vtable = infcx.drain_fulfillment_cx_or_panic(span, &mut fulfill_cx, &vtable);
@@ -2169,8 +2465,7 @@ fn fulfill_obligation<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 pub fn resolve_drop_in_place<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     ty: Ty<'tcx>,
-) -> ty::Instance<'tcx>
-{
+) -> ty::Instance<'tcx> {
     let def_id = tcx.require_lang_item(::rustc::middle::lang_items::DropInPlaceFnLangItem);
     let substs = tcx.intern_substs(&[Kind::from(ty)]);
     resolve(tcx, def_id, substs)

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -410,7 +410,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     fn type_layout_with_substs(&self, ty: Ty<'tcx>, substs: &'tcx Substs<'tcx>) -> EvalResult<'tcx, &'tcx Layout> {
-        // TODO(solson): Is this inefficient? Needs investigation.
+        // FIXME(solson): Is this inefficient? Needs investigation.
         let ty = self.monomorphize(ty, substs);
 
         ty.layout(self.tcx, ty::ParamEnv::empty(Reveal::All)).map_err(|layout| EvalErrorKind::Layout(layout).into())
@@ -482,7 +482,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         self.memory.locks_lifetime_ended(None);
         let frame = self.stack.pop().expect("tried to pop a stack frame, but there were none");
         if !self.stack.is_empty() {
-            // TODO: IS this the correct time to start considering these accesses as originating from the returned-to stack frame?
+            // FIXME: IS this the correct time to start considering these accesses as originating from the returned-to stack frame?
             let cur_frame = self.cur_frame();
             self.memory.set_cur_frame(cur_frame);
         }
@@ -698,7 +698,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                                     assert_eq!(self.type_size(operand_ty)?, Some(0));
                                 }
                                 let (offset, TyAndPacked { ty, packed: _}) = self.nonnull_offset_and_ty(dest_ty, nndiscr, discrfield_source)?;
-                                // TODO: The packed flag is ignored
+                                // FIXME: The packed flag is ignored
 
                                 // FIXME(solson)
                                 let dest = self.force_allocation(dest)?.to_ptr()?;
@@ -1377,7 +1377,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     RawNullablePointer { value, .. } => {
                         use rustc::ty::layout::Primitive::*;
                         match value {
-                            // TODO(solson): Does signedness matter here? What should the sign be?
+                            // FIXME(solson): Does signedness matter here? What should the sign be?
                             Int(int) => PrimValKind::from_uint_size(int.size().bytes()),
                             F32 => PrimValKind::F32,
                             F64 => PrimValKind::F64,
@@ -1595,7 +1595,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     return self.unsize_into_ptr(src, src_ty, dest, dest_ty, src_ty.boxed_ty(), dest_ty.boxed_ty());
                 }
                 if self.ty_to_primval_kind(src_ty).is_ok() {
-                    // TODO: We ignore the packed flag here
+                    // FIXME: We ignore the packed flag here
                     let sty = self.get_field_ty(src_ty, 0)?.ty;
                     let dty = self.get_field_ty(dest_ty, 0)?.ty;
                     return self.unsize_into(src, sty, dest, dty);
@@ -1613,7 +1613,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 //let dst = adt::MaybeSizedValue::sized(dst);
                 let src_ptr = match src {
                     Value::ByRef { ptr, aligned: true } => ptr,
-                    // TODO: Is it possible for unaligned pointers to occur here?
+                    // FIXME: Is it possible for unaligned pointers to occur here?
                     _ => bug!("expected aligned pointer, got {:?}", src),
                 };
 
@@ -1818,7 +1818,7 @@ impl<'tcx> Frame<'tcx> {
     }
 }
 
-// TODO(solson): Upstream these methods into rustc::ty::layout.
+// FIXME(solson): Upstream these methods into rustc::ty::layout.
 
 pub(super) trait IntegerExt {
     fn size(self) -> Size;

--- a/src/librustc_mir/interpret/lvalue.rs
+++ b/src/librustc_mir/interpret/lvalue.rs
@@ -90,7 +90,8 @@ impl<'tcx> Lvalue<'tcx> {
 
     pub fn to_ptr(self) -> EvalResult<'tcx, MemoryPointer> {
         let (ptr, extra, _aligned) = self.to_ptr_extra_aligned();
-        // At this point, we forget about the alignment information -- the lvalue has been turned into a reference,
+        // At this point, we forget about the alignment information
+        // -- the lvalue has been turned into a reference,
         // and no matter where it came from, it now must be aligned.
         assert_eq!(extra, LvalueExtra::None);
         ptr.to_ptr()
@@ -146,7 +147,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     ) -> EvalResult<'tcx, Option<Value>> {
         use rustc::mir::Lvalue::*;
         match *lvalue {
-            // Might allow this in the future, right now there's no way to do this from Rust code anyway
+            // Might allow this in the future,
+            // right now there's no way to do this from Rust code anyway
             Local(mir::RETURN_POINTER) => err!(ReadFromReturnPointer),
             // Directly reading a local will always succeed
             Local(local) => self.frame().get_local(local).map(Some),
@@ -449,7 +451,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         outer_ty: Ty<'tcx>,
         n: u64,
     ) -> EvalResult<'tcx, Lvalue<'tcx>> {
-        // Taking the outer type here may seem odd; it's needed because for array types, the outer type gives away the length.
+        // Taking the outer type here may seem odd;
+        // it's needed because for array types, the outer type gives away the length.
         let base = self.force_allocation(base)?;
         let (base_ptr, _, aligned) = base.to_ptr_extra_aligned();
 

--- a/src/librustc_mir/interpret/lvalue.rs
+++ b/src/librustc_mir/interpret/lvalue.rs
@@ -4,13 +4,7 @@ use rustc::ty::{self, Ty};
 use rustc_data_structures::indexed_vec::Idx;
 use syntax::ast::Mutability;
 
-use super::{
-    EvalResult,
-    EvalContext,
-    MemoryPointer,
-    PrimVal, Value, Pointer,
-    Machine,
-};
+use super::{EvalResult, EvalContext, MemoryPointer, PrimVal, Value, Pointer, Machine};
 
 #[derive(Copy, Clone, Debug)]
 pub enum Lvalue<'tcx> {
@@ -27,10 +21,7 @@ pub enum Lvalue<'tcx> {
 
     /// An lvalue referring to a value on the stack. Represented by a stack frame index paired with
     /// a Mir local index.
-    Local {
-        frame: usize,
-        local: mir::Local,
-    },
+    Local { frame: usize, local: mir::Local },
 
     /// An lvalue referring to a global
     Global(GlobalId<'tcx>),
@@ -74,7 +65,11 @@ impl<'tcx> Lvalue<'tcx> {
     }
 
     pub fn from_primval_ptr(ptr: Pointer) -> Self {
-        Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true }
+        Lvalue::Ptr {
+            ptr,
+            extra: LvalueExtra::None,
+            aligned: true,
+        }
     }
 
     pub fn from_ptr(ptr: MemoryPointer) -> Self {
@@ -83,7 +78,11 @@ impl<'tcx> Lvalue<'tcx> {
 
     pub(super) fn to_ptr_extra_aligned(self) -> (Pointer, LvalueExtra, bool) {
         match self {
-            Lvalue::Ptr { ptr, extra, aligned } => (ptr, extra, aligned),
+            Lvalue::Ptr {
+                ptr,
+                extra,
+                aligned,
+            } => (ptr, extra, aligned),
             _ => bug!("to_ptr_and_extra: expected Lvalue::Ptr, got {:?}", self),
 
         }
@@ -104,7 +103,12 @@ impl<'tcx> Lvalue<'tcx> {
             ty::TySlice(elem) => {
                 match self {
                     Lvalue::Ptr { extra: LvalueExtra::Length(len), .. } => (elem, len),
-                    _ => bug!("elem_ty_and_len of a TySlice given non-slice lvalue: {:?}", self),
+                    _ => {
+                        bug!(
+                            "elem_ty_and_len of a TySlice given non-slice lvalue: {:?}",
+                            self
+                        )
+                    }
                 }
             }
 
@@ -136,7 +140,10 @@ impl<'tcx> Global<'tcx> {
 impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     /// Reads a value from the lvalue without going through the intermediate step of obtaining
     /// a `miri::Lvalue`
-    pub fn try_read_lvalue(&mut self, lvalue: &mir::Lvalue<'tcx>) -> EvalResult<'tcx, Option<Value>> {
+    pub fn try_read_lvalue(
+        &mut self,
+        lvalue: &mir::Lvalue<'tcx>,
+    ) -> EvalResult<'tcx, Option<Value>> {
         use rustc::mir::Lvalue::*;
         match *lvalue {
             // Might allow this in the future, right now there's no way to do this from Rust code anyway
@@ -146,14 +153,22 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             // Directly reading a static will always succeed
             Static(ref static_) => {
                 let instance = ty::Instance::mono(self.tcx, static_.def_id);
-                let cid = GlobalId { instance, promoted: None };
-                Ok(Some(self.globals.get(&cid).expect("global not cached").value))
-            },
+                let cid = GlobalId {
+                    instance,
+                    promoted: None,
+                };
+                Ok(Some(
+                    self.globals.get(&cid).expect("global not cached").value,
+                ))
+            }
             Projection(ref proj) => self.try_read_lvalue_projection(proj),
         }
     }
 
-    fn try_read_lvalue_projection(&mut self, proj: &mir::LvalueProjection<'tcx>) -> EvalResult<'tcx, Option<Value>> {
+    fn try_read_lvalue_projection(
+        &mut self,
+        proj: &mir::LvalueProjection<'tcx>,
+    ) -> EvalResult<'tcx, Option<Value>> {
         use rustc::mir::ProjectionElem::*;
         let base = match self.try_read_lvalue(&proj.base)? {
             Some(base) => base,
@@ -184,7 +199,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     /// Returns a value and (in case of a ByRef) if we are supposed to use aligned accesses.
-    pub(super) fn eval_and_read_lvalue(&mut self, lvalue: &mir::Lvalue<'tcx>) -> EvalResult<'tcx, Value> {
+    pub(super) fn eval_and_read_lvalue(
+        &mut self,
+        lvalue: &mir::Lvalue<'tcx>,
+    ) -> EvalResult<'tcx, Value> {
         // Shortcut for things like accessing a fat pointer's field,
         // which would otherwise (in the `eval_lvalue` path) require moving a `ByValPair` to memory
         // and returning an `Lvalue::Ptr` to it
@@ -197,28 +215,37 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
     pub fn read_lvalue(&self, lvalue: Lvalue<'tcx>) -> EvalResult<'tcx, Value> {
         match lvalue {
-            Lvalue::Ptr { ptr, extra, aligned } => {
+            Lvalue::Ptr {
+                ptr,
+                extra,
+                aligned,
+            } => {
                 assert_eq!(extra, LvalueExtra::None);
                 Ok(Value::ByRef { ptr, aligned })
             }
-            Lvalue::Local { frame, local } => {
-                self.stack[frame].get_local(local)
-            }
-            Lvalue::Global(cid) => {
-                Ok(self.globals.get(&cid).expect("global not cached").value)
-            }
+            Lvalue::Local { frame, local } => self.stack[frame].get_local(local),
+            Lvalue::Global(cid) => Ok(self.globals.get(&cid).expect("global not cached").value),
         }
     }
 
-    pub fn eval_lvalue(&mut self, mir_lvalue: &mir::Lvalue<'tcx>) -> EvalResult<'tcx, Lvalue<'tcx>> {
+    pub fn eval_lvalue(
+        &mut self,
+        mir_lvalue: &mir::Lvalue<'tcx>,
+    ) -> EvalResult<'tcx, Lvalue<'tcx>> {
         use rustc::mir::Lvalue::*;
         let lvalue = match *mir_lvalue {
             Local(mir::RETURN_POINTER) => self.frame().return_lvalue,
-            Local(local) => Lvalue::Local { frame: self.cur_frame(), local },
+            Local(local) => Lvalue::Local {
+                frame: self.cur_frame(),
+                local,
+            },
 
             Static(ref static_) => {
                 let instance = ty::Instance::mono(self.tcx, static_.def_id);
-                Lvalue::Global(GlobalId { instance, promoted: None })
+                Lvalue::Global(GlobalId {
+                    instance,
+                    promoted: None,
+                })
             }
 
             Projection(ref proj) => {
@@ -245,15 +272,16 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         let base_layout = self.type_layout(base_ty)?;
         use rustc::ty::layout::Layout::*;
         let (offset, packed) = match *base_layout {
-            Univariant { ref variant, .. } => {
-                (variant.offsets[field_index], variant.packed)
-            },
+            Univariant { ref variant, .. } => (variant.offsets[field_index], variant.packed),
 
             General { ref variants, .. } => {
                 let (_, base_extra, _) = base.to_ptr_extra_aligned();
                 if let LvalueExtra::DowncastVariant(variant_idx) = base_extra {
                     // +1 for the discriminant, which is field 0
-                    (variants[variant_idx].offsets[field_index + 1], variants[variant_idx].packed)
+                    (
+                        variants[variant_idx].offsets[field_index + 1],
+                        variants[variant_idx].packed,
+                    )
                 } else {
                     bug!("field access on enum had no variant index");
                 }
@@ -284,8 +312,13 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     ty::TyArray(elem_ty, n) => {
                         assert!(field < n as u64);
                         self.type_size(elem_ty)?.expect("array elements are sized") as u64
-                    },
-                    _ => bug!("lvalue_field: got Array layout but non-array type {:?}", base_ty),
+                    }
+                    _ => {
+                        bug!(
+                            "lvalue_field: got Array layout but non-array type {:?}",
+                            base_ty
+                        )
+                    }
                 };
                 (Size::from_bytes(field * elem_size), false)
             }
@@ -301,33 +334,60 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
         // Do not allocate in trivial cases
         let (base_ptr, base_extra, aligned) = match base {
-            Lvalue::Ptr { ptr, extra, aligned } => (ptr, extra, aligned),
-            Lvalue::Local { frame, local } => match self.stack[frame].get_local(local)? {
-                // in case the type has a single field, just return the value
-                Value::ByVal(_) if self.get_field_count(base_ty).map(|c| c == 1).unwrap_or(false) => {
-                    assert_eq!(offset.bytes(), 0, "ByVal can only have 1 non zst field with offset 0");
-                    return Ok(base);
-                },
-                Value::ByRef{..} |
-                Value::ByValPair(..) |
-                Value::ByVal(_) => self.force_allocation(base)?.to_ptr_extra_aligned(),
-            },
-            Lvalue::Global(cid) => match self.globals.get(&cid).expect("uncached global").value {
-                // in case the type has a single field, just return the value
-                Value::ByVal(_) if self.get_field_count(base_ty).map(|c| c == 1).unwrap_or(false) => {
-                    assert_eq!(offset.bytes(), 0, "ByVal can only have 1 non zst field with offset 0");
-                    return Ok(base);
-                },
-                Value::ByRef{..} |
-                Value::ByValPair(..) |
-                Value::ByVal(_) => self.force_allocation(base)?.to_ptr_extra_aligned(),
-            },
+            Lvalue::Ptr {
+                ptr,
+                extra,
+                aligned,
+            } => (ptr, extra, aligned),
+            Lvalue::Local { frame, local } => {
+                match self.stack[frame].get_local(local)? {
+                    // in case the type has a single field, just return the value
+                    Value::ByVal(_)
+                        if self.get_field_count(base_ty).map(|c| c == 1).unwrap_or(
+                            false,
+                        ) => {
+                        assert_eq!(
+                            offset.bytes(),
+                            0,
+                            "ByVal can only have 1 non zst field with offset 0"
+                        );
+                        return Ok(base);
+                    }
+                    Value::ByRef { .. } |
+                    Value::ByValPair(..) |
+                    Value::ByVal(_) => self.force_allocation(base)?.to_ptr_extra_aligned(),
+                }
+            }
+            Lvalue::Global(cid) => {
+                match self.globals.get(&cid).expect("uncached global").value {
+                    // in case the type has a single field, just return the value
+                    Value::ByVal(_)
+                        if self.get_field_count(base_ty).map(|c| c == 1).unwrap_or(
+                            false,
+                        ) => {
+                        assert_eq!(
+                            offset.bytes(),
+                            0,
+                            "ByVal can only have 1 non zst field with offset 0"
+                        );
+                        return Ok(base);
+                    }
+                    Value::ByRef { .. } |
+                    Value::ByValPair(..) |
+                    Value::ByVal(_) => self.force_allocation(base)?.to_ptr_extra_aligned(),
+                }
+            }
         };
 
         let offset = match base_extra {
             LvalueExtra::Vtable(tab) => {
-                let (_, align) = self.size_and_align_of_dst(base_ty, base_ptr.to_value_with_vtable(tab))?;
-                offset.abi_align(Align::from_bytes(align, align).unwrap()).bytes()
+                let (_, align) = self.size_and_align_of_dst(
+                    base_ty,
+                    base_ptr.to_value_with_vtable(tab),
+                )?;
+                offset
+                    .abi_align(Align::from_bytes(align, align).unwrap())
+                    .bytes()
             }
             _ => offset.bytes(),
         };
@@ -341,41 +401,74 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         } else {
             match base_extra {
                 LvalueExtra::None => bug!("expected fat pointer"),
-                LvalueExtra::DowncastVariant(..) =>
-                    bug!("Rust doesn't support unsized fields in enum variants"),
+                LvalueExtra::DowncastVariant(..) => {
+                    bug!("Rust doesn't support unsized fields in enum variants")
+                }
                 LvalueExtra::Vtable(_) |
-                LvalueExtra::Length(_) => {},
+                LvalueExtra::Length(_) => {}
             }
             base_extra
         };
 
-        Ok(Lvalue::Ptr { ptr, extra, aligned: aligned && !packed })
+        Ok(Lvalue::Ptr {
+            ptr,
+            extra,
+            aligned: aligned && !packed,
+        })
     }
 
     pub(super) fn val_to_lvalue(&self, val: Value, ty: Ty<'tcx>) -> EvalResult<'tcx, Lvalue<'tcx>> {
         Ok(match self.tcx.struct_tail(ty).sty {
             ty::TyDynamic(..) => {
                 let (ptr, vtable) = val.into_ptr_vtable_pair(&self.memory)?;
-                Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable), aligned: true }
-            },
+                Lvalue::Ptr {
+                    ptr,
+                    extra: LvalueExtra::Vtable(vtable),
+                    aligned: true,
+                }
+            }
             ty::TyStr | ty::TySlice(_) => {
                 let (ptr, len) = val.into_slice(&self.memory)?;
-                Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len), aligned: true }
+                Lvalue::Ptr {
+                    ptr,
+                    extra: LvalueExtra::Length(len),
+                    aligned: true,
+                }
+            }
+            _ => Lvalue::Ptr {
+                ptr: val.into_ptr(&self.memory)?,
+                extra: LvalueExtra::None,
+                aligned: true,
             },
-            _ => Lvalue::Ptr { ptr: val.into_ptr(&self.memory)?, extra: LvalueExtra::None, aligned: true },
         })
     }
 
-    pub(super) fn lvalue_index(&mut self, base: Lvalue<'tcx>, outer_ty: Ty<'tcx>, n: u64) -> EvalResult<'tcx, Lvalue<'tcx>> {
+    pub(super) fn lvalue_index(
+        &mut self,
+        base: Lvalue<'tcx>,
+        outer_ty: Ty<'tcx>,
+        n: u64,
+    ) -> EvalResult<'tcx, Lvalue<'tcx>> {
         // Taking the outer type here may seem odd; it's needed because for array types, the outer type gives away the length.
         let base = self.force_allocation(base)?;
         let (base_ptr, _, aligned) = base.to_ptr_extra_aligned();
 
         let (elem_ty, len) = base.elem_ty_and_len(outer_ty);
-        let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized");
-        assert!(n < len, "Tried to access element {} of array/slice with length {}", n, len);
+        let elem_size = self.type_size(elem_ty)?.expect(
+            "slice element must be sized",
+        );
+        assert!(
+            n < len,
+            "Tried to access element {} of array/slice with length {}",
+            n,
+            len
+        );
         let ptr = base_ptr.offset(n * elem_size, self.memory.layout)?;
-        Ok(Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned })
+        Ok(Lvalue::Ptr {
+            ptr,
+            extra: LvalueExtra::None,
+            aligned,
+        })
     }
 
     pub(super) fn eval_lvalue_projection(
@@ -399,7 +492,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 use rustc::ty::layout::Layout::*;
                 let extra = match *base_layout {
                     General { .. } => LvalueExtra::DowncastVariant(variant),
-                    RawNullablePointer { .. } | StructWrappedNullablePointer { .. } => base_extra,
+                    RawNullablePointer { .. } |
+                    StructWrappedNullablePointer { .. } => base_extra,
                     _ => bug!("variant downcast on non-aggregate: {:?}", base_layout),
                 };
                 (base_ptr, extra, aligned)
@@ -428,13 +522,19 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 return self.lvalue_index(base, base_ty, n);
             }
 
-            ConstantIndex { offset, min_length, from_end } => {
+            ConstantIndex {
+                offset,
+                min_length,
+                from_end,
+            } => {
                 // FIXME(solson)
                 let base = self.force_allocation(base)?;
                 let (base_ptr, _, aligned) = base.to_ptr_extra_aligned();
 
                 let (elem_ty, n) = base.elem_ty_and_len(base_ty);
-                let elem_size = self.type_size(elem_ty)?.expect("sequence element must be sized");
+                let elem_size = self.type_size(elem_ty)?.expect(
+                    "sequence element must be sized",
+                );
                 assert!(n >= min_length as u64);
 
                 let index = if from_end {
@@ -453,7 +553,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 let (base_ptr, _, aligned) = base.to_ptr_extra_aligned();
 
                 let (elem_ty, n) = base.elem_ty_and_len(base_ty);
-                let elem_size = self.type_size(elem_ty)?.expect("slice element must be sized");
+                let elem_size = self.type_size(elem_ty)?.expect(
+                    "slice element must be sized",
+                );
                 assert!(u64::from(from) <= n - u64::from(to));
                 let ptr = base_ptr.offset(u64::from(from) * elem_size, &self)?;
                 let extra = LvalueExtra::Length(n - u64::from(to) - u64::from(from));
@@ -461,10 +563,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             }
         };
 
-        Ok(Lvalue::Ptr { ptr, extra, aligned })
+        Ok(Lvalue::Ptr {
+            ptr,
+            extra,
+            aligned,
+        })
     }
 
     pub(super) fn lvalue_ty(&self, lvalue: &mir::Lvalue<'tcx>) -> Ty<'tcx> {
-        self.monomorphize(lvalue.ty(self.mir(), self.tcx).to_ty(self.tcx), self.substs())
+        self.monomorphize(
+            lvalue.ty(self.mir(), self.tcx).to_ty(self.tcx),
+            self.substs(),
+        )
     }
 }

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -2,12 +2,7 @@
 //! This separation exists to ensure that no fancy miri features like
 //! interpreting common C functions leak into CTFE.
 
-use super::{
-    EvalResult,
-    EvalContext,
-    Lvalue,
-    PrimVal
-};
+use super::{EvalResult, EvalContext, Lvalue, PrimVal};
 
 use rustc::{mir, ty};
 use syntax::codemap::Span;
@@ -76,4 +71,3 @@ pub trait Machine<'tcx>: Sized {
         ty: ty::Ty<'tcx>,
     ) -> EvalResult<'tcx, PrimVal>;
 }
-

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -8,12 +8,7 @@ use rustc::ty::layout::{self, TargetDataLayout, HasDataLayout};
 use syntax::ast::Mutability;
 use rustc::middle::region::CodeExtent;
 
-use super::{
-    EvalResult, EvalErrorKind,
-    PrimVal, Pointer,
-    EvalContext, DynamicLifetime,
-    Machine,
-};
+use super::{EvalResult, EvalErrorKind, PrimVal, Pointer, EvalContext, DynamicLifetime, Machine};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Locks
@@ -134,19 +129,35 @@ pub struct Allocation<M> {
 }
 
 impl<M> Allocation<M> {
-    fn iter_locks<'a>(&'a self, offset: u64, len: u64) -> impl Iterator<Item=(&'a MemoryRange, &'a LockInfo)> + 'a {
-        self.locks.range(MemoryRange::range(offset, len))
+    fn iter_locks<'a>(
+        &'a self,
+        offset: u64,
+        len: u64,
+    ) -> impl Iterator<Item = (&'a MemoryRange, &'a LockInfo)> + 'a {
+        self.locks.range(MemoryRange::range(offset, len)).filter(
+            move |&(range, _)| range.overlaps(offset, len),
+        )
+    }
+
+    fn iter_locks_mut<'a>(
+        &'a mut self,
+        offset: u64,
+        len: u64,
+    ) -> impl Iterator<Item = (&'a MemoryRange, &'a mut LockInfo)> + 'a {
+        self.locks
+            .range_mut(MemoryRange::range(offset, len))
             .filter(move |&(range, _)| range.overlaps(offset, len))
     }
 
-    fn iter_locks_mut<'a>(&'a mut self, offset: u64, len: u64) -> impl Iterator<Item=(&'a MemoryRange, &'a mut LockInfo)> + 'a {
-        self.locks.range_mut(MemoryRange::range(offset, len))
-            .filter(move |&(range, _)| range.overlaps(offset, len))
-    }
-
-    fn check_locks<'tcx>(&self, frame: Option<usize>, offset: u64, len: u64, access: AccessKind) -> Result<(), LockInfo> {
+    fn check_locks<'tcx>(
+        &self,
+        frame: Option<usize>,
+        offset: u64,
+        len: u64,
+        access: AccessKind,
+    ) -> Result<(), LockInfo> {
         if len == 0 {
-            return Ok(())
+            return Ok(());
         }
         for (_, lock) in self.iter_locks(offset, len) {
             // Check if the lock is in conflict with the access.
@@ -185,7 +196,10 @@ impl<'tcx> MemoryPointer {
     }
 
     pub(crate) fn wrapping_signed_offset<C: HasDataLayout>(self, i: i64, cx: C) -> Self {
-        MemoryPointer::new(self.alloc_id, cx.data_layout().wrapping_signed_offset(self.offset, i))
+        MemoryPointer::new(
+            self.alloc_id,
+            cx.data_layout().wrapping_signed_offset(self.offset, i),
+        )
     }
 
     pub fn overflowing_signed_offset<C: HasDataLayout>(self, i: i128, cx: C) -> (Self, bool) {
@@ -194,7 +208,10 @@ impl<'tcx> MemoryPointer {
     }
 
     pub(crate) fn signed_offset<C: HasDataLayout>(self, i: i64, cx: C) -> EvalResult<'tcx, Self> {
-        Ok(MemoryPointer::new(self.alloc_id, cx.data_layout().signed_offset(self.offset, i)?))
+        Ok(MemoryPointer::new(
+            self.alloc_id,
+            cx.data_layout().signed_offset(self.offset, i)?,
+        ))
     }
 
     pub fn overflowing_offset<C: HasDataLayout>(self, i: u64, cx: C) -> (Self, bool) {
@@ -203,7 +220,10 @@ impl<'tcx> MemoryPointer {
     }
 
     pub fn offset<C: HasDataLayout>(self, i: u64, cx: C) -> EvalResult<'tcx, Self> {
-        Ok(MemoryPointer::new(self.alloc_id, cx.data_layout().offset(self.offset, i)?))
+        Ok(MemoryPointer::new(
+            self.alloc_id,
+            cx.data_layout().offset(self.offset, i)?,
+        ))
     }
 }
 
@@ -275,7 +295,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         }
     }
 
-    pub fn allocations(&self) -> ::std::collections::hash_map::Iter<AllocId, Allocation<M::MemoryKinds>> {
+    pub fn allocations(
+        &self,
+    ) -> ::std::collections::hash_map::Iter<AllocId, Allocation<M::MemoryKinds>> {
         self.alloc_map.iter()
     }
 
@@ -296,10 +318,20 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             return Ok(MemoryPointer::new(alloc_id, 0));
         }
 
-        let ptr = self.allocate(bytes.len() as u64, 1, Kind::UninitializedStatic)?;
+        let ptr = self.allocate(
+            bytes.len() as u64,
+            1,
+            Kind::UninitializedStatic,
+        )?;
         self.write_bytes(ptr.into(), bytes)?;
-        self.mark_static_initalized(ptr.alloc_id, Mutability::Immutable)?;
-        self.literal_alloc_cache.insert(bytes.to_vec(), ptr.alloc_id);
+        self.mark_static_initalized(
+            ptr.alloc_id,
+            Mutability::Immutable,
+        )?;
+        self.literal_alloc_cache.insert(
+            bytes.to_vec(),
+            ptr.alloc_id,
+        );
         Ok(ptr)
     }
 
@@ -352,13 +384,23 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         }
         if let Ok(alloc) = self.get(ptr.alloc_id) {
             if alloc.kind != kind {
-                return err!(ReallocatedWrongMemoryKind(format!("{:?}", alloc.kind), format!("{:?}", kind)));
+                return err!(ReallocatedWrongMemoryKind(
+                    format!("{:?}", alloc.kind),
+                    format!("{:?}", kind),
+                ));
             }
         }
 
         // For simplicities' sake, we implement reallocate as "alloc, copy, dealloc"
         let new_ptr = self.allocate(new_size, new_align, kind)?;
-        self.copy(ptr.into(), new_ptr.into(), min(old_size, new_size), min(old_align, new_align), /*nonoverlapping*/true)?;
+        self.copy(
+            ptr.into(),
+            new_ptr.into(),
+            min(old_size, new_size),
+            min(old_align, new_align),
+            /*nonoverlapping*/
+            true,
+        )?;
         self.deallocate(ptr, Some((old_size, old_align)), kind)?;
 
         Ok(new_ptr)
@@ -384,11 +426,20 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         // However, we should check *something*.  For now, we make sure that there is no conflicting write
         // lock by another frame.  We *have* to permit deallocation if we hold a read lock.
         // FIXME: Figure out the exact rules here.
-        alloc.check_locks(Some(self.cur_frame), 0, alloc.bytes.len() as u64, AccessKind::Read)
+        alloc
+            .check_locks(
+                Some(self.cur_frame),
+                0,
+                alloc.bytes.len() as u64,
+                AccessKind::Read,
+            )
             .map_err(|lock| EvalErrorKind::DeallocatedLockedMemory { ptr, lock })?;
 
         if alloc.kind != kind {
-            return err!(DeallocatedWrongMemoryKind(format!("{:?}", alloc.kind), format!("{:?}", kind)));
+            return err!(DeallocatedWrongMemoryKind(
+                format!("{:?}", alloc.kind),
+                format!("{:?}", kind),
+            ));
         }
         if let Some((size, align)) = size_and_align {
             if size != alloc.bytes.len() as u64 || align != alloc.align {
@@ -422,14 +473,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
                     });
                 }
                 ptr.offset
-            },
+            }
             PrimVal::Bytes(bytes) => {
                 let v = ((bytes as u128) % (1 << self.pointer_size())) as u64;
                 if v == 0 {
                     return err!(InvalidNullPointerUsage);
                 }
                 v
-            },
+            }
             PrimVal::Undef => return err!(ReadUndefBytes),
         };
         if offset % align == 0 {
@@ -446,7 +497,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         let alloc = self.get(ptr.alloc_id)?;
         let allocation_size = alloc.bytes.len() as u64;
         if ptr.offset > allocation_size {
-            return err!(PointerOutOfBounds { ptr, access, allocation_size });
+            return err!(PointerOutOfBounds {
+                ptr,
+                access,
+                allocation_size,
+            });
         }
         Ok(())
     }
@@ -458,40 +513,84 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
 /// Locking
 impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
-    pub(crate) fn check_locks(&self, ptr: MemoryPointer, len: u64, access: AccessKind) -> EvalResult<'tcx> {
+    pub(crate) fn check_locks(
+        &self,
+        ptr: MemoryPointer,
+        len: u64,
+        access: AccessKind,
+    ) -> EvalResult<'tcx> {
         if len == 0 {
-            return Ok(())
+            return Ok(());
         }
         let alloc = self.get(ptr.alloc_id)?;
         let frame = self.cur_frame;
-        alloc.check_locks(Some(frame), ptr.offset, len, access)
-            .map_err(|lock| EvalErrorKind::MemoryLockViolation { ptr, len, frame, access, lock }.into())
+        alloc
+            .check_locks(Some(frame), ptr.offset, len, access)
+            .map_err(|lock| {
+                EvalErrorKind::MemoryLockViolation {
+                    ptr,
+                    len,
+                    frame,
+                    access,
+                    lock,
+                }.into()
+            })
     }
 
     /// Acquire the lock for the given lifetime
-    pub(crate) fn acquire_lock(&mut self, ptr: MemoryPointer, len: u64, region: Option<CodeExtent>, kind: AccessKind) -> EvalResult<'tcx> {
+    pub(crate) fn acquire_lock(
+        &mut self,
+        ptr: MemoryPointer,
+        len: u64,
+        region: Option<CodeExtent>,
+        kind: AccessKind,
+    ) -> EvalResult<'tcx> {
         use std::collections::btree_map::Entry::*;
 
         let frame = self.cur_frame;
         assert!(len > 0);
-        trace!("Frame {} acquiring {:?} lock at {:?}, size {} for region {:?}", frame, kind, ptr, len, region);
+        trace!(
+            "Frame {} acquiring {:?} lock at {:?}, size {} for region {:?}",
+            frame,
+            kind,
+            ptr,
+            len,
+            region
+        );
         self.check_bounds(ptr.offset(len, self.layout)?, true)?; // if ptr.offset is in bounds, then so is ptr (because offset checks for overflow)
         let alloc = self.get_mut_unchecked(ptr.alloc_id)?;
 
         // Check if this conflicts with other locks
-        alloc.check_locks(None, ptr.offset, len, kind)
-            .map_err(|lock| EvalErrorKind::MemoryAcquireConflict { ptr, len, kind, lock })?;
+        alloc.check_locks(None, ptr.offset, len, kind).map_err(
+            |lock| {
+                EvalErrorKind::MemoryAcquireConflict {
+                    ptr,
+                    len,
+                    kind,
+                    lock,
+                }
+            },
+        )?;
 
         let lifetime = DynamicLifetime { frame, region };
         match (alloc.locks.entry(MemoryRange::new(ptr.offset, len)), kind) {
-            (Vacant(entry), AccessKind::Read) => { entry.insert(ReadLock(vec![lifetime])); },
-            (Vacant(entry), AccessKind::Write) => { entry.insert(WriteLock(lifetime)); },
-            (Occupied(mut entry), AccessKind::Read) =>
+            (Vacant(entry), AccessKind::Read) => {
+                entry.insert(ReadLock(vec![lifetime]));
+            }
+            (Vacant(entry), AccessKind::Write) => {
+                entry.insert(WriteLock(lifetime));
+            }
+            (Occupied(mut entry), AccessKind::Read) => {
                 match *entry.get_mut() {
                     ReadLock(ref mut lifetimes) => lifetimes.push(lifetime),
-                    WriteLock(_) => bug!("We already checked that there is no conflicting write lock"),
-                },
-            (Occupied(_), AccessKind::Write) => bug!("We already checked that there is no conflicting lock"),
+                    WriteLock(_) => {
+                        bug!("We already checked that there is no conflicting write lock")
+                    }
+                }
+            }
+            (Occupied(_), AccessKind::Write) => {
+                bug!("We already checked that there is no conflicting lock")
+            }
         };
         Ok(())
     }
@@ -502,24 +601,36 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         let cur_frame = self.cur_frame;
         let alloc = self.get_mut_unchecked(ptr.alloc_id)?;
 
-        let mut remove_list : Vec<MemoryRange> = Vec::new();
+        let mut remove_list: Vec<MemoryRange> = Vec::new();
         for (range, lock) in alloc.iter_locks_mut(ptr.offset, len) {
             match *lock {
                 WriteLock(ref lft) => {
                     // Make sure we can release this lock
                     if lft.frame != cur_frame {
-                        return err!(InvalidMemoryLockRelease { ptr, len, frame: cur_frame, lock: lock.clone() });
+                        return err!(InvalidMemoryLockRelease {
+                            ptr,
+                            len,
+                            frame: cur_frame,
+                            lock: lock.clone(),
+                        });
                     }
                     if !range.contained_in(ptr.offset, len) {
-                        return err!(Unimplemented(format!("miri does not support releasing part of a write-locked region")));
+                        return err!(Unimplemented(format!(
+                            "miri does not support releasing part of a write-locked region"
+                        )));
                     }
                     // Release it later.  We cannot do this now.
                     remove_list.push(*range);
                 }
                 ReadLock(_) => {
                     // Abort here and bubble the error outwards so that we do not even register a suspension.
-                    return err!(InvalidMemoryLockRelease { ptr, len, frame: cur_frame, lock: lock.clone() });
-                },
+                    return err!(InvalidMemoryLockRelease {
+                        ptr,
+                        len,
+                        frame: cur_frame,
+                        lock: lock.clone(),
+                    });
+                }
             }
         }
 
@@ -535,22 +646,26 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
     pub(crate) fn locks_lifetime_ended(&mut self, ending_region: Option<CodeExtent>) {
         let cur_frame = self.cur_frame;
-        trace!("Releasing frame {} locks that expire at {:?}", cur_frame, ending_region);
-        let has_ended =  |lifetime: &DynamicLifetime| -> bool {
+        trace!(
+            "Releasing frame {} locks that expire at {:?}",
+            cur_frame,
+            ending_region
+        );
+        let has_ended = |lifetime: &DynamicLifetime| -> bool {
             if lifetime.frame != cur_frame {
                 return false;
             }
             match ending_region {
                 None => true, // When a function ends, we end *all* its locks. It's okay for a function to still have lifetime-related locks
-                              // when it returns, that can happen e.g. with NLL when a lifetime can, but does not have to, extend beyond the
-                              // end of a function.  Same for a function still having recoveries.
+                // when it returns, that can happen e.g. with NLL when a lifetime can, but does not have to, extend beyond the
+                // end of a function.  Same for a function still having recoveries.
                 Some(ending_region) => lifetime.region == Some(ending_region),
             }
         };
 
         for alloc in self.alloc_map.values_mut() {
             // Collect things for removal as we cannot remove while iterating
-            let mut remove_list : Vec<MemoryRange> = Vec::new();
+            let mut remove_list: Vec<MemoryRange> = Vec::new();
             for (range, lock) in alloc.locks.iter_mut() {
                 // Delete everything that ends now -- i.e., keep only all the other lifetimes.
                 match *lock {
@@ -564,7 +679,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
                         if lfts.is_empty() {
                             remove_list.push(*range);
                         }
-                    },
+                    }
                 }
             }
             // Perform delayed removal
@@ -580,19 +695,26 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     pub fn get(&self, id: AllocId) -> EvalResult<'tcx, &Allocation<M::MemoryKinds>> {
         match self.alloc_map.get(&id) {
             Some(alloc) => Ok(alloc),
-            None => match self.functions.get(&id) {
-                Some(_) => err!(DerefFunctionPointer),
-                None => err!(DanglingPointerDeref),
+            None => {
+                match self.functions.get(&id) {
+                    Some(_) => err!(DerefFunctionPointer),
+                    None => err!(DanglingPointerDeref),
+                }
             }
         }
     }
-    
-    fn get_mut_unchecked(&mut self, id: AllocId) -> EvalResult<'tcx, &mut Allocation<M::MemoryKinds>> {
+
+    fn get_mut_unchecked(
+        &mut self,
+        id: AllocId,
+    ) -> EvalResult<'tcx, &mut Allocation<M::MemoryKinds>> {
         match self.alloc_map.get_mut(&id) {
             Some(alloc) => Ok(alloc),
-            None => match self.functions.get(&id) {
-                Some(_) => err!(DerefFunctionPointer),
-                None => err!(DanglingPointerDeref),
+            None => {
+                match self.functions.get(&id) {
+                    Some(_) => err!(DerefFunctionPointer),
+                    None => err!(DanglingPointerDeref),
+                }
             }
         }
     }
@@ -613,9 +735,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         debug!("reading fn ptr: {}", ptr.alloc_id);
         match self.functions.get(&ptr.alloc_id) {
             Some(&fndef) => Ok(fndef),
-            None => match self.alloc_map.get(&ptr.alloc_id) {
-                Some(_) => err!(ExecuteMemory),
-                None => err!(InvalidFunctionPointer),
+            None => {
+                match self.alloc_map.get(&ptr.alloc_id) {
+                    Some(_) => err!(ExecuteMemory),
+                    None => err!(InvalidFunctionPointer),
+                }
             }
         }
     }
@@ -643,12 +767,16 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
                 (None, Some(instance)) => {
                     trace!("{} {}", msg, instance);
                     continue;
-                },
+                }
                 (None, None) => {
                     trace!("{} (deallocated)", msg);
                     continue;
-                },
-                (Some(_), Some(_)) => bug!("miri invariant broken: an allocation id exists that points to both a function and a memory location"),
+                }
+                (Some(_), Some(_)) => {
+                    bug!(
+                        "miri invariant broken: an allocation id exists that points to both a function and a memory location"
+                    )
+                }
             };
 
             for i in 0..(alloc.bytes.len() as u64) {
@@ -667,13 +795,21 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             }
 
             let immutable = match (alloc.kind, alloc.mutable) {
-                (Kind::UninitializedStatic, _) => " (static in the process of initialization)".to_owned(),
+                (Kind::UninitializedStatic, _) => {
+                    " (static in the process of initialization)".to_owned()
+                }
                 (Kind::Static, Mutability::Mutable) => " (static mut)".to_owned(),
                 (Kind::Static, Mutability::Immutable) => " (immutable)".to_owned(),
                 (Kind::Machine(m), _) => format!(" ({:?})", m),
                 (Kind::Stack, _) => " (stack)".to_owned(),
             };
-            trace!("{}({} bytes, alignment {}){}", msg, alloc.bytes.len(), alloc.align, immutable);
+            trace!(
+                "{}({} bytes, alignment {}){}",
+                msg,
+                alloc.bytes.len(),
+                alloc.align,
+                immutable
+            );
 
             if !relocations.is_empty() {
                 msg.clear();
@@ -697,12 +833,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         trace!("### LEAK REPORT ###");
         let leaks: Vec<_> = self.alloc_map
             .iter()
-            .filter_map(|(&key, val)| {
-                if val.kind != Kind::Static {
-                    Some(key)
-                } else {
-                    None
-                }
+            .filter_map(|(&key, val)| if val.kind != Kind::Static {
+                Some(key)
+            } else {
+                None
             })
             .collect();
         let n = leaks.len();
@@ -713,7 +847,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
 /// Byte accessors
 impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
-    fn get_bytes_unchecked(&self, ptr: MemoryPointer, size: u64, align: u64) -> EvalResult<'tcx, &[u8]> {
+    fn get_bytes_unchecked(
+        &self,
+        ptr: MemoryPointer,
+        size: u64,
+        align: u64,
+    ) -> EvalResult<'tcx, &[u8]> {
         // Zero-sized accesses can use dangling pointers, but they still have to be aligned and non-NULL
         if self.reads_are_aligned.get() {
             self.check_align(ptr.into(), align)?;
@@ -730,7 +869,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         Ok(&alloc.bytes[offset..offset + size as usize])
     }
 
-    fn get_bytes_unchecked_mut(&mut self, ptr: MemoryPointer, size: u64, align: u64) -> EvalResult<'tcx, &mut [u8]> {
+    fn get_bytes_unchecked_mut(
+        &mut self,
+        ptr: MemoryPointer,
+        size: u64,
+        align: u64,
+    ) -> EvalResult<'tcx, &mut [u8]> {
         // Zero-sized accesses can use dangling pointers, but they still have to be aligned and non-NULL
         if self.writes_are_aligned.get() {
             self.check_align(ptr.into(), align)?;
@@ -756,7 +900,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         self.get_bytes_unchecked(ptr, size, align)
     }
 
-    fn get_bytes_mut(&mut self, ptr: MemoryPointer, size: u64, align: u64) -> EvalResult<'tcx, &mut [u8]> {
+    fn get_bytes_mut(
+        &mut self,
+        ptr: MemoryPointer,
+        size: u64,
+        align: u64,
+    ) -> EvalResult<'tcx, &mut [u8]> {
         assert_ne!(size, 0);
         self.clear_relocations(ptr, size)?;
         self.mark_definedness(ptr.into(), size, true)?;
@@ -770,12 +919,19 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     pub fn mark_static(&mut self, alloc_id: AllocId) {
         trace!("mark_static: {:?}", alloc_id);
         if !self.static_alloc.insert(alloc_id) {
-            bug!("tried to mark an allocation ({:?}) as static twice", alloc_id);
+            bug!(
+                "tried to mark an allocation ({:?}) as static twice",
+                alloc_id
+            );
         }
     }
 
     /// mark an allocation pointed to by a static as static and initialized
-    pub fn mark_inner_allocation(&mut self, alloc: AllocId, mutability: Mutability) -> EvalResult<'tcx> {
+    pub fn mark_inner_allocation(
+        &mut self,
+        alloc: AllocId,
+        mutability: Mutability,
+    ) -> EvalResult<'tcx> {
         // relocations into other statics are not "inner allocations"
         if !self.static_alloc.contains(&alloc) {
             self.mark_static_initalized(alloc, mutability)?;
@@ -784,12 +940,25 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     }
 
     /// mark an allocation as static and initialized, either mutable or not
-    pub fn mark_static_initalized(&mut self, alloc_id: AllocId, mutability: Mutability) -> EvalResult<'tcx> {
-        trace!("mark_static_initalized {:?}, mutability: {:?}", alloc_id, mutability);
+    pub fn mark_static_initalized(
+        &mut self,
+        alloc_id: AllocId,
+        mutability: Mutability,
+    ) -> EvalResult<'tcx> {
+        trace!(
+            "mark_static_initalized {:?}, mutability: {:?}",
+            alloc_id,
+            mutability
+        );
         // do not use `self.get_mut(alloc_id)` here, because we might have already marked a
         // sub-element or have circular pointers (e.g. `Rc`-cycles)
         let relocations = match self.alloc_map.get_mut(&alloc_id) {
-            Some(&mut Allocation { ref mut relocations, ref mut kind, ref mut mutable, .. }) => {
+            Some(&mut Allocation {
+                     ref mut relocations,
+                     ref mut kind,
+                     ref mut mutable,
+                     ..
+                 }) => {
                 match *kind {
                     // const eval results can refer to "locals".
                     // E.g. `const Foo: &u32 = &1;` refers to the temp local that stores the `1`
@@ -807,7 +976,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
                 // take out the relocations vector to free the borrow on self, so we can call
                 // mark recursively
                 mem::replace(relocations, Default::default())
-            },
+            }
             None if !self.functions.contains_key(&alloc_id) => return err!(DanglingPointerDeref),
             _ => return Ok(()),
         };
@@ -816,11 +985,21 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             self.mark_inner_allocation(alloc, mutability)?;
         }
         // put back the relocations
-        self.alloc_map.get_mut(&alloc_id).expect("checked above").relocations = relocations;
+        self.alloc_map
+            .get_mut(&alloc_id)
+            .expect("checked above")
+            .relocations = relocations;
         Ok(())
     }
 
-    pub fn copy(&mut self, src: Pointer, dest: Pointer, size: u64, align: u64, nonoverlapping: bool) -> EvalResult<'tcx> {
+    pub fn copy(
+        &mut self,
+        src: Pointer,
+        dest: Pointer,
+        size: u64,
+        align: u64,
+        nonoverlapping: bool,
+    ) -> EvalResult<'tcx> {
         if size == 0 {
             // Empty accesses don't need to be valid pointers, but they should still be aligned
             if self.reads_are_aligned.get() {
@@ -846,8 +1025,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             if src.alloc_id == dest.alloc_id {
                 if nonoverlapping {
                     if (src.offset <= dest.offset && src.offset + size > dest.offset) ||
-                       (dest.offset <= src.offset && dest.offset + size > src.offset) {
-                        return err!(Intrinsic(format!("copy_nonoverlapping called on overlapping ranges")));
+                        (dest.offset <= src.offset && dest.offset + size > src.offset)
+                    {
+                        return err!(Intrinsic(
+                            format!("copy_nonoverlapping called on overlapping ranges"),
+                        ));
                     }
                 }
                 ptr::copy(src_bytes, dest_bytes, size as usize);
@@ -874,7 +1056,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
                 self.check_defined(ptr, (size + 1) as u64)?;
                 self.check_locks(ptr, (size + 1) as u64, AccessKind::Read)?;
                 Ok(&alloc.bytes[offset..offset + size])
-            },
+            }
             None => err!(UnterminatedCString(ptr)),
         }
     }
@@ -912,7 +1094,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             return Ok(());
         }
         let bytes = self.get_bytes_mut(ptr.to_ptr()?, count, 1)?;
-        for b in bytes { *b = val; }
+        for b in bytes {
+            *b = val;
+        }
         Ok(())
     }
 
@@ -938,16 +1122,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
     pub fn write_ptr(&mut self, dest: MemoryPointer, ptr: MemoryPointer) -> EvalResult<'tcx> {
         self.write_usize(dest, ptr.offset as u64)?;
-        self.get_mut(dest.alloc_id)?.relocations.insert(dest.offset, ptr.alloc_id);
+        self.get_mut(dest.alloc_id)?.relocations.insert(
+            dest.offset,
+            ptr.alloc_id,
+        );
         Ok(())
     }
 
-    pub fn write_primval(
-        &mut self,
-        dest: Pointer,
-        val: PrimVal,
-        size: u64,
-    ) -> EvalResult<'tcx> {
+    pub fn write_primval(&mut self, dest: Pointer, val: PrimVal, size: u64) -> EvalResult<'tcx> {
         match val {
             PrimVal::Ptr(ptr) => {
                 assert_eq!(size, self.pointer_size());
@@ -983,8 +1165,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
     pub fn write_bool(&mut self, ptr: MemoryPointer, b: bool) -> EvalResult<'tcx> {
         let align = self.layout.i1_align.abi();
-        self.get_bytes_mut(ptr, 1, align)
-            .map(|bytes| bytes[0] = b as u8)
+        self.get_bytes_mut(ptr, 1, align).map(
+            |bytes| bytes[0] = b as u8,
+        )
     }
 
     fn int_align(&self, size: u64) -> EvalResult<'tcx, u64> {
@@ -1000,7 +1183,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
     pub fn read_int(&self, ptr: MemoryPointer, size: u64) -> EvalResult<'tcx, i128> {
         let align = self.int_align(size)?;
-        self.get_bytes(ptr, size, align).map(|b| read_target_int(self.endianess(), b).unwrap())
+        self.get_bytes(ptr, size, align).map(|b| {
+            read_target_int(self.endianess(), b).unwrap()
+        })
     }
 
     pub fn write_int(&mut self, ptr: MemoryPointer, n: i128, size: u64) -> EvalResult<'tcx> {
@@ -1013,7 +1198,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
     pub fn read_uint(&self, ptr: MemoryPointer, size: u64) -> EvalResult<'tcx, u128> {
         let align = self.int_align(size)?;
-        self.get_bytes(ptr, size, align).map(|b| read_target_uint(self.endianess(), b).unwrap())
+        self.get_bytes(ptr, size, align).map(|b| {
+            read_target_uint(self.endianess(), b).unwrap()
+        })
     }
 
     pub fn write_uint(&mut self, ptr: MemoryPointer, n: u128, size: u64) -> EvalResult<'tcx> {
@@ -1059,21 +1246,29 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     }
 
     pub fn read_f32(&self, ptr: MemoryPointer) -> EvalResult<'tcx, f32> {
-        self.get_bytes(ptr, 4, self.layout.f32_align.abi())
-            .map(|b| read_target_f32(self.endianess(), b).unwrap())
+        self.get_bytes(ptr, 4, self.layout.f32_align.abi()).map(
+            |b| {
+                read_target_f32(self.endianess(), b).unwrap()
+            },
+        )
     }
 
     pub fn read_f64(&self, ptr: MemoryPointer) -> EvalResult<'tcx, f64> {
-        self.get_bytes(ptr, 8, self.layout.f64_align.abi())
-            .map(|b| read_target_f64(self.endianess(), b).unwrap())
+        self.get_bytes(ptr, 8, self.layout.f64_align.abi()).map(
+            |b| {
+                read_target_f64(self.endianess(), b).unwrap()
+            },
+        )
     }
 }
 
 /// Relocations
 impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
-    fn relocations(&self, ptr: MemoryPointer, size: u64)
-        -> EvalResult<'tcx, btree_map::Range<u64, AllocId>>
-    {
+    fn relocations(
+        &self,
+        ptr: MemoryPointer,
+        size: u64,
+    ) -> EvalResult<'tcx, btree_map::Range<u64, AllocId>> {
         let start = ptr.offset.saturating_sub(self.pointer_size() - 1);
         let end = ptr.offset + size;
         Ok(self.get(ptr.alloc_id)?.relocations.range(start..end))
@@ -1082,7 +1277,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     fn clear_relocations(&mut self, ptr: MemoryPointer, size: u64) -> EvalResult<'tcx> {
         // Find all relocations overlapping the given range.
         let keys: Vec<_> = self.relocations(ptr, size)?.map(|(&k, _)| k).collect();
-        if keys.is_empty() { return Ok(()); }
+        if keys.is_empty() {
+            return Ok(());
+        }
 
         // Find the start and end of the given range and its outermost relocations.
         let start = ptr.offset;
@@ -1094,11 +1291,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 
         // Mark parts of the outermost relocations as undefined if they partially fall outside the
         // given range.
-        if first < start { alloc.undef_mask.set_range(first, start, false); }
-        if last > end { alloc.undef_mask.set_range(end, last, false); }
+        if first < start {
+            alloc.undef_mask.set_range(first, start, false);
+        }
+        if last > end {
+            alloc.undef_mask.set_range(end, last, false);
+        }
 
         // Forget all the relocations.
-        for k in keys { alloc.relocations.remove(&k); }
+        for k in keys {
+            alloc.relocations.remove(&k);
+        }
 
         Ok(())
     }
@@ -1112,7 +1315,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         Ok(())
     }
 
-    fn copy_relocations(&mut self, src: MemoryPointer, dest: MemoryPointer, size: u64) -> EvalResult<'tcx> {
+    fn copy_relocations(
+        &mut self,
+        src: MemoryPointer,
+        dest: MemoryPointer,
+        size: u64,
+    ) -> EvalResult<'tcx> {
         let relocations: Vec<_> = self.relocations(src, size)?
             .map(|(&offset, &alloc_id)| {
                 // Update relocation offsets for the new positions in the destination allocation.
@@ -1127,7 +1335,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 /// Undefined bytes
 impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
     // FIXME(solson): This is a very naive, slow version.
-    fn copy_undef_mask(&mut self, src: MemoryPointer, dest: MemoryPointer, size: u64) -> EvalResult<'tcx> {
+    fn copy_undef_mask(
+        &mut self,
+        src: MemoryPointer,
+        dest: MemoryPointer,
+        size: u64,
+    ) -> EvalResult<'tcx> {
         // The bits have to be saved locally before writing to dest in case src and dest overlap.
         assert_eq!(size as usize as u64, size);
         let mut v = Vec::with_capacity(size as usize);
@@ -1136,14 +1349,22 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             v.push(defined);
         }
         for (i, defined) in v.into_iter().enumerate() {
-            self.get_mut(dest.alloc_id)?.undef_mask.set(dest.offset + i as u64, defined);
+            self.get_mut(dest.alloc_id)?.undef_mask.set(
+                dest.offset +
+                    i as u64,
+                defined,
+            );
         }
         Ok(())
     }
 
     fn check_defined(&self, ptr: MemoryPointer, size: u64) -> EvalResult<'tcx> {
         let alloc = self.get(ptr.alloc_id)?;
-        if !alloc.undef_mask.is_range_defined(ptr.offset, ptr.offset + size) {
+        if !alloc.undef_mask.is_range_defined(
+            ptr.offset,
+            ptr.offset + size,
+        )
+        {
             return err!(ReadUndefBytes);
         }
         Ok(())
@@ -1153,14 +1374,18 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         &mut self,
         ptr: Pointer,
         size: u64,
-        new_state: bool
+        new_state: bool,
     ) -> EvalResult<'tcx> {
         if size == 0 {
-            return Ok(())
+            return Ok(());
         }
         let ptr = ptr.to_ptr()?;
         let mut alloc = self.get_mut(ptr.alloc_id)?;
-        alloc.undef_mask.set_range(ptr.offset, ptr.offset + size, new_state);
+        alloc.undef_mask.set_range(
+            ptr.offset,
+            ptr.offset + size,
+            new_state,
+        );
         Ok(())
     }
 }
@@ -1169,14 +1394,22 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
 // Methods to access integers in the target endianess
 ////////////////////////////////////////////////////////////////////////////////
 
-fn write_target_uint(endianess: layout::Endian, mut target: &mut [u8], data: u128) -> Result<(), io::Error> {
+fn write_target_uint(
+    endianess: layout::Endian,
+    mut target: &mut [u8],
+    data: u128,
+) -> Result<(), io::Error> {
     let len = target.len();
     match endianess {
         layout::Endian::Little => target.write_uint128::<LittleEndian>(data, len),
         layout::Endian::Big => target.write_uint128::<BigEndian>(data, len),
     }
 }
-fn write_target_int(endianess: layout::Endian, mut target: &mut [u8], data: i128) -> Result<(), io::Error> {
+fn write_target_int(
+    endianess: layout::Endian,
+    mut target: &mut [u8],
+    data: i128,
+) -> Result<(), io::Error> {
     let len = target.len();
     match endianess {
         layout::Endian::Little => target.write_int128::<LittleEndian>(data, len),
@@ -1201,13 +1434,21 @@ fn read_target_int(endianess: layout::Endian, mut source: &[u8]) -> Result<i128,
 // Methods to access floats in the target endianess
 ////////////////////////////////////////////////////////////////////////////////
 
-fn write_target_f32(endianess: layout::Endian, mut target: &mut [u8], data: f32) -> Result<(), io::Error> {
+fn write_target_f32(
+    endianess: layout::Endian,
+    mut target: &mut [u8],
+    data: f32,
+) -> Result<(), io::Error> {
     match endianess {
         layout::Endian::Little => target.write_f32::<LittleEndian>(data),
         layout::Endian::Big => target.write_f32::<BigEndian>(data),
     }
 }
-fn write_target_f64(endianess: layout::Endian, mut target: &mut [u8], data: f64) -> Result<(), io::Error> {
+fn write_target_f64(
+    endianess: layout::Endian,
+    mut target: &mut [u8],
+    data: f64,
+) -> Result<(), io::Error> {
     match endianess {
         layout::Endian::Little => target.write_f64::<LittleEndian>(data),
         layout::Endian::Big => target.write_f64::<BigEndian>(data),
@@ -1252,21 +1493,29 @@ impl UndefMask {
 
     /// Check whether the range `start..end` (end-exclusive) is entirely defined.
     pub fn is_range_defined(&self, start: u64, end: u64) -> bool {
-        if end > self.len { return false; }
+        if end > self.len {
+            return false;
+        }
         for i in start..end {
-            if !self.get(i) { return false; }
+            if !self.get(i) {
+                return false;
+            }
         }
         true
     }
 
     fn set_range(&mut self, start: u64, end: u64, new_state: bool) {
         let len = self.len;
-        if end > len { self.grow(end - len, new_state); }
+        if end > len {
+            self.grow(end - len, new_state);
+        }
         self.set_range_inbounds(start, end, new_state);
     }
 
     fn set_range_inbounds(&mut self, start: u64, end: u64, new_state: bool) {
-        for i in start..end { self.set(i, new_state); }
+        for i in start..end {
+            self.set(i, new_state);
+        }
     }
 
     fn get(&self, i: u64) -> bool {
@@ -1288,7 +1537,9 @@ impl UndefMask {
         if amount > unused_trailing_bits {
             let additional_blocks = amount / BLOCK_SIZE + 1;
             assert_eq!(additional_blocks as usize as u64, additional_blocks);
-            self.blocks.extend(iter::repeat(0).take(additional_blocks as usize));
+            self.blocks.extend(
+                iter::repeat(0).take(additional_blocks as usize),
+            );
         }
         let start = self.len;
         self.len += amount;
@@ -1314,7 +1565,8 @@ pub trait HasMemory<'a, 'tcx, M: Machine<'tcx>> {
 
     // These are not supposed to be overriden.
     fn read_maybe_aligned<F, T>(&self, aligned: bool, f: F) -> EvalResult<'tcx, T>
-        where F: FnOnce(&Self) -> EvalResult<'tcx, T>
+    where
+        F: FnOnce(&Self) -> EvalResult<'tcx, T>,
     {
         let old = self.memory().reads_are_aligned.get();
         // Do alignment checking if *all* nested calls say it has to be aligned.
@@ -1325,7 +1577,8 @@ pub trait HasMemory<'a, 'tcx, M: Machine<'tcx>> {
     }
 
     fn read_maybe_aligned_mut<F, T>(&mut self, aligned: bool, f: F) -> EvalResult<'tcx, T>
-        where F: FnOnce(&mut Self) -> EvalResult<'tcx, T>
+    where
+        F: FnOnce(&mut Self) -> EvalResult<'tcx, T>,
     {
         let old = self.memory().reads_are_aligned.get();
         // Do alignment checking if *all* nested calls say it has to be aligned.
@@ -1336,7 +1589,8 @@ pub trait HasMemory<'a, 'tcx, M: Machine<'tcx>> {
     }
 
     fn write_maybe_aligned_mut<F, T>(&mut self, aligned: bool, f: F) -> EvalResult<'tcx, T>
-        where F: FnOnce(&mut Self) -> EvalResult<'tcx, T>
+    where
+        F: FnOnce(&mut Self) -> EvalResult<'tcx, T>,
     {
         let old = self.memory().writes_are_aligned.get();
         // Do alignment checking if *all* nested calls say it has to be aligned.
@@ -1375,7 +1629,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> HasMemory<'a, 'tcx, M> for EvalContext<'a, 'tcx
 // Pointer arithmetic
 ////////////////////////////////////////////////////////////////////////////////
 
-pub trait PointerArithmetic : layout::HasDataLayout {
+pub trait PointerArithmetic: layout::HasDataLayout {
     // These are not supposed to be overriden.
 
     //// Trunace the given value to the pointer size; also return whether there was an overflow
@@ -1405,20 +1659,12 @@ pub trait PointerArithmetic : layout::HasDataLayout {
 
     fn signed_offset<'tcx>(self, val: u64, i: i64) -> EvalResult<'tcx, u64> {
         let (res, over) = self.overflowing_signed_offset(val, i as i128);
-        if over {
-            err!(OverflowingMath)
-        } else {
-            Ok(res)
-        }
+        if over { err!(OverflowingMath) } else { Ok(res) }
     }
 
     fn offset<'tcx>(self, val: u64, i: u64) -> EvalResult<'tcx, u64> {
         let (res, over) = self.overflowing_offset(val, i);
-        if over {
-            err!(OverflowingMath)
-        } else {
-            Ok(res)
-        }
+        if over { err!(OverflowingMath) } else { Ok(res) }
     }
 
     fn wrapping_signed_offset(self, val: u64, i: i64) -> u64 {
@@ -1441,7 +1687,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> layout::HasDataLayout for &'a EvalContext<'a, '
     }
 }
 
-impl<'c, 'b, 'a, 'tcx, M: Machine<'tcx>> layout::HasDataLayout for &'c &'b mut EvalContext<'a, 'tcx, M> {
+impl<'c, 'b, 'a, 'tcx, M: Machine<'tcx>> layout::HasDataLayout
+    for &'c &'b mut EvalContext<'a, 'tcx, M> {
     #[inline]
     fn data_layout(&self) -> &TargetDataLayout {
         self.memory().layout

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -383,7 +383,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
         // in a local, and the local could be deallocated (from StorageDead) before the function returns.
         // However, we should check *something*.  For now, we make sure that there is no conflicting write
         // lock by another frame.  We *have* to permit deallocation if we hold a read lock.
-        // TODO: Figure out the exact rules here.
+        // FIXME: Figure out the exact rules here.
         alloc.check_locks(Some(self.cur_frame), 0, alloc.bytes.len() as u64, AccessKind::Read)
             .map_err(|lock| EvalErrorKind::DeallocatedLockedMemory { ptr, lock })?;
 
@@ -528,7 +528,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             alloc.locks.remove(&range);
         }
 
-        // TODO: Test that we actually released a write lock for the entire covered region.
+        // FIXME: Test that we actually released a write lock for the entire covered region.
 
         Ok(())
     }

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -19,58 +19,21 @@ mod terminator;
 mod traits;
 mod value;
 
-pub use self::error::{
-    EvalError,
-    EvalResult,
-    EvalErrorKind,
-};
+pub use self::error::{EvalError, EvalResult, EvalErrorKind};
 
-pub use self::eval_context::{
-    EvalContext,
-    Frame,
-    ResourceLimits,
-    StackPopCleanup,
-    DynamicLifetime,
-    TyAndPacked,
-};
+pub use self::eval_context::{EvalContext, Frame, ResourceLimits, StackPopCleanup, DynamicLifetime,
+                             TyAndPacked};
 
-pub use self::lvalue::{
-    Lvalue,
-    LvalueExtra,
-    Global,
-    GlobalId,
-};
+pub use self::lvalue::{Lvalue, LvalueExtra, Global, GlobalId};
 
-pub use self::memory::{
-    AllocId,
-    Memory,
-    MemoryPointer,
-    Kind,
-    HasMemory,
-};
+pub use self::memory::{AllocId, Memory, MemoryPointer, Kind, HasMemory};
 
-use self::memory::{
-    PointerArithmetic,
-    LockInfo,
-    AccessKind,
-};
+use self::memory::{PointerArithmetic, LockInfo, AccessKind};
 
-pub use self::value::{
-    PrimVal,
-    PrimValKind,
-    Value,
-    Pointer,
-};
+pub use self::value::{PrimVal, PrimValKind, Value, Pointer};
 
-pub use self::const_eval::{
-    eval_body_as_integer,
-    eval_body_as_primval,
-};
+pub use self::const_eval::{eval_body_as_integer, eval_body_as_primval};
 
-pub use self::machine::{
-    Machine,
-};
+pub use self::machine::Machine;
 
-pub use self::validation::{
-    ValidationQuery,
-};
+pub use self::validation::ValidationQuery;

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -148,7 +148,6 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
         let left_kind = self.ty_to_primval_kind(left_ty)?;
         let right_kind = self.ty_to_primval_kind(right_ty)?;
-        //trace!("Running binary op {:?}: {:?} ({:?}), {:?} ({:?})", bin_op, left, left_kind, right, right_kind);
 
         // I: Handle operations that support pointers
         if !left_kind.is_float() && !right_kind.is_float() {

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -3,22 +3,10 @@ use rustc::ty::Ty;
 use rustc_const_math::ConstFloat;
 use syntax::ast;
 
-use super::{
-    EvalResult,
-    EvalContext,
-    Lvalue,
-    Machine,
-};
+use super::{EvalResult, EvalContext, Lvalue, Machine};
 
-use super::value::{
-    PrimVal,
-    PrimValKind,
-    Value,
-    bytes_to_f32,
-    bytes_to_f64,
-    f32_to_bytes,
-    f64_to_bytes,
-};
+use super::value::{PrimVal, PrimValKind, Value, bytes_to_f32, bytes_to_f64, f32_to_bytes,
+                   f64_to_bytes};
 
 impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     fn binop_with_overflow(
@@ -27,10 +15,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         left: &mir::Operand<'tcx>,
         right: &mir::Operand<'tcx>,
     ) -> EvalResult<'tcx, (PrimVal, bool)> {
-        let left_ty    = self.operand_ty(left);
-        let right_ty   = self.operand_ty(right);
-        let left_val   = self.eval_operand_to_primval(left)?;
-        let right_val  = self.eval_operand_to_primval(right)?;
+        let left_ty = self.operand_ty(left);
+        let right_ty = self.operand_ty(right);
+        let left_val = self.eval_operand_to_primval(left)?;
+        let right_val = self.eval_operand_to_primval(right)?;
         self.binary_op(op, left_val, left_ty, right_val, right_ty)
     }
 
@@ -158,7 +146,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         use rustc::mir::BinOp::*;
         use super::PrimValKind::*;
 
-        let left_kind  = self.ty_to_primval_kind(left_ty)?;
+        let left_kind = self.ty_to_primval_kind(left_ty)?;
         let right_kind = self.ty_to_primval_kind(right_ty)?;
         //trace!("Running binary op {:?}: {:?} ({:?}), {:?} ({:?})", bin_op, left, left_kind, right, right_kind);
 
@@ -183,23 +171,30 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         }
 
         if left_kind != right_kind {
-            let msg = format!("unimplemented binary op {:?}: {:?} ({:?}), {:?} ({:?})", bin_op, left, left_kind, right, right_kind);
+            let msg = format!(
+                "unimplemented binary op {:?}: {:?} ({:?}), {:?} ({:?})",
+                bin_op,
+                left,
+                left_kind,
+                right,
+                right_kind
+            );
             return err!(Unimplemented(msg));
         }
 
         let val = match (bin_op, left_kind) {
             (Eq, F32) => PrimVal::from_bool(bytes_to_f32(l) == bytes_to_f32(r)),
             (Ne, F32) => PrimVal::from_bool(bytes_to_f32(l) != bytes_to_f32(r)),
-            (Lt, F32) => PrimVal::from_bool(bytes_to_f32(l) <  bytes_to_f32(r)),
+            (Lt, F32) => PrimVal::from_bool(bytes_to_f32(l) < bytes_to_f32(r)),
             (Le, F32) => PrimVal::from_bool(bytes_to_f32(l) <= bytes_to_f32(r)),
-            (Gt, F32) => PrimVal::from_bool(bytes_to_f32(l) >  bytes_to_f32(r)),
+            (Gt, F32) => PrimVal::from_bool(bytes_to_f32(l) > bytes_to_f32(r)),
             (Ge, F32) => PrimVal::from_bool(bytes_to_f32(l) >= bytes_to_f32(r)),
 
             (Eq, F64) => PrimVal::from_bool(bytes_to_f64(l) == bytes_to_f64(r)),
             (Ne, F64) => PrimVal::from_bool(bytes_to_f64(l) != bytes_to_f64(r)),
-            (Lt, F64) => PrimVal::from_bool(bytes_to_f64(l) <  bytes_to_f64(r)),
+            (Lt, F64) => PrimVal::from_bool(bytes_to_f64(l) < bytes_to_f64(r)),
             (Le, F64) => PrimVal::from_bool(bytes_to_f64(l) <= bytes_to_f64(r)),
-            (Gt, F64) => PrimVal::from_bool(bytes_to_f64(l) >  bytes_to_f64(r)),
+            (Gt, F64) => PrimVal::from_bool(bytes_to_f64(l) > bytes_to_f64(r)),
             (Ge, F64) => PrimVal::from_bool(bytes_to_f64(l) >= bytes_to_f64(r)),
 
             (Add, F32) => f32_arithmetic!(+, l, r),
@@ -218,15 +213,15 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             (Ne, _) => PrimVal::from_bool(l != r),
 
             (Lt, k) if k.is_signed_int() => PrimVal::from_bool((l as i128) < (r as i128)),
-            (Lt, _) => PrimVal::from_bool(l <  r),
+            (Lt, _) => PrimVal::from_bool(l < r),
             (Le, k) if k.is_signed_int() => PrimVal::from_bool((l as i128) <= (r as i128)),
             (Le, _) => PrimVal::from_bool(l <= r),
             (Gt, k) if k.is_signed_int() => PrimVal::from_bool((l as i128) > (r as i128)),
-            (Gt, _) => PrimVal::from_bool(l >  r),
+            (Gt, _) => PrimVal::from_bool(l > r),
             (Ge, k) if k.is_signed_int() => PrimVal::from_bool((l as i128) >= (r as i128)),
             (Ge, _) => PrimVal::from_bool(l >= r),
 
-            (BitOr,  _) => PrimVal::Bytes(l | r),
+            (BitOr, _) => PrimVal::Bytes(l | r),
             (BitAnd, _) => PrimVal::Bytes(l & r),
             (BitXor, _) => PrimVal::Bytes(l ^ r),
 
@@ -237,7 +232,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             (Rem, k) if k.is_int() => return int_arithmetic!(k, overflowing_rem, l, r),
 
             _ => {
-                let msg = format!("unimplemented binary op {:?}: {:?} ({:?}), {:?} ({:?})", bin_op, left, left_kind, right, right_kind);
+                let msg = format!(
+                    "unimplemented binary op {:?}: {:?} ({:?}), {:?} ({:?})",
+                    bin_op,
+                    left,
+                    left_kind,
+                    right,
+                    right_kind
+                );
                 return err!(Unimplemented(msg));
             }
         };
@@ -259,19 +261,19 @@ pub fn unary_op<'tcx>(
     let result_bytes = match (un_op, val_kind) {
         (Not, Bool) => !val.to_bool()? as u128,
 
-        (Not, U8)  => !(bytes as u8) as u128,
+        (Not, U8) => !(bytes as u8) as u128,
         (Not, U16) => !(bytes as u16) as u128,
         (Not, U32) => !(bytes as u32) as u128,
         (Not, U64) => !(bytes as u64) as u128,
         (Not, U128) => !bytes,
 
-        (Not, I8)  => !(bytes as i8) as u128,
+        (Not, I8) => !(bytes as i8) as u128,
         (Not, I16) => !(bytes as i16) as u128,
         (Not, I32) => !(bytes as i32) as u128,
         (Not, I64) => !(bytes as i64) as u128,
         (Not, I128) => !(bytes as i128) as u128,
 
-        (Neg, I8)  => -(bytes as i8) as u128,
+        (Neg, I8) => -(bytes as i8) as u128,
         (Neg, I16) => -(bytes as i16) as u128,
         (Neg, I32) => -(bytes as i32) as u128,
         (Neg, I64) => -(bytes as i64) as u128,

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -135,7 +135,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                                 &self,
                             )?;
                             trace!("struct wrapped nullable pointer type: {}", ty);
-                            // only the pointer part of a fat pointer is used for this space optimization
+                            // only the pointer part of a fat pointer
+                            // is used for this space optimization
                             let discr_size = self.type_size(ty)?.expect(
                                 "bad StructWrappedNullablePointer discrfield",
                             );
@@ -158,14 +159,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             // Mark locals as dead or alive.
             StorageLive(ref lvalue) |
             StorageDead(ref lvalue) => {
-                let (frame, local) =
-                    match self.eval_lvalue(lvalue)? {
-                        Lvalue::Local { frame, local } if self.cur_frame() == frame => (
-                            frame,
-                            local,
-                        ),
-                        _ => return err!(Unimplemented("Storage annotations must refer to locals of the topmost stack frame.".to_owned())), // FIXME maybe this should get its own error type
-                    };
+                let (frame, local) = match self.eval_lvalue(lvalue)? {
+                    Lvalue::Local { frame, local } if self.cur_frame() == frame => (frame, local),
+                    // FIXME maybe this should get its own error type
+                    _ => {
+                        return err!(Unimplemented(
+                            "Storage annotations must refer to locals \
+                                                        of the topmost stack frame."
+                                .to_owned(),
+                        ))
+                    }
+                };
                 let old_val = match stmt.kind {
                     StorageLive(_) => self.stack[frame].storage_live(local)?,
                     StorageDead(_) => self.stack[frame].storage_dead(local)?,

--- a/src/librustc_mir/interpret/terminator/drop.rs
+++ b/src/librustc_mir/interpret/terminator/drop.rs
@@ -2,29 +2,48 @@ use rustc::mir;
 use rustc::ty::{self, Ty};
 use syntax::codemap::Span;
 
-use interpret::{
-    EvalResult,
-    EvalContext, StackPopCleanup,
-    Lvalue, LvalueExtra,
-    PrimVal, Value,
-    Machine,
-};
+use interpret::{EvalResult, EvalContext, StackPopCleanup, Lvalue, LvalueExtra, PrimVal, Value,
+                Machine};
 
 impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
-    pub(crate) fn drop_lvalue(&mut self, lval: Lvalue<'tcx>, instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
+    pub(crate) fn drop_lvalue(
+        &mut self,
+        lval: Lvalue<'tcx>,
+        instance: ty::Instance<'tcx>,
+        ty: Ty<'tcx>,
+        span: Span,
+    ) -> EvalResult<'tcx> {
         trace!("drop_lvalue: {:#?}", lval);
         // We take the address of the object.  This may well be unaligned, which is fine for us here.
         // However, unaligned accesses will probably make the actual drop implementation fail -- a problem shared
         // by rustc.
         let val = match self.force_allocation(lval)? {
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable), aligned: _ } => ptr.to_value_with_vtable(vtable),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len), aligned: _ } => ptr.to_value_with_len(len),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: _ } => ptr.to_value(),
+            Lvalue::Ptr {
+                ptr,
+                extra: LvalueExtra::Vtable(vtable),
+                aligned: _,
+            } => ptr.to_value_with_vtable(vtable),
+            Lvalue::Ptr {
+                ptr,
+                extra: LvalueExtra::Length(len),
+                aligned: _,
+            } => ptr.to_value_with_len(len),
+            Lvalue::Ptr {
+                ptr,
+                extra: LvalueExtra::None,
+                aligned: _,
+            } => ptr.to_value(),
             _ => bug!("force_allocation broken"),
         };
         self.drop(val, instance, ty, span)
     }
-    pub(crate) fn drop(&mut self, arg: Value, mut instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
+    pub(crate) fn drop(
+        &mut self,
+        arg: Value,
+        mut instance: ty::Instance<'tcx>,
+        ty: Ty<'tcx>,
+        span: Span,
+    ) -> EvalResult<'tcx> {
         trace!("drop: {:#?}, {:?}, {:?}", arg, ty.sty, instance.def);
 
         if let ty::InstanceDef::DropGlue(_, None) = instance.def {
@@ -42,11 +61,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     Some(func) => {
                         instance = func;
                         self.load_mir(func.def)?
-                    },
+                    }
                     // no drop fn -> bail out
                     None => return Ok(()),
                 }
-            },
+            }
             _ => self.load_mir(instance.def)?,
         };
 

--- a/src/librustc_mir/interpret/terminator/drop.rs
+++ b/src/librustc_mir/interpret/terminator/drop.rs
@@ -14,9 +14,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         span: Span,
     ) -> EvalResult<'tcx> {
         trace!("drop_lvalue: {:#?}", lval);
-        // We take the address of the object.  This may well be unaligned, which is fine for us here.
-        // However, unaligned accesses will probably make the actual drop implementation fail -- a problem shared
-        // by rustc.
+        // We take the address of the object.
+        // This may well be unaligned, which is fine for us here.
+        // However, unaligned accesses will probably make the actual drop implementation fail
+        // -- a problem shared by rustc.
         let val = match self.force_allocation(lval)? {
             Lvalue::Ptr {
                 ptr,

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -124,7 +124,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                             err!(ArrayIndexOutOfBounds(span, len, index))
                         },
                         mir::AssertMessage::Math(ref err) =>
-                            err!(Math(terminator.source_info.span, err.clone())),
+                            err!(Math(Some(terminator.source_info.span), err.clone())),
                     }
                 }
             },

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -4,15 +4,8 @@ use rustc::ty::layout::Layout;
 use syntax::codemap::Span;
 use syntax::abi::Abi;
 
-use super::{
-    EvalError, EvalResult, EvalErrorKind,
-    EvalContext, eval_context, TyAndPacked,
-    Lvalue,
-    MemoryPointer,
-    PrimVal, Value,
-    Machine,
-    HasMemory,
-};
+use super::{EvalError, EvalResult, EvalErrorKind, EvalContext, eval_context, TyAndPacked, Lvalue,
+            MemoryPointer, PrimVal, Value, Machine, HasMemory};
 use super::eval_context::IntegerExt;
 
 use rustc_data_structures::indexed_vec::Idx;
@@ -38,7 +31,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
             Goto { target } => self.goto_block(target),
 
-            SwitchInt { ref discr, ref values, ref targets, .. } => {
+            SwitchInt {
+                ref discr,
+                ref values,
+                ref targets,
+                ..
+            } => {
                 // FIXME(CTFE): forbid branching
                 let discr_val = self.eval_operand(discr)?;
                 let discr_ty = self.operand_ty(discr);
@@ -58,7 +56,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 self.goto_block(target_block);
             }
 
-            Call { ref func, ref args, ref destination, .. } => {
+            Call {
+                ref func,
+                ref args,
+                ref destination,
+                ..
+            } => {
                 let destination = match *destination {
                     Some((ref lv, target)) => Some((self.eval_lvalue(lv)?, target)),
                     None => None,
@@ -80,22 +83,35 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                                 if !self.check_sig_compat(sig, real_sig)? {
                                     return err!(FunctionPointerTyMismatch(real_sig, sig));
                                 }
-                            },
+                            }
                             ref other => bug!("instance def ty: {:?}", other),
                         }
                         (instance, sig)
-                    },
-                    ty::TyFnDef(def_id, substs) => (eval_context::resolve(self.tcx, def_id, substs), func_ty.fn_sig(self.tcx)),
+                    }
+                    ty::TyFnDef(def_id, substs) => (
+                        eval_context::resolve(self.tcx, def_id, substs),
+                        func_ty.fn_sig(self.tcx),
+                    ),
                     _ => {
                         let msg = format!("can't handle callee of type {:?}", func_ty);
                         return err!(Unimplemented(msg));
                     }
                 };
                 let sig = self.erase_lifetimes(&sig);
-                self.eval_fn_call(fn_def, destination, args, terminator.source_info.span, sig)?;
+                self.eval_fn_call(
+                    fn_def,
+                    destination,
+                    args,
+                    terminator.source_info.span,
+                    sig,
+                )?;
             }
 
-            Drop { ref location, target, .. } => {
+            Drop {
+                ref location,
+                target,
+                ..
+            } => {
                 trace!("TerminatorKind::drop: {:?}, {:?}", location, self.substs());
                 // FIXME(CTFE): forbid drop in const eval
                 let lval = self.eval_lvalue(location)?;
@@ -104,10 +120,21 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 let ty = eval_context::apply_param_substs(self.tcx, self.substs(), &ty);
 
                 let instance = eval_context::resolve_drop_in_place(self.tcx, ty);
-                self.drop_lvalue(lval, instance, ty, terminator.source_info.span)?;
+                self.drop_lvalue(
+                    lval,
+                    instance,
+                    ty,
+                    terminator.source_info.span,
+                )?;
             }
 
-            Assert { ref cond, expected, ref msg, target, .. } => {
+            Assert {
+                ref cond,
+                expected,
+                ref msg,
+                target,
+                ..
+            } => {
                 let cond_val = self.eval_operand_to_primval(cond)?.to_bool()?;
                 if expected == cond_val {
                     self.goto_block(target);
@@ -122,12 +149,13 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                                 .expect("can't eval index")
                                 .to_u64()?;
                             err!(ArrayIndexOutOfBounds(span, len, index))
-                        },
-                        mir::AssertMessage::Math(ref err) =>
-                            err!(Math(Some(terminator.source_info.span), err.clone())),
-                    }
+                        }
+                        mir::AssertMessage::Math(ref err) => {
+                            err!(Math(Some(terminator.source_info.span), err.clone()))
+                        }
+                    };
                 }
-            },
+            }
 
             DropAndReplace { .. } => unimplemented!(),
             Resume => unimplemented!(),
@@ -144,27 +172,30 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         sig: ty::FnSig<'tcx>,
         real_sig: ty::FnSig<'tcx>,
     ) -> EvalResult<'tcx, bool> {
-        fn check_ty_compat<'tcx>(
-            ty: ty::Ty<'tcx>,
-            real_ty: ty::Ty<'tcx>,
-        ) -> bool {
-            if ty == real_ty { return true; } // This is actually a fast pointer comparison
+        fn check_ty_compat<'tcx>(ty: ty::Ty<'tcx>, real_ty: ty::Ty<'tcx>) -> bool {
+            if ty == real_ty {
+                return true;
+            } // This is actually a fast pointer comparison
             return match (&ty.sty, &real_ty.sty) {
                 // Permit changing the pointer type of raw pointers and references as well as
                 // mutability of raw pointers.
                 // FIXME: Should not be allowed when fat pointers are involved.
                 (&TypeVariants::TyRawPtr(_), &TypeVariants::TyRawPtr(_)) => true,
-                (&TypeVariants::TyRef(_, _), &TypeVariants::TyRef(_, _)) =>
-                    ty.is_mutable_pointer() == real_ty.is_mutable_pointer(),
+                (&TypeVariants::TyRef(_, _), &TypeVariants::TyRef(_, _)) => {
+                    ty.is_mutable_pointer() == real_ty.is_mutable_pointer()
+                }
                 // rule out everything else
-                _ => false
-            }
+                _ => false,
+            };
         }
 
-        if sig.abi == real_sig.abi &&
-            sig.variadic == real_sig.variadic &&
+        if sig.abi == real_sig.abi && sig.variadic == real_sig.variadic &&
             sig.inputs_and_output.len() == real_sig.inputs_and_output.len() &&
-            sig.inputs_and_output.iter().zip(real_sig.inputs_and_output).all(|(ty, real_ty)| check_ty_compat(ty, real_ty)) {
+            sig.inputs_and_output
+                .iter()
+                .zip(real_sig.inputs_and_output)
+                .all(|(ty, real_ty)| check_ty_compat(ty, real_ty))
+        {
             // Definitely good.
             return Ok(true);
         }
@@ -224,22 +255,15 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 M::call_intrinsic(self, instance, arg_operands, ret, ty, layout, target)?;
                 self.dump_local(ret);
                 Ok(())
-            },
-            ty::InstanceDef::ClosureOnceShim{..} => {
+            }
+            ty::InstanceDef::ClosureOnceShim { .. } => {
                 let mut args = Vec::new();
                 for arg in arg_operands {
                     let arg_val = self.eval_operand(arg)?;
                     let arg_ty = self.operand_ty(arg);
                     args.push((arg_val, arg_ty));
                 }
-                if M::eval_fn_call(
-                    self,
-                    instance,
-                    destination,
-                    arg_operands,
-                    span,
-                    sig,
-                )? {
+                if M::eval_fn_call(self, instance, destination, arg_operands, span, sig)? {
                     return Ok(());
                 }
                 let mut arg_locals = self.frame().mir.args_iter();
@@ -250,19 +274,25 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                             let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
                             self.write_value(arg_val, dest, arg_ty)?;
                         }
-                    },
+                    }
                     // non capture closure as fn ptr
                     // need to inject zst ptr for closure object (aka do nothing)
                     // and need to pack arguments
                     Abi::Rust => {
-                        trace!("arg_locals: {:?}", self.frame().mir.args_iter().collect::<Vec<_>>());
+                        trace!(
+                            "arg_locals: {:?}",
+                            self.frame().mir.args_iter().collect::<Vec<_>>()
+                        );
                         trace!("arg_operands: {:?}", arg_operands);
                         let local = arg_locals.nth(1).unwrap();
                         for (i, (arg_val, arg_ty)) in args.into_iter().enumerate() {
-                            let dest = self.eval_lvalue(&mir::Lvalue::Local(local).field(mir::Field::new(i), arg_ty))?;
+                            let dest = self.eval_lvalue(&mir::Lvalue::Local(local).field(
+                                mir::Field::new(i),
+                                arg_ty,
+                            ))?;
                             self.write_value(arg_val, dest, arg_ty)?;
                         }
-                    },
+                    }
                     _ => bug!("bad ABI for ClosureOnceShim: {:?}", sig.abi),
                 }
                 Ok(())
@@ -276,27 +306,24 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 }
 
                 // Push the stack frame, and potentially be entirely done if the call got hooked
-                if M::eval_fn_call(
-                    self,
-                    instance,
-                    destination,
-                    arg_operands,
-                    span,
-                    sig,
-                )? {
+                if M::eval_fn_call(self, instance, destination, arg_operands, span, sig)? {
                     return Ok(());
                 }
 
                 // Pass the arguments
                 let mut arg_locals = self.frame().mir.args_iter();
                 trace!("ABI: {:?}", sig.abi);
-                trace!("arg_locals: {:?}", self.frame().mir.args_iter().collect::<Vec<_>>());
+                trace!(
+                    "arg_locals: {:?}",
+                    self.frame().mir.args_iter().collect::<Vec<_>>()
+                );
                 trace!("arg_operands: {:?}", arg_operands);
                 match sig.abi {
                     Abi::RustCall => {
                         assert_eq!(args.len(), 2);
 
-                        {   // write first argument
+                        {
+                            // write first argument
                             let first_local = arg_locals.next().unwrap();
                             let dest = self.eval_lvalue(&mir::Lvalue::Local(first_local))?;
                             let (arg_val, arg_ty) = args.remove(0);
@@ -306,37 +333,61 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         // unpack and write all other args
                         let (arg_val, arg_ty) = args.remove(0);
                         let layout = self.type_layout(arg_ty)?;
-                        if let (&ty::TyTuple(fields, _), &Layout::Univariant { ref variant, .. }) = (&arg_ty.sty, layout) {
+                        if let (&ty::TyTuple(fields, _),
+                                &Layout::Univariant { ref variant, .. }) = (&arg_ty.sty, layout)
+                        {
                             trace!("fields: {:?}", fields);
                             if self.frame().mir.args_iter().count() == fields.len() + 1 {
                                 let offsets = variant.offsets.iter().map(|s| s.bytes());
                                 match arg_val {
                                     Value::ByRef { ptr, aligned } => {
-                                        assert!(aligned, "Unaligned ByRef-values cannot occur as function arguments");
-                                        for ((offset, ty), arg_local) in offsets.zip(fields).zip(arg_locals) {
-                                            let arg = Value::ByRef { ptr: ptr.offset(offset, &self)?, aligned: true};
-                                            let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
-                                            trace!("writing arg {:?} to {:?} (type: {})", arg, dest, ty);
+                                        assert!(
+                                            aligned,
+                                            "Unaligned ByRef-values cannot occur as function arguments"
+                                        );
+                                        for ((offset, ty), arg_local) in
+                                            offsets.zip(fields).zip(arg_locals)
+                                        {
+                                            let arg = Value::ByRef {
+                                                ptr: ptr.offset(offset, &self)?,
+                                                aligned: true,
+                                            };
+                                            let dest =
+                                                self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
+                                            trace!(
+                                                "writing arg {:?} to {:?} (type: {})",
+                                                arg,
+                                                dest,
+                                                ty
+                                            );
                                             self.write_value(arg, dest, ty)?;
                                         }
-                                    },
-                                    Value::ByVal(PrimVal::Undef) => {},
+                                    }
+                                    Value::ByVal(PrimVal::Undef) => {}
                                     other => {
                                         assert_eq!(fields.len(), 1);
-                                        let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_locals.next().unwrap()))?;
+                                        let dest = self.eval_lvalue(&mir::Lvalue::Local(
+                                            arg_locals.next().unwrap(),
+                                        ))?;
                                         self.write_value(other, dest, fields[0])?;
                                     }
                                 }
                             } else {
                                 trace!("manual impl of rust-call ABI");
                                 // called a manual impl of a rust-call function
-                                let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_locals.next().unwrap()))?;
+                                let dest = self.eval_lvalue(
+                                    &mir::Lvalue::Local(arg_locals.next().unwrap()),
+                                )?;
                                 self.write_value(arg_val, dest, arg_ty)?;
                             }
                         } else {
-                            bug!("rust-call ABI tuple argument was {:?}, {:?}", arg_ty, layout);
+                            bug!(
+                                "rust-call ABI tuple argument was {:?}, {:?}",
+                                arg_ty,
+                                layout
+                            );
                         }
-                    },
+                    }
                     _ => {
                         for (arg_local, (arg_val, arg_ty)) in arg_locals.zip(args) {
                             let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
@@ -345,7 +396,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     }
                 }
                 Ok(())
-            },
+            }
             ty::InstanceDef::DropGlue(..) => {
                 assert_eq!(arg_operands.len(), 1);
                 assert_eq!(sig.abi, Abi::Rust);
@@ -361,7 +412,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     _ => bug!("can only deref pointer types"),
                 };
                 self.drop(val, instance, pointee_type, span)
-            },
+            }
             ty::InstanceDef::FnPtrShim(..) => {
                 trace!("ABI: {}", sig.abi);
                 let mut args = Vec::new();
@@ -370,22 +421,15 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     let arg_ty = self.operand_ty(arg);
                     args.push((arg_val, arg_ty));
                 }
-                if M::eval_fn_call(
-                    self,
-                    instance,
-                    destination,
-                    arg_operands,
-                    span,
-                    sig,
-                )? {
+                if M::eval_fn_call(self, instance, destination, arg_operands, span, sig)? {
                     return Ok(());
                 }
                 let arg_locals = self.frame().mir.args_iter();
                 match sig.abi {
                     Abi::Rust => {
                         args.remove(0);
-                    },
-                    Abi::RustCall => {},
+                    }
+                    Abi::RustCall => {}
                     _ => unimplemented!(),
                 };
                 for (arg_local, (arg_val, arg_ty)) in arg_locals.zip(args) {
@@ -393,43 +437,56 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     self.write_value(arg_val, dest, arg_ty)?;
                 }
                 Ok(())
-            },
+            }
             ty::InstanceDef::Virtual(_, idx) => {
                 let ptr_size = self.memory.pointer_size();
-                let (_, vtable) = self.eval_operand(&arg_operands[0])?.into_ptr_vtable_pair(&self.memory)?;
-                let fn_ptr = self.memory.read_ptr(vtable.offset(ptr_size * (idx as u64 + 3), &self)?)?;
+                let (_, vtable) = self.eval_operand(&arg_operands[0])?.into_ptr_vtable_pair(
+                    &self.memory,
+                )?;
+                let fn_ptr = self.memory.read_ptr(
+                    vtable.offset(ptr_size * (idx as u64 + 3), &self)?,
+                )?;
                 let instance = self.memory.get_fn(fn_ptr.to_ptr()?)?;
                 let mut arg_operands = arg_operands.to_vec();
                 let ty = self.operand_ty(&arg_operands[0]);
                 let ty = self.get_field_ty(ty, 0)?.ty; // FIXME: packed flag is ignored
                 match arg_operands[0] {
-                    mir::Operand::Consume(ref mut lval) => *lval = lval.clone().field(mir::Field::new(0), ty),
+                    mir::Operand::Consume(ref mut lval) => {
+                        *lval = lval.clone().field(mir::Field::new(0), ty)
+                    }
                     _ => bug!("virtual call first arg cannot be a constant"),
                 }
                 // recurse with concrete function
-                self.eval_fn_call(
-                    instance,
-                    destination,
-                    &arg_operands,
-                    span,
-                    sig,
-                )
-            },
+                self.eval_fn_call(instance, destination, &arg_operands, span, sig)
+            }
         }
     }
 
-    pub fn read_discriminant_value(&self, adt_ptr: MemoryPointer, adt_ty: Ty<'tcx>) -> EvalResult<'tcx, u128> {
+    pub fn read_discriminant_value(
+        &self,
+        adt_ptr: MemoryPointer,
+        adt_ty: Ty<'tcx>,
+    ) -> EvalResult<'tcx, u128> {
         use rustc::ty::layout::Layout::*;
         let adt_layout = self.type_layout(adt_ty)?;
         //trace!("read_discriminant_value {:#?}", adt_layout);
 
         let discr_val = match *adt_layout {
-            General { discr, .. } | CEnum { discr, signed: false, .. } => {
+            General { discr, .. } |
+            CEnum {
+                discr,
+                signed: false,
+                ..
+            } => {
                 let discr_size = discr.size().bytes();
                 self.memory.read_uint(adt_ptr, discr_size)?
             }
 
-            CEnum { discr, signed: true, .. } => {
+            CEnum {
+                discr,
+                signed: true,
+                ..
+            } => {
                 let discr_size = discr.size().bytes();
                 self.memory.read_int(adt_ptr, discr_size)? as u128
             }
@@ -437,32 +494,62 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             RawNullablePointer { nndiscr, value } => {
                 let discr_size = value.size(&self.tcx.data_layout).bytes();
                 trace!("rawnullablepointer with size {}", discr_size);
-                self.read_nonnull_discriminant_value(adt_ptr, nndiscr as u128, discr_size)?
+                self.read_nonnull_discriminant_value(
+                    adt_ptr,
+                    nndiscr as u128,
+                    discr_size,
+                )?
             }
 
-            StructWrappedNullablePointer { nndiscr, ref discrfield_source, .. } => {
-                let (offset, TyAndPacked { ty, packed }) = self.nonnull_offset_and_ty(adt_ty, nndiscr, discrfield_source)?;
+            StructWrappedNullablePointer {
+                nndiscr,
+                ref discrfield_source,
+                ..
+            } => {
+                let (offset, TyAndPacked { ty, packed }) = self.nonnull_offset_and_ty(
+                    adt_ty,
+                    nndiscr,
+                    discrfield_source,
+                )?;
                 let nonnull = adt_ptr.offset(offset.bytes(), &*self)?;
                 trace!("struct wrapped nullable pointer type: {}", ty);
                 // only the pointer part of a fat pointer is used for this space optimization
-                let discr_size = self.type_size(ty)?.expect("bad StructWrappedNullablePointer discrfield");
-                self.read_maybe_aligned(!packed,
-                    |ectx| ectx.read_nonnull_discriminant_value(nonnull, nndiscr as u128, discr_size))?
+                let discr_size = self.type_size(ty)?.expect(
+                    "bad StructWrappedNullablePointer discrfield",
+                );
+                self.read_maybe_aligned(!packed, |ectx| {
+                    ectx.read_nonnull_discriminant_value(nonnull, nndiscr as u128, discr_size)
+                })?
             }
 
             // The discriminant_value intrinsic returns 0 for non-sum types.
-            Array { .. } | FatPointer { .. } | Scalar { .. } | Univariant { .. } |
-            Vector { .. } | UntaggedUnion { .. } => 0,
+            Array { .. } |
+            FatPointer { .. } |
+            Scalar { .. } |
+            Univariant { .. } |
+            Vector { .. } |
+            UntaggedUnion { .. } => 0,
         };
 
         Ok(discr_val)
     }
 
-    fn read_nonnull_discriminant_value(&self, ptr: MemoryPointer, nndiscr: u128, discr_size: u64) -> EvalResult<'tcx, u128> {
-        trace!("read_nonnull_discriminant_value: {:?}, {}, {}", ptr, nndiscr, discr_size);
+    fn read_nonnull_discriminant_value(
+        &self,
+        ptr: MemoryPointer,
+        nndiscr: u128,
+        discr_size: u64,
+    ) -> EvalResult<'tcx, u128> {
+        trace!(
+            "read_nonnull_discriminant_value: {:?}, {}, {}",
+            ptr,
+            nndiscr,
+            discr_size
+        );
         let not_null = match self.memory.read_uint(ptr, discr_size) {
             Ok(0) => false,
-            Ok(_) | Err(EvalError{ kind: EvalErrorKind::ReadPointerAsBytes, .. }) => true,
+            Ok(_) |
+            Err(EvalError { kind: EvalErrorKind::ReadPointerAsBytes, .. }) => true,
             Err(e) => return Err(e),
         };
         assert!(nndiscr == 0 || nndiscr == 1);

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -152,7 +152,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             return match (&ty.sty, &real_ty.sty) {
                 // Permit changing the pointer type of raw pointers and references as well as
                 // mutability of raw pointers.
-                // TODO: Should not be allowed when fat pointers are involved.
+                // FIXME: Should not be allowed when fat pointers are involved.
                 (&TypeVariants::TyRawPtr(_), &TypeVariants::TyRawPtr(_)) => true,
                 (&TypeVariants::TyRef(_, _), &TypeVariants::TyRef(_, _)) =>
                     ty.is_mutable_pointer() == real_ty.is_mutable_pointer(),
@@ -401,7 +401,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 let instance = self.memory.get_fn(fn_ptr.to_ptr()?)?;
                 let mut arg_operands = arg_operands.to_vec();
                 let ty = self.operand_ty(&arg_operands[0]);
-                let ty = self.get_field_ty(ty, 0)?.ty; // TODO: packed flag is ignored
+                let ty = self.get_field_ty(ty, 0)?.ty; // FIXME: packed flag is ignored
                 match arg_operands[0] {
                     mir::Operand::Consume(ref mut lval) => *lval = lval.clone().field(mir::Field::new(0), ty),
                     _ => bug!("virtual call first arg cannot be a constant"),

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -5,16 +5,13 @@ use rustc::ty::{self, Ty};
 use syntax::codemap::DUMMY_SP;
 use syntax::ast::{self, Mutability};
 
-use super::{
-    EvalResult,
-    EvalContext, eval_context,
-    MemoryPointer, Kind,
-    Value, PrimVal,
-    Machine,
-};
+use super::{EvalResult, EvalContext, eval_context, MemoryPointer, Kind, Value, PrimVal, Machine};
 
 impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
-    pub(crate) fn fulfill_obligation(&self, trait_ref: ty::PolyTraitRef<'tcx>) -> traits::Vtable<'tcx, ()> {
+    pub(crate) fn fulfill_obligation(
+        &self,
+        trait_ref: ty::PolyTraitRef<'tcx>,
+    ) -> traits::Vtable<'tcx, ()> {
         // Do the initial selection for the obligation. This yields the shallow result we are
         // looking for -- that is, what specific impl.
         self.tcx.infer_ctxt().enter(|infcx| {
@@ -43,15 +40,25 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     /// The `trait_ref` encodes the erased self type. Hence if we are
     /// making an object `Foo<Trait>` from a value of type `Foo<T>`, then
     /// `trait_ref` would map `T:Trait`.
-    pub fn get_vtable(&mut self, ty: Ty<'tcx>, trait_ref: ty::PolyTraitRef<'tcx>) -> EvalResult<'tcx, MemoryPointer> {
+    pub fn get_vtable(
+        &mut self,
+        ty: Ty<'tcx>,
+        trait_ref: ty::PolyTraitRef<'tcx>,
+    ) -> EvalResult<'tcx, MemoryPointer> {
         debug!("get_vtable(trait_ref={:?})", trait_ref);
 
-        let size = self.type_size(trait_ref.self_ty())?.expect("can't create a vtable for an unsized type");
+        let size = self.type_size(trait_ref.self_ty())?.expect(
+            "can't create a vtable for an unsized type",
+        );
         let align = self.type_align(trait_ref.self_ty())?;
 
         let ptr_size = self.memory.pointer_size();
         let methods = ::rustc::traits::get_vtable_methods(self.tcx, trait_ref);
-        let vtable = self.memory.allocate(ptr_size * (3 + methods.count() as u64), ptr_size, Kind::UninitializedStatic)?;
+        let vtable = self.memory.allocate(
+            ptr_size * (3 + methods.count() as u64),
+            ptr_size,
+            Kind::UninitializedStatic,
+        )?;
 
         let drop = eval_context::resolve_drop_in_place(self.tcx, ty);
         let drop = self.memory.create_fn_alloc(drop);
@@ -71,12 +78,18 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             }
         }
 
-        self.memory.mark_static_initalized(vtable.alloc_id, Mutability::Mutable)?;
+        self.memory.mark_static_initalized(
+            vtable.alloc_id,
+            Mutability::Mutable,
+        )?;
 
         Ok(vtable)
     }
 
-    pub fn read_drop_type_from_vtable(&self, vtable: MemoryPointer) -> EvalResult<'tcx, Option<ty::Instance<'tcx>>> {
+    pub fn read_drop_type_from_vtable(
+        &self,
+        vtable: MemoryPointer,
+    ) -> EvalResult<'tcx, Option<ty::Instance<'tcx>>> {
         // we don't care about the pointee type, we just want a pointer
         match self.read_ptr(vtable, self.tcx.mk_nil_ptr())? {
             // some values don't need to call a drop impl, so the value is null
@@ -86,10 +99,15 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         }
     }
 
-    pub fn read_size_and_align_from_vtable(&self, vtable: MemoryPointer) -> EvalResult<'tcx, (u64, u64)> {
+    pub fn read_size_and_align_from_vtable(
+        &self,
+        vtable: MemoryPointer,
+    ) -> EvalResult<'tcx, (u64, u64)> {
         let pointer_size = self.memory.pointer_size();
         let size = self.memory.read_usize(vtable.offset(pointer_size, self)?)?;
-        let align = self.memory.read_usize(vtable.offset(pointer_size * 2, self)?)?;
+        let align = self.memory.read_usize(
+            vtable.offset(pointer_size * 2, self)?,
+        )?;
         Ok((size, align))
     }
 
@@ -103,8 +121,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             let vtable = self.fulfill_obligation(trait_ref);
             if let traits::VtableImpl(vtable_impl) = vtable {
                 let name = self.tcx.item_name(def_id);
-                let assoc_const_opt = self.tcx.associated_items(vtable_impl.impl_def_id)
-                    .find(|item| item.kind == ty::AssociatedKind::Const && item.name == name);
+                let assoc_const_opt = self.tcx.associated_items(vtable_impl.impl_def_id).find(
+                    |item| {
+                        item.kind == ty::AssociatedKind::Const && item.name == name
+                    },
+                );
                 if let Some(assoc_const) = assoc_const_opt {
                     return ty::Instance::new(assoc_const.def_id, vtable_impl.substs);
                 }

--- a/src/librustc_mir/interpret/validation.rs
+++ b/src/librustc_mir/interpret/validation.rs
@@ -7,14 +7,8 @@ use rustc::traits::Reveal;
 use rustc::infer::TransNormalize;
 use rustc::middle::region::CodeExtent;
 
-use super::{
-    EvalError, EvalResult, EvalErrorKind,
-    EvalContext, DynamicLifetime,
-    AccessKind, LockInfo,
-    Value,
-    Lvalue, LvalueExtra,
-    Machine,
-};
+use super::{EvalError, EvalResult, EvalErrorKind, EvalContext, DynamicLifetime, AccessKind,
+            LockInfo, Value, Lvalue, LvalueExtra, Machine};
 
 pub type ValidationQuery<'tcx> = ValidationOperand<'tcx, Lvalue<'tcx>>;
 
@@ -23,7 +17,7 @@ enum ValidationMode {
     Acquire,
     /// Recover because the given region ended
     Recover(CodeExtent),
-    Release
+    Release,
 }
 
 impl ValidationMode {
@@ -38,7 +32,11 @@ impl ValidationMode {
 
 // Validity checks
 impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
-    pub(crate) fn validation_op(&mut self, op: ValidationOp, operand: &ValidationOperand<'tcx, mir::Lvalue<'tcx>>) -> EvalResult<'tcx> {
+    pub(crate) fn validation_op(
+        &mut self,
+        op: ValidationOp,
+        operand: &ValidationOperand<'tcx, mir::Lvalue<'tcx>>,
+    ) -> EvalResult<'tcx> {
         // If mir-emit-validate is set to 0 (i.e., disabled), we may still see validation commands
         // because other crates may have been compiled with mir-emit-validate > 0.  Ignore those
         // commands.  This makes mir-emit-validate also a flag to control whether miri will do
@@ -72,14 +70,19 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             // Now test
             let name = self.stack[self.cur_frame()].instance.to_string();
             if RE.is_match(&name) {
-                return Ok(())
+                return Ok(());
             }
         }
 
         // We need to monomorphize ty *without* erasing lifetimes
         let ty = operand.ty.subst(self.tcx, self.substs());
         let lval = self.eval_lvalue(&operand.lval)?;
-        let query = ValidationQuery { lval, ty, re: operand.re, mutbl: operand.mutbl };
+        let query = ValidationQuery {
+            lval,
+            ty,
+            re: operand.re,
+            mutbl: operand.mutbl,
+        };
 
         let mode = match op {
             ValidationOp::Acquire => ValidationMode::Acquire,
@@ -101,9 +104,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         match op {
             ValidationOp::Suspend(ce) => {
                 if query.mutbl == MutMutable {
-                    let lft = DynamicLifetime { frame: self.cur_frame(), region: Some(ce) };
+                    let lft = DynamicLifetime {
+                        frame: self.cur_frame(),
+                        region: Some(ce),
+                    };
                     trace!("Suspending {:?} until {:?}", query, ce);
-                    self.suspended.entry(lft).or_insert_with(Vec::new).push(query);
+                    self.suspended.entry(lft).or_insert_with(Vec::new).push(
+                        query,
+                    );
                 }
             }
             _ => {}
@@ -114,7 +122,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     pub(crate) fn end_region(&mut self, ce: CodeExtent) -> EvalResult<'tcx> {
         self.memory.locks_lifetime_ended(Some(ce));
         // Recover suspended lvals
-        let lft = DynamicLifetime { frame: self.cur_frame(), region: Some(ce) };
+        let lft = DynamicLifetime {
+            frame: self.cur_frame(),
+            region: Some(ce),
+        };
         if let Some(queries) = self.suspended.remove(&lft) {
             for query in queries {
                 trace!("Recovering {:?} from suspension", query);
@@ -135,12 +146,26 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         for (idx, field) in variant.fields.iter().enumerate() {
             let field_ty = field.ty(self.tcx, subst);
             let field_lvalue = self.lvalue_field(query.lval, idx, query.ty, field_ty)?;
-            self.validate(ValidationQuery { lval: field_lvalue, ty: field_ty, ..query }, mode)?;
+            self.validate(
+                ValidationQuery {
+                    lval: field_lvalue,
+                    ty: field_ty,
+                    ..query
+                },
+                mode,
+            )?;
         }
         Ok(())
     }
 
-    fn validate_ptr(&mut self, val: Value, pointee_ty: Ty<'tcx>, re: Option<CodeExtent>, mutbl: Mutability, mode: ValidationMode) -> EvalResult<'tcx> {
+    fn validate_ptr(
+        &mut self,
+        val: Value,
+        pointee_ty: Ty<'tcx>,
+        re: Option<CodeExtent>,
+        mutbl: Mutability,
+        mode: ValidationMode,
+    ) -> EvalResult<'tcx> {
         // Check alignment and non-NULLness
         let (_, align) = self.size_and_align_of_dst(pointee_ty, val)?;
         let ptr = val.into_ptr(&self.memory)?;
@@ -148,20 +173,27 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
         // Recurse
         let pointee_lvalue = self.val_to_lvalue(val, pointee_ty)?;
-        self.validate(ValidationQuery { lval: pointee_lvalue, ty: pointee_ty, re, mutbl }, mode)
+        self.validate(
+            ValidationQuery {
+                lval: pointee_lvalue,
+                ty: pointee_ty,
+                re,
+                mutbl,
+            },
+            mode,
+        )
     }
 
     /// Validate the lvalue at the given type. If `acquire` is false, just do a release of all write locks
     #[inline]
-    fn validate(&mut self, query: ValidationQuery<'tcx>, mode: ValidationMode) -> EvalResult<'tcx>
-    {
+    fn validate(&mut self, query: ValidationQuery<'tcx>, mode: ValidationMode) -> EvalResult<'tcx> {
         match self.try_validate(query, mode) {
             // Releasing an uninitalized variable is a NOP.  This is needed because
             // we have to release the return value of a function; due to destination-passing-style
             // the callee may directly write there.
             // FIXME: Ideally we would know whether the destination is already initialized, and only
             // release if it is.
-            res @ Err(EvalError{ kind: EvalErrorKind::ReadUndefBytes, ..}) => {
+            res @ Err(EvalError { kind: EvalErrorKind::ReadUndefBytes, .. }) => {
                 if let ValidationMode::Release = mode {
                     return Ok(());
                 }
@@ -171,8 +203,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         }
     }
 
-    fn try_validate(&mut self, mut query: ValidationQuery<'tcx>, mode: ValidationMode) -> EvalResult<'tcx>
-    {
+    fn try_validate(
+        &mut self,
+        mut query: ValidationQuery<'tcx>,
+        mode: ValidationMode,
+    ) -> EvalResult<'tcx> {
         use rustc::ty::TypeVariants::*;
         use rustc::ty::RegionKind::*;
         use rustc::ty::AdtKind;
@@ -195,12 +230,13 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             Lvalue::Local { frame, local } => {
                 let res = self.stack[frame].get_local(local);
                 match (res, mode) {
-                    (Err(EvalError{ kind: EvalErrorKind::DeadLocal, ..}), ValidationMode::Recover(_)) => {
+                    (Err(EvalError { kind: EvalErrorKind::DeadLocal, .. }),
+                     ValidationMode::Recover(_)) => {
                         return Ok(());
                     }
-                    _ => {},
+                    _ => {}
                 }
-            },
+            }
             _ => {}
         }
 
@@ -218,16 +254,22 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         // just assembles pieces (that each own their memory) together to a larger whole.
         // FIXME: Currently, we don't acquire locks for padding and discriminants. We should.
         let is_owning = match query.ty.sty {
-            TyInt(_) | TyUint(_) | TyRawPtr(_) |
-            TyBool | TyFloat(_) | TyChar | TyStr |
+            TyInt(_) | TyUint(_) | TyRawPtr(_) | TyBool | TyFloat(_) | TyChar | TyStr |
             TyRef(..) | TyFnPtr(..) | TyFnDef(..) | TyNever => true,
             TyAdt(adt, _) if adt.is_box() => true,
-            TySlice(_) | TyAdt(_, _) | TyTuple(..) | TyClosure(..) | TyArray(..) | TyDynamic(..) => false,
-            TyParam(_) | TyInfer(_) | TyProjection(_) | TyAnon(..) | TyError => bug!("I got an incomplete/unnormalized type for validation"),
+            TySlice(_) | TyAdt(_, _) | TyTuple(..) | TyClosure(..) | TyArray(..) |
+            TyDynamic(..) => false,
+            TyParam(_) | TyInfer(_) | TyProjection(_) | TyAnon(..) | TyError => {
+                bug!("I got an incomplete/unnormalized type for validation")
+            }
         };
         if is_owning {
             match query.lval {
-                Lvalue::Ptr { ptr, extra, aligned: _ } => {
+                Lvalue::Ptr {
+                    ptr,
+                    extra,
+                    aligned: _,
+                } => {
                     // Determine the size
                     // FIXME: Can we reuse size_and_align_of_dst for Lvalues?
                     let len = match self.type_size(query.ty)? {
@@ -237,7 +279,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         }
                         None => {
                             // The only unsized typ we concider "owning" is TyStr.
-                            assert_eq!(query.ty.sty, TyStr, "Found a surprising unsized owning type");
+                            assert_eq!(
+                                query.ty.sty,
+                                TyStr,
+                                "Found a surprising unsized owning type"
+                            );
                             // The extra must be the length, in bytes.
                             match extra {
                                 LvalueExtra::Length(len) => len,
@@ -248,7 +294,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     // Handle locking
                     if len > 0 {
                         let ptr = ptr.to_ptr()?;
-                        let access = match query.mutbl { MutMutable => AccessKind::Write, MutImmutable => AccessKind::Read };
+                        let access = match query.mutbl {
+                            MutMutable => AccessKind::Write,
+                            MutImmutable => AccessKind::Read,
+                        };
                         if mode.acquiring() {
                             self.memory.acquire_lock(ptr, len, query.re, access)?;
                         } else {
@@ -256,7 +305,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         }
                     }
                 }
-                Lvalue::Local { .. } | Lvalue::Global(..) => {
+                Lvalue::Local { .. } |
+                Lvalue::Global(..) => {
                     // These are not backed by memory, so we have nothing to do.
                 }
             }
@@ -272,10 +322,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 // FIXME: Check if these are valid bool/float/codepoint/UTF-8, respectively (and in particular, not undef).
                 Ok(())
             }
-            TyNever => {
-                err!(ValidationFailure(format!("The empty type is never valid.")))
-            }
-            TyRef(region, ty::TypeAndMut { ty: pointee_ty, mutbl }) => {
+            TyNever => err!(ValidationFailure(format!("The empty type is never valid."))),
+            TyRef(region,
+                  ty::TypeAndMut {
+                      ty: pointee_ty,
+                      mutbl,
+                  }) => {
                 let val = self.read_lvalue(query.lval)?;
                 // Sharing restricts our context
                 if mutbl == MutImmutable {
@@ -288,7 +340,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         ReScope(ce) => query.re = Some(ce),
                         // It is possible for us to encounter erased lifetimes here because the lifetimes in
                         // this functions' Subst will be erased.
-                        _ => {},
+                        _ => {}
                     }
                 }
                 self.validate_ptr(val, pointee_ty, query.re, query.mutbl, mode)
@@ -298,7 +350,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 self.validate_ptr(val, query.ty.boxed_ty(), query.re, query.mutbl, mode)
             }
             TyFnPtr(_sig) => {
-                let ptr = self.read_lvalue(query.lval)?.into_ptr(&self.memory)?.to_ptr()?;
+                let ptr = self.read_lvalue(query.lval)?
+                    .into_ptr(&self.memory)?
+                    .to_ptr()?;
                 self.memory.get_fn(ptr)?;
                 // FIXME: Check if the signature matches (should be the same check as what terminator/mod.rs already does on call?).
                 Ok(())
@@ -313,18 +367,37 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             TySlice(elem_ty) => {
                 let len = match query.lval {
                     Lvalue::Ptr { extra: LvalueExtra::Length(len), .. } => len,
-                    _ => bug!("acquire_valid of a TySlice given non-slice lvalue: {:?}", query.lval),
+                    _ => {
+                        bug!(
+                            "acquire_valid of a TySlice given non-slice lvalue: {:?}",
+                            query.lval
+                        )
+                    }
                 };
                 for i in 0..len {
                     let inner_lvalue = self.lvalue_index(query.lval, query.ty, i)?;
-                    self.validate(ValidationQuery { lval: inner_lvalue, ty: elem_ty, ..query }, mode)?;
+                    self.validate(
+                        ValidationQuery {
+                            lval: inner_lvalue,
+                            ty: elem_ty,
+                            ..query
+                        },
+                        mode,
+                    )?;
                 }
                 Ok(())
             }
             TyArray(elem_ty, len) => {
                 for i in 0..len {
                     let inner_lvalue = self.lvalue_index(query.lval, query.ty, i as u64)?;
-                    self.validate(ValidationQuery { lval: inner_lvalue, ty: elem_ty, ..query }, mode)?;
+                    self.validate(
+                        ValidationQuery {
+                            lval: inner_lvalue,
+                            ty: elem_ty,
+                            ..query
+                        },
+                        mode,
+                    )?;
                 }
                 Ok(())
             }
@@ -332,7 +405,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 // Check that this is a valid vtable
                 let vtable = match query.lval {
                     Lvalue::Ptr { extra: LvalueExtra::Vtable(vtable), .. } => vtable,
-                    _ => bug!("acquire_valid of a TyDynamic given non-trait-object lvalue: {:?}", query.lval),
+                    _ => {
+                        bug!(
+                            "acquire_valid of a TyDynamic given non-trait-object lvalue: {:?}",
+                            query.lval
+                        )
+                    }
                 };
                 self.read_size_and_align_from_vtable(vtable)?;
                 // FIXME: Check that the vtable contains all the function pointers we expect it to have.
@@ -343,7 +421,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 Ok(())
             }
             TyAdt(adt, subst) => {
-                if Some(adt.did) == self.tcx.lang_items.unsafe_cell_type() && query.mutbl == MutImmutable {
+                if Some(adt.did) == self.tcx.lang_items.unsafe_cell_type() &&
+                    query.mutbl == MutImmutable
+                {
                     // No locks for shared unsafe cells.  Also no other validation, the only field is private anyway.
                     return Ok(());
                 }
@@ -355,8 +435,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         let discr = self.read_discriminant_value(ptr, query.ty)?;
 
                         // Get variant index for discriminant
-                        let variant_idx = adt.discriminants(self.tcx)
-                            .position(|variant_discr| variant_discr.to_u128_unchecked() == discr);
+                        let variant_idx = adt.discriminants(self.tcx).position(|variant_discr| {
+                            variant_discr.to_u128_unchecked() == discr
+                        });
                         let variant_idx = match variant_idx {
                             Some(val) => val,
                             None => return err!(InvalidDiscriminant),
@@ -366,13 +447,22 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         if variant.fields.len() > 0 {
                             // Downcast to this variant, if needed
                             let lval = if adt.variants.len() > 1 {
-                                self.eval_lvalue_projection(query.lval, query.ty, &mir::ProjectionElem::Downcast(adt, variant_idx))?
+                                self.eval_lvalue_projection(
+                                    query.lval,
+                                    query.ty,
+                                    &mir::ProjectionElem::Downcast(adt, variant_idx),
+                                )?
                             } else {
                                 query.lval
                             };
 
                             // Recursively validate the fields
-                            self.validate_variant(ValidationQuery { lval, ..query} , variant, subst, mode)
+                            self.validate_variant(
+                                ValidationQuery { lval, ..query },
+                                variant,
+                                subst,
+                                mode,
+                            )
                         } else {
                             // No fields, nothing left to check.  Downcasting may fail, e.g. in case of a CEnum.
                             Ok(())
@@ -391,20 +481,34 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             TyTuple(ref types, _) => {
                 for (idx, field_ty) in types.iter().enumerate() {
                     let field_lvalue = self.lvalue_field(query.lval, idx, query.ty, field_ty)?;
-                    self.validate(ValidationQuery { lval: field_lvalue, ty: field_ty, ..query }, mode)?;
+                    self.validate(
+                        ValidationQuery {
+                            lval: field_lvalue,
+                            ty: field_ty,
+                            ..query
+                        },
+                        mode,
+                    )?;
                 }
                 Ok(())
             }
             TyClosure(def_id, ref closure_substs) => {
                 for (idx, field_ty) in closure_substs.upvar_tys(def_id, self.tcx).enumerate() {
                     let field_lvalue = self.lvalue_field(query.lval, idx, query.ty, field_ty)?;
-                    self.validate(ValidationQuery { lval: field_lvalue, ty: field_ty, ..query }, mode)?;
+                    self.validate(
+                        ValidationQuery {
+                            lval: field_lvalue,
+                            ty: field_ty,
+                            ..query
+                        },
+                        mode,
+                    )?;
                 }
                 // FIXME: Check if the signature matches (should be the same check as what terminator/mod.rs already does on call?).
                 // Is there other things we can/should check?  Like vtable pointers?
                 Ok(())
             }
-            _ => bug!("We already establishd that this is a type we support.")
+            _ => bug!("We already establishd that this is a type we support."),
         }
     }
 }

--- a/src/librustc_mir/interpret/value.rs
+++ b/src/librustc_mir/interpret/value.rs
@@ -3,11 +3,7 @@
 
 use rustc::ty::layout::HasDataLayout;
 
-use super::{
-    EvalResult,
-    Memory, MemoryPointer, HasMemory, PointerArithmetic,
-    Machine,
-};
+use super::{EvalResult, Memory, MemoryPointer, HasMemory, PointerArithmetic, Machine};
 
 pub(super) fn bytes_to_f32(bytes: u128) -> f32 {
     f32::from_bits(bytes as u32)
@@ -36,7 +32,7 @@ pub(super) fn f64_to_bytes(f: f64) -> u128 {
 /// operations and fat pointers. This idea was taken from rustc's trans.
 #[derive(Clone, Copy, Debug)]
 pub enum Value {
-    ByRef { ptr: Pointer, aligned: bool},
+    ByRef { ptr: Pointer, aligned: bool },
     ByVal(PrimVal),
     ByValPair(PrimVal, PrimVal),
 }
@@ -69,8 +65,10 @@ impl<'tcx> Pointer {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
-                Ok(Pointer::from(PrimVal::Bytes(layout.signed_offset(b as u64, i)? as u128)))
-            },
+                Ok(Pointer::from(
+                    PrimVal::Bytes(layout.signed_offset(b as u64, i)? as u128),
+                ))
+            }
             PrimVal::Ptr(ptr) => ptr.signed_offset(i, layout).map(Pointer::from),
             PrimVal::Undef => err!(ReadUndefBytes),
         }
@@ -81,8 +79,10 @@ impl<'tcx> Pointer {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
-                Ok(Pointer::from(PrimVal::Bytes(layout.offset(b as u64, i)? as u128)))
-            },
+                Ok(Pointer::from(
+                    PrimVal::Bytes(layout.offset(b as u64, i)? as u128),
+                ))
+            }
             PrimVal::Ptr(ptr) => ptr.offset(i, layout).map(Pointer::from),
             PrimVal::Undef => err!(ReadUndefBytes),
         }
@@ -93,8 +93,10 @@ impl<'tcx> Pointer {
         match self.primval {
             PrimVal::Bytes(b) => {
                 assert_eq!(b as u64 as u128, b);
-                Ok(Pointer::from(PrimVal::Bytes(layout.wrapping_signed_offset(b as u64, i) as u128)))
-            },
+                Ok(Pointer::from(PrimVal::Bytes(
+                    layout.wrapping_signed_offset(b as u64, i) as u128,
+                )))
+            }
             PrimVal::Ptr(ptr) => Ok(Pointer::from(ptr.wrapping_signed_offset(i, layout))),
             PrimVal::Undef => err!(ReadUndefBytes),
         }
@@ -154,9 +156,18 @@ pub enum PrimVal {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PrimValKind {
-    I8, I16, I32, I64, I128,
-    U8, U16, U32, U64, U128,
-    F32, F64,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    F32,
+    F64,
     Bool,
     Char,
     Ptr,
@@ -171,26 +182,35 @@ impl<'a, 'tcx: 'a> Value {
 
     /// Convert the value into a pointer (or a pointer-sized integer).  If the value is a ByRef,
     /// this may have to perform a load.
-    pub fn into_ptr<M: Machine<'tcx>>(&self, mem: &Memory<'a, 'tcx, M>) -> EvalResult<'tcx, Pointer> {
+    pub fn into_ptr<M: Machine<'tcx>>(
+        &self,
+        mem: &Memory<'a, 'tcx, M>,
+    ) -> EvalResult<'tcx, Pointer> {
         use self::Value::*;
         match *self {
             ByRef { ptr, aligned } => {
-                mem.read_maybe_aligned(aligned, |mem| mem.read_ptr(ptr.to_ptr()?) )
-            },
-            ByVal(ptr) | ByValPair(ptr, _) => Ok(ptr.into()),
+                mem.read_maybe_aligned(aligned, |mem| mem.read_ptr(ptr.to_ptr()?))
+            }
+            ByVal(ptr) |
+            ByValPair(ptr, _) => Ok(ptr.into()),
         }
     }
 
     pub(super) fn into_ptr_vtable_pair<M: Machine<'tcx>>(
         &self,
-        mem: &Memory<'a, 'tcx, M>
+        mem: &Memory<'a, 'tcx, M>,
     ) -> EvalResult<'tcx, (Pointer, MemoryPointer)> {
         use self::Value::*;
         match *self {
-            ByRef { ptr: ref_ptr, aligned } => {
+            ByRef {
+                ptr: ref_ptr,
+                aligned,
+            } => {
                 mem.read_maybe_aligned(aligned, |mem| {
                     let ptr = mem.read_ptr(ref_ptr.to_ptr()?)?;
-                    let vtable = mem.read_ptr(ref_ptr.offset(mem.pointer_size(), mem.layout)?.to_ptr()?)?;
+                    let vtable = mem.read_ptr(
+                        ref_ptr.offset(mem.pointer_size(), mem.layout)?.to_ptr()?,
+                    )?;
                     Ok((ptr, vtable.to_ptr()?))
                 })
             }
@@ -202,21 +222,29 @@ impl<'a, 'tcx: 'a> Value {
         }
     }
 
-    pub(super) fn into_slice<M: Machine<'tcx>>(&self, mem: &Memory<'a, 'tcx, M>) -> EvalResult<'tcx, (Pointer, u64)> {
+    pub(super) fn into_slice<M: Machine<'tcx>>(
+        &self,
+        mem: &Memory<'a, 'tcx, M>,
+    ) -> EvalResult<'tcx, (Pointer, u64)> {
         use self::Value::*;
         match *self {
-            ByRef { ptr: ref_ptr, aligned } => {
+            ByRef {
+                ptr: ref_ptr,
+                aligned,
+            } => {
                 mem.read_maybe_aligned(aligned, |mem| {
                     let ptr = mem.read_ptr(ref_ptr.to_ptr()?)?;
-                    let len = mem.read_usize(ref_ptr.offset(mem.pointer_size(), mem.layout)?.to_ptr()?)?;
+                    let len = mem.read_usize(
+                        ref_ptr.offset(mem.pointer_size(), mem.layout)?.to_ptr()?,
+                    )?;
                     Ok((ptr, len))
                 })
-            },
+            }
             ByValPair(ptr, val) => {
                 let len = val.to_u128()?;
                 assert_eq!(len as u64 as u128, len);
                 Ok((ptr.into(), len as u64))
-            },
+            }
             ByVal(PrimVal::Undef) => err!(ReadUndefBytes),
             ByVal(_) => bug!("expected ptr and length, got {:?}", self),
         }
@@ -348,7 +376,7 @@ impl PrimValKind {
         }
     }
 
-     pub fn is_float(self) -> bool {
+    pub fn is_float(self) -> bool {
         use self::PrimValKind::*;
         match self {
             F32 | F64 => true,

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -16,7 +16,11 @@ macro_rules! eprintln {
 const MIRI_PATH: &'static str = concat!("target/", env!("PROFILE"), "/miri");
 
 fn compile_fail(sysroot: &Path, path: &str, target: &str, host: &str, fullmir: bool) {
-    eprintln!("## Running compile-fail tests in {} against miri for target {}", path, target);
+    eprintln!(
+        "## Running compile-fail tests in {} against miri for target {}",
+        path,
+        target
+    );
     let mut config = compiletest::default_config();
     config.mode = "compile-fail".parse().expect("Invalid mode");
     config.rustc_path = MIRI_PATH.into();
@@ -26,7 +30,9 @@ fn compile_fail(sysroot: &Path, path: &str, target: &str, host: &str, fullmir: b
             // skip fullmir on nonhost
             return;
         }
-        let sysroot = Path::new(&std::env::var("HOME").unwrap()).join(".xargo").join("HOST");
+        let sysroot = Path::new(&std::env::var("HOME").unwrap())
+            .join(".xargo")
+            .join("HOST");
         config.target_rustcflags = Some(format!("--sysroot {}", sysroot.to_str().unwrap()));
         config.src_base = PathBuf::from(path.to_string());
     } else {
@@ -50,12 +56,13 @@ fn run_pass(path: &str) {
 }
 
 fn miri_pass(path: &str, target: &str, host: &str, fullmir: bool, opt: bool) {
-    let opt_str = if opt {
-        " with optimizations"
-    } else {
-        ""
-    };
-    eprintln!("## Running run-pass tests in {} against miri for target {}{}", path, target, opt_str);
+    let opt_str = if opt { " with optimizations" } else { "" };
+    eprintln!(
+        "## Running run-pass tests in {} against miri for target {}{}",
+        path,
+        target,
+        opt_str
+    );
     let mut config = compiletest::default_config();
     config.mode = "mir-opt".parse().expect("Invalid mode");
     config.src_base = PathBuf::from(path);
@@ -68,7 +75,9 @@ fn miri_pass(path: &str, target: &str, host: &str, fullmir: bool, opt: bool) {
             // skip fullmir on nonhost
             return;
         }
-        let sysroot = Path::new(&std::env::var("HOME").unwrap()).join(".xargo").join("HOST");
+        let sysroot = Path::new(&std::env::var("HOME").unwrap())
+            .join(".xargo")
+            .join("HOST");
         flags.push(format!("--sysroot {}", sysroot.to_str().unwrap()));
     }
     if opt {
@@ -99,7 +108,9 @@ fn for_all_targets<F: FnMut(String)>(sysroot: &Path, mut f: F) {
     let target_dir = sysroot.join("lib").join("rustlib");
     for entry in std::fs::read_dir(target_dir).expect("invalid sysroot") {
         let entry = entry.unwrap();
-        if !is_target_dir(entry.path()) { continue; }
+        if !is_target_dir(entry.path()) {
+            continue;
+        }
         let target = entry.file_name().into_string().unwrap();
         f(target);
     }
@@ -125,7 +136,9 @@ fn get_host() -> String {
         .expect("rustc not found for -vV")
         .stdout;
     let host = std::str::from_utf8(&host).expect("sysroot is not utf8");
-    let host = host.split("\nhost: ").nth(1).expect("no host: part in rustc -vV");
+    let host = host.split("\nhost: ").nth(1).expect(
+        "no host: part in rustc -vV",
+    );
     let host = host.split('\n').next().expect("no \n after host");
     String::from(host)
 }

--- a/tests/run-pass-fullmir/hashmap.rs
+++ b/tests/run-pass-fullmir/hashmap.rs
@@ -21,5 +21,5 @@ fn main() {
     }
     assert_eq!(map.values().fold(0, |x, y| x+y), num*(num-1)/2);
 
-    // TODO: Test Entry API
+    // FIXME: Test Entry API
 }


### PR DESCRIPTION
Our lines are often longer than 100 chars. This won't be allowed once miri moves to rustc. I ran rustfmt, which fixed a bunch of those, but there's more (probably inside macros) which rustfmt chokes upon.