### PR TITLE
Prepare for splitting off static alloc ids from local alloc ids

### DIFF
--- a/miri/fn_call.rs
+++ b/miri/fn_call.rs
@@ -329,8 +329,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                     if let Ok(instance) = self.resolve_path(path) {
                         let cid = GlobalId { instance, promoted: None };
                         // compute global if not cached
-                        let val = match self.globals.get(&cid).map(|&ptr| ptr) {
-                            Some(ptr) => self.value_to_primval(Value::by_ref(ptr.into()), usize)?.to_u64()?,
+                        let val = match self.globals.get(&cid).cloned() {
+                            Some(ptr) => self.value_to_primval(Value::ByRef(ptr), usize)?.to_u64()?,
                             None => eval_body_as_primval(self.tcx, instance)?.0.to_u64()?,
                         };
                         if val == name {

--- a/miri/fn_call.rs
+++ b/miri/fn_call.rs
@@ -317,7 +317,8 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
             }
 
             "sysconf" => {
-                let name = self.value_to_primval(args[0], usize)?.to_u64()?;
+                let c_int = self.operand_ty(&arg_operands[0]);
+                let name = self.value_to_primval(args[0], c_int)?.to_u64()?;
                 trace!("sysconf() called with name {}", name);
                 // cache the sysconf integers via miri's global cache
                 let paths = &[
@@ -330,7 +331,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                         let cid = GlobalId { instance, promoted: None };
                         // compute global if not cached
                         let val = match self.globals.get(&cid).cloned() {
-                            Some(ptr) => self.value_to_primval(Value::ByRef(ptr), usize)?.to_u64()?,
+                            Some(ptr) => self.value_to_primval(Value::ByRef(ptr), c_int)?.to_u64()?,
                             None => eval_body_as_primval(self.tcx, instance)?.0.to_u64()?,
                         };
                         if val == name {

--- a/miri/intrinsic.rs
+++ b/miri/intrinsic.rs
@@ -18,7 +18,7 @@ pub trait EvalContextExt<'tcx> {
         &mut self,
         instance: ty::Instance<'tcx>,
         args: &[mir::Operand<'tcx>],
-        dest: Lvalue<'tcx>,
+        dest: Lvalue,
         dest_ty: Ty<'tcx>,
         dest_layout: &'tcx Layout,
         target: mir::BasicBlock,
@@ -30,7 +30,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
         &mut self,
         instance: ty::Instance<'tcx>,
         args: &[mir::Operand<'tcx>],
-        dest: Lvalue<'tcx>,
+        dest: Lvalue,
         dest_ty: Ty<'tcx>,
         dest_layout: &'tcx Layout,
         target: mir::BasicBlock,
@@ -291,7 +291,6 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                     Lvalue::Local { frame, local } => self.modify_local(frame, local, init)?,
                     Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true } => self.memory.write_repeat(ptr, 0, size)?,
                     Lvalue::Ptr { .. } => bug!("init intrinsic tried to write to fat or unaligned ptr target"),
-                    Lvalue::Global(cid) => self.modify_global(cid, init)?,
                 }
             }
 
@@ -469,7 +468,6 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                     Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true } =>
                         self.memory.mark_definedness(ptr, size, false)?,
                     Lvalue::Ptr { .. } => bug!("uninit intrinsic tried to write to fat or unaligned ptr target"),
-                    Lvalue::Global(cid) => self.modify_global(cid, uninit)?,
                 }
             }
 

--- a/miri/intrinsic.rs
+++ b/miri/intrinsic.rs
@@ -8,7 +8,7 @@ use rustc_miri::interpret::{
     Lvalue, LvalueExtra,
     PrimVal, PrimValKind, Value, Pointer,
     HasMemory,
-    EvalContext,
+    EvalContext, PtrAndAlign,
 };
 
 use helpers::EvalContextExt as HelperEvalContextExt;
@@ -266,10 +266,10 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let size = self.type_size(dest_ty)?.expect("cannot zero unsized value");
                 let init = |this: &mut Self, val: Value| {
                     let zero_val = match val {
-                        Value::ByRef { ptr, aligned } => {
+                        Value::ByRef(PtrAndAlign { ptr, .. }) => {
                             // These writes have no alignment restriction anyway.
                             this.memory.write_repeat(ptr, 0, size)?;
-                            Value::ByRef { ptr, aligned }
+                            val
                         },
                         // TODO(solson): Revisit this, it's fishy to check for Undef here.
                         Value::ByVal(PrimVal::Undef) => match this.ty_to_primval_kind(dest_ty) {
@@ -289,7 +289,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 };
                 match dest {
                     Lvalue::Local { frame, local } => self.modify_local(frame, local, init)?,
-                    Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true } => self.memory.write_repeat(ptr, 0, size)?,
+                    Lvalue::Ptr { ptr: PtrAndAlign { ptr, aligned: true }, extra: LvalueExtra::None } => self.memory.write_repeat(ptr, 0, size)?,
                     Lvalue::Ptr { .. } => bug!("init intrinsic tried to write to fat or unaligned ptr target"),
                 }
             }
@@ -456,16 +456,16 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
                 let size = dest_layout.size(&self.tcx.data_layout).bytes();
                 let uninit = |this: &mut Self, val: Value| {
                     match val {
-                        Value::ByRef { ptr, aligned } => {
+                        Value::ByRef(PtrAndAlign { ptr, .. }) => {
                             this.memory.mark_definedness(ptr, size, false)?;
-                            Ok(Value::ByRef { ptr, aligned })
+                            Ok(val)
                         },
                         _ => Ok(Value::ByVal(PrimVal::Undef)),
                     }
                 };
                 match dest {
                     Lvalue::Local { frame, local } => self.modify_local(frame, local, uninit)?,
-                    Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: true } =>
+                    Lvalue::Ptr { ptr: PtrAndAlign { ptr, aligned: true }, extra: LvalueExtra::None } =>
                         self.memory.mark_definedness(ptr, size, false)?,
                     Lvalue::Ptr { .. } => bug!("uninit intrinsic tried to write to fat or unaligned ptr target"),
                 }

--- a/miri/lib.rs
+++ b/miri/lib.rs
@@ -167,7 +167,7 @@ impl<'tcx> Machine<'tcx> for Evaluator {
     fn eval_fn_call<'a>(
         ecx: &mut EvalContext<'a, 'tcx, Self>,
         instance: ty::Instance<'tcx>,
-        destination: Option<(Lvalue<'tcx>, mir::BasicBlock)>,
+        destination: Option<(Lvalue, mir::BasicBlock)>,
         arg_operands: &[mir::Operand<'tcx>],
         span: Span,
         sig: ty::FnSig<'tcx>,
@@ -179,7 +179,7 @@ impl<'tcx> Machine<'tcx> for Evaluator {
         ecx: &mut rustc_miri::interpret::EvalContext<'a, 'tcx, Self>,
         instance: ty::Instance<'tcx>,
         args: &[mir::Operand<'tcx>],
-        dest: Lvalue<'tcx>,
+        dest: Lvalue,
         dest_ty: ty::Ty<'tcx>,
         dest_layout: &'tcx Layout,
         target: mir::BasicBlock,

--- a/miri/lib.rs
+++ b/miri/lib.rs
@@ -71,7 +71,7 @@ pub fn eval_main<'a, 'tcx: 'a>(
             // Return value
             let size = ecx.tcx.data_layout.pointer_size.bytes();
             let align = ecx.tcx.data_layout.pointer_align.abi();
-            let ret_ptr = ecx.memory_mut().allocate(size, align, Kind::Stack)?;
+            let ret_ptr = ecx.memory_mut().allocate(size, align, MemoryKind::Stack)?;
             cleanup_ptr = Some(ret_ptr);
 
             // Push our stack frame
@@ -114,7 +114,7 @@ pub fn eval_main<'a, 'tcx: 'a>(
         while ecx.step()? {}
         ecx.run_tls_dtors()?;
         if let Some(cleanup_ptr) = cleanup_ptr {
-            ecx.memory_mut().deallocate(cleanup_ptr, None, Kind::Stack)?;
+            ecx.memory_mut().deallocate(cleanup_ptr, None, MemoryKind::Stack)?;
         }
         Ok(())
     }
@@ -161,7 +161,7 @@ struct MemoryData<'tcx> {
 impl<'tcx> Machine<'tcx> for Evaluator {
     type Data = EvaluatorData;
     type MemoryData = MemoryData<'tcx>;
-    type MemoryKinds = memory::Kind;
+    type MemoryKinds = memory::MemoryKind;
 
     /// Returns Ok() when the function was handled, fail otherwise
     fn eval_fn_call<'a>(
@@ -198,8 +198,8 @@ impl<'tcx> Machine<'tcx> for Evaluator {
         ecx.ptr_op(bin_op, left, left_ty, right, right_ty)
     }
 
-    fn mark_static_initialized(m: memory::Kind) -> EvalResult<'tcx> {
-        use memory::Kind::*;
+    fn mark_static_initialized(m: memory::MemoryKind) -> EvalResult<'tcx> {
+        use memory::MemoryKind::*;
         match m {
             // FIXME: This could be allowed, but not for env vars set during miri execution
             Env => err!(Unimplemented("statics can't refer to env vars".to_owned())),
@@ -218,7 +218,7 @@ impl<'tcx> Machine<'tcx> for Evaluator {
             Ok(PrimVal::Bytes(align.into()))
         } else {
             ecx.memory
-                .allocate(size, align, Kind::Machine(memory::Kind::Rust))
+                .allocate(size, align, MemoryKind::Machine(memory::MemoryKind::Rust))
                 .map(PrimVal::Ptr)
         }
     }

--- a/miri/memory.rs
+++ b/miri/memory.rs
@@ -1,6 +1,6 @@
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub enum Kind {
+pub enum MemoryKind {
     /// Error if deallocated any other way than `rust_deallocate`
     Rust,
     /// Error if deallocated any other way than `free`
@@ -9,8 +9,8 @@ pub enum Kind {
     Env,
 }
 
-impl Into<::rustc_miri::interpret::Kind<Kind>> for Kind {
-    fn into(self) -> ::rustc_miri::interpret::Kind<Kind> {
-        ::rustc_miri::interpret::Kind::Machine(self)
+impl Into<::rustc_miri::interpret::MemoryKind<MemoryKind>> for MemoryKind {
+    fn into(self) -> ::rustc_miri::interpret::MemoryKind<MemoryKind> {
+        ::rustc_miri::interpret::MemoryKind::Machine(self)
     }
 }

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -47,7 +47,7 @@ pub fn eval_body_as_primval<'a, 'tcx>(
         };
         let cleanup = StackPopCleanup::MarkStatic(mutability);
         let name = ty::tls::with(|tcx| tcx.item_path_str(instance.def_id()));
-        trace!("pushing stack frame for global: {}", name);
+        trace!("const_eval: pushing stack frame for global: {}", name);
         ecx.push_stack_frame(
             instance,
             mir.span,

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -10,7 +10,7 @@ use super::{
     GlobalId, Lvalue, Value,
     PrimVal,
     EvalContext, StackPopCleanup, PtrAndAlign,
-    Kind,
+    MemoryKind,
 };
 
 use rustc_const_math::ConstInt;
@@ -33,7 +33,7 @@ pub fn eval_body_as_primval<'a, 'tcx>(
     if !ecx.globals.contains_key(&cid) {
         let size = ecx.type_size_with_substs(mir.return_ty, instance.substs)?.expect("unsized global");
         let align = ecx.type_align_with_substs(mir.return_ty, instance.substs)?;
-        let ptr = ecx.memory.allocate(size, align, Kind::UninitializedStatic)?;
+        let ptr = ecx.memory.allocate(size, align, MemoryKind::UninitializedStatic)?;
         let aligned = !ecx.is_packed(mir.return_ty)?;
         ecx.globals.insert(cid, PtrAndAlign { ptr: ptr.into(), aligned });
         let mutable = !mir.return_ty.is_freeze(

--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -7,9 +7,10 @@ use syntax::codemap::Span;
 
 use super::{
     EvalResult, EvalError, EvalErrorKind,
-    Global, GlobalId, Lvalue,
+    GlobalId, Lvalue, Value,
     PrimVal,
     EvalContext, StackPopCleanup,
+    Kind,
 };
 
 use rustc_const_math::ConstInt;
@@ -30,7 +31,10 @@ pub fn eval_body_as_primval<'a, 'tcx>(
     
     let mir = ecx.load_mir(instance.def)?;
     if !ecx.globals.contains_key(&cid) {
-        ecx.globals.insert(cid, Global::uninitialized(mir.return_ty));
+        let size = ecx.type_size_with_substs(mir.return_ty, instance.substs)?.expect("unsized global");
+        let align = ecx.type_align_with_substs(mir.return_ty, instance.substs)?;
+        let ptr = ecx.memory.allocate(size, align, Kind::UninitializedStatic)?;
+        ecx.globals.insert(cid, ptr);
         let mutable = !mir.return_ty.is_freeze(
                 ecx.tcx,
                 ty::ParamEnv::empty(Reveal::All),
@@ -47,13 +51,13 @@ pub fn eval_body_as_primval<'a, 'tcx>(
             instance,
             mir.span,
             mir,
-            Lvalue::Global(cid),
+            Lvalue::from_ptr(ptr),
             cleanup,
         )?;
 
         while ecx.step()? {}
     }
-    let value = ecx.globals.get(&cid).expect("global not cached").value;
+    let value = Value::by_ref(ecx.globals.get(&cid).expect("global not cached").into());
     Ok((ecx.value_to_primval(value, mir.return_ty)?, mir.return_ty))
 }
 
@@ -132,7 +136,7 @@ impl<'tcx> super::Machine<'tcx> for CompileTimeFunctionEvaluator {
     fn eval_fn_call<'a>(
         ecx: &mut EvalContext<'a, 'tcx, Self>,
         instance: ty::Instance<'tcx>,
-        destination: Option<(Lvalue<'tcx>, mir::BasicBlock)>,
+        destination: Option<(Lvalue, mir::BasicBlock)>,
         _arg_operands: &[mir::Operand<'tcx>],
         span: Span,
         _sig: ty::FnSig<'tcx>,
@@ -168,7 +172,7 @@ impl<'tcx> super::Machine<'tcx> for CompileTimeFunctionEvaluator {
         _ecx: &mut EvalContext<'a, 'tcx, Self>,
         _instance: ty::Instance<'tcx>,
         _args: &[mir::Operand<'tcx>],
-        _dest: Lvalue<'tcx>,
+        _dest: Lvalue,
         _dest_ty: Ty<'tcx>,
         _dest_layout: &'tcx layout::Layout,
         _target: mir::BasicBlock,

--- a/src/librustc_mir/interpret/error.rs
+++ b/src/librustc_mir/interpret/error.rs
@@ -139,7 +139,7 @@ impl<'tcx> Error for EvalError<'tcx> {
             DoubleFree =>
                 "tried to deallocate dangling pointer",
             InvalidFunctionPointer =>
-                "tried to use an integer pointer or a dangling pointer as a function pointer",
+                "tried to use a function pointer after offsetting it",
             InvalidBool =>
                 "invalid boolean value read",
             InvalidDiscriminant =>

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -20,7 +20,7 @@ use super::{
     EvalError, EvalResult, EvalErrorKind,
     GlobalId, Lvalue, LvalueExtra,
     Memory, MemoryPointer, HasMemory,
-    Kind as MemoryKind,
+    MemoryKind,
     operator,
     PrimVal, PrimValKind, Value, Pointer,
     ValidationQuery,

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -214,20 +214,6 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         self.stack.len() - 1
     }
 
-    /// Returns true if the current frame or any parent frame is part of a ctfe.
-    ///
-    /// Used to disable features in const eval, which do not have a rfc enabling
-    /// them or which can't be written in a way that they produce the same output
-    /// that evaluating the code at runtime would produce.
-    pub fn const_env(&self) -> bool {
-        for frame in self.stack.iter().rev() {
-            if let StackPopCleanup::MarkStatic(_) = frame.return_to_block {
-                return true;
-            }
-        }
-        false
-    }
-
     pub fn str_to_value(&mut self, s: &str) -> EvalResult<'tcx, Value> {
         let ptr = self.memory.allocate_cached(s.as_bytes())?;
         Ok(Value::ByValPair(PrimVal::Ptr(ptr), PrimVal::from_u128(s.len() as u128)))

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -7,7 +7,7 @@ use rustc::middle::const_val::ConstVal;
 use rustc::middle::region::CodeExtent;
 use rustc::mir;
 use rustc::traits::Reveal;
-use rustc::ty::layout::{self, Layout, Size, Align};
+use rustc::ty::layout::{self, Layout, Size, Align, HasDataLayout};
 use rustc::ty::subst::{Subst, Substs, Kind};
 use rustc::ty::{self, Ty, TyCtxt, TypeFoldable, Binder};
 use rustc::traits;
@@ -41,7 +41,7 @@ pub struct EvalContext<'a, 'tcx: 'a, M: Machine<'tcx>> {
     pub(crate) suspended: HashMap<DynamicLifetime, Vec<ValidationQuery<'tcx>>>,
 
     /// Precomputed statics, constants and promoteds.
-    pub globals: HashMap<GlobalId<'tcx>, MemoryPointer>,
+    pub globals: HashMap<GlobalId<'tcx>, PtrAndAlign>,
 
     /// The virtual call stack.
     pub(crate) stack: Vec<Frame<'tcx>>,
@@ -141,6 +141,25 @@ impl Default for ResourceLimits {
 pub struct TyAndPacked<'tcx> {
     pub ty: Ty<'tcx>,
     pub packed: bool,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct PtrAndAlign {
+    pub ptr: Pointer,
+    /// Remember whether this lvalue is *supposed* to be aligned.
+    pub aligned: bool,
+}
+
+impl PtrAndAlign {
+    pub fn to_ptr<'tcx>(self) -> EvalResult<'tcx, MemoryPointer> {
+        self.ptr.to_ptr()
+    }
+    pub fn offset<'tcx, C: HasDataLayout>(self, i: u64, cx: C) -> EvalResult<'tcx, Self> {
+        Ok(PtrAndAlign {
+            ptr: self.ptr.offset(i, cx)?,
+            aligned: self.aligned,
+        })
+    }
 }
 
 impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
@@ -503,7 +522,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     }
 
     pub fn deallocate_local(&mut self, local: Option<Value>) -> EvalResult<'tcx> {
-        if let Some(Value::ByRef { ptr, aligned: _ }) = local {
+        if let Some(Value::ByRef(ptr)) = local {
             trace!("deallocating local");
             let ptr = ptr.to_ptr()?;
             self.memory.dump_alloc(ptr.alloc_id);
@@ -536,9 +555,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         self.memory.write_uint(discr_dest, discr_val, discr_size)?;
 
         let dest = Lvalue::Ptr {
-            ptr: dest_ptr.into(),
+            ptr: PtrAndAlign {
+                ptr: dest_ptr.into(),
+                aligned: true,
+            },
             extra: LvalueExtra::DowncastVariant(variant_idx),
-            aligned: true,
         };
 
         self.assign_fields(dest, dest_ty, operands)
@@ -617,7 +638,13 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 self.inc_step_counter_and_check_limit(operands.len() as u64)?;
                 use rustc::ty::layout::Layout::*;
                 match *dest_layout {
-                    Univariant { .. } | Array { .. } => {
+                    Univariant { ref variant, .. } => {
+                        self.write_maybe_aligned_mut(!variant.packed, |ecx| {
+                            ecx.assign_fields(dest, dest_ty, operands)
+                        })?;
+                    }
+
+                    Array { .. } => {
                         self.assign_fields(dest, dest_ty, operands)?;
                     }
 
@@ -664,10 +691,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         }
                     }
 
-                    StructWrappedNullablePointer { nndiscr, ref discrfield_source, .. } => {
+                    StructWrappedNullablePointer { nndiscr, ref discrfield_source, ref nonnull, .. } => {
                         if let mir::AggregateKind::Adt(_, variant, _, _) = **kind {
                             if nndiscr == variant as u64 {
-                                self.assign_fields(dest, dest_ty, operands)?;
+                                self.write_maybe_aligned_mut(!nonnull.packed, |ecx| {
+                                    ecx.assign_fields(dest, dest_ty, operands)
+                                })?;
                             } else {
                                 for operand in operands {
                                     let operand_ty = self.operand_ty(operand);
@@ -682,7 +711,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                                 let dest = dest.offset(offset.bytes(), &self)?;
                                 let dest_size = self.type_size(ty)?
                                     .expect("bad StructWrappedNullablePointer discrfield");
-                                self.memory.write_int(dest, 0, dest_size)?;
+                                self.memory.write_maybe_aligned_mut(!nonnull.packed, |mem| {
+                                    mem.write_int(dest, 0, dest_size)
+                                })?;
                             }
                         } else {
                             bug!("tried to assign {:?} to Layout::RawNullablePointer", kind);
@@ -707,12 +738,14 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         self.assign_fields(dest, dest_ty, operands)?;
                     }
 
-                    UntaggedUnion { .. } => {
+                    UntaggedUnion { ref variants } => {
                         assert_eq!(operands.len(), 1);
                         let operand = &operands[0];
                         let value = self.eval_operand(operand)?;
                         let value_ty = self.operand_ty(operand);
-                        self.write_value(value, dest, value_ty)?;
+                        self.write_maybe_aligned_mut(!variants.packed, |ecx| {
+                            ecx.write_value(value, dest, value_ty)
+                        })?;
                     }
 
                     _ => {
@@ -756,12 +789,12 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 let src = self.eval_lvalue(lvalue)?;
                 // We ignore the alignment of the lvalue here -- special handling for packed structs ends
                 // at the `&` operator.
-                let (ptr, extra, _aligned) = self.force_allocation(src)?.to_ptr_extra_aligned();
+                let (ptr, extra) = self.force_allocation(src)?.to_ptr_extra_aligned();
 
                 let val = match extra {
-                    LvalueExtra::None => ptr.to_value(),
-                    LvalueExtra::Length(len) => ptr.to_value_with_len(len),
-                    LvalueExtra::Vtable(vtable) => ptr.to_value_with_vtable(vtable),
+                    LvalueExtra::None => ptr.ptr.to_value(),
+                    LvalueExtra::Length(len) => ptr.ptr.to_value_with_len(len),
+                    LvalueExtra::Vtable(vtable) => ptr.ptr.to_value_with_vtable(vtable),
                     LvalueExtra::DowncastVariant(..) =>
                         bug!("attempted to take a reference to an enum downcast lvalue"),
                 };
@@ -1024,7 +1057,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                     Literal::Item { def_id, substs } => {
                         let instance = self.resolve_associated_const(def_id, substs);
                         let cid = GlobalId { instance, promoted: None };
-                        Value::by_ref(self.globals.get(&cid).expect("static/const not cached").into())
+                        Value::ByRef(*self.globals.get(&cid).expect("static/const not cached"))
                     }
 
                     Literal::Promoted { index } => {
@@ -1032,13 +1065,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                             instance: self.frame().instance,
                             promoted: Some(index),
                         };
-                        Value::by_ref(self.globals.get(&cid).expect("promoted not cached").into())
+                        Value::ByRef(*self.globals.get(&cid).expect("promoted not cached"))
                     }
                 };
 
                 Ok(value)
             }
         }
+    }
+
+    pub fn read_global_as_value(&self, gid: GlobalId) -> Value {
+        Value::ByRef(*self.globals.get(&gid).expect("global not cached"))
     }
 
     pub fn operand_ty(&self, operand: &mir::Operand<'tcx>) -> Ty<'tcx> {
@@ -1052,6 +1089,21 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         Ok(())
     }
 
+    pub fn is_packed(&self, ty: Ty<'tcx>) -> EvalResult<'tcx, bool> {
+        let layout = self.type_layout(ty)?;
+        use rustc::ty::layout::Layout::*;
+        Ok(match *layout {
+            Univariant { ref variant, .. } => variant.packed,
+
+            StructWrappedNullablePointer { ref nonnull, .. } => nonnull.packed,
+
+            UntaggedUnion { ref variants } => variants.packed,
+
+            // can only apply #[repr(packed)] to struct and union
+            _ => false,
+        })
+    }
+
     pub fn force_allocation(
         &mut self,
         lvalue: Lvalue,
@@ -1061,8 +1113,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 // -1 since we don't store the return value
                 match self.stack[frame].locals[local.index() - 1] {
                     None => return err!(DeadLocal),
-                    Some(Value::ByRef { ptr, aligned }) => {
-                        Lvalue::Ptr { ptr, aligned, extra: LvalueExtra::None }
+                    Some(Value::ByRef(ptr)) => {
+                        Lvalue::Ptr { ptr, extra: LvalueExtra::None }
                     },
                     Some(val) => {
                         let ty = self.stack[frame].mir.local_decls[local].ty;
@@ -1083,7 +1135,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     /// ensures this Value is not a ByRef
     pub(super) fn follow_by_ref_value(&mut self, value: Value, ty: Ty<'tcx>) -> EvalResult<'tcx, Value> {
         match value {
-            Value::ByRef { ptr, aligned } => {
+            Value::ByRef(PtrAndAlign { ptr, aligned }) => {
                 self.read_maybe_aligned(aligned, |ectx| ectx.read_value(ptr, ty))
             }
             other => Ok(other),
@@ -1141,7 +1193,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         // correct if we never look at this data with the wrong type.
 
         match dest {
-            Lvalue::Ptr { ptr, extra, aligned } => {
+            Lvalue::Ptr { ptr: PtrAndAlign { ptr, aligned }, extra } => {
                 assert_eq!(extra, LvalueExtra::None);
                 self.write_maybe_aligned_mut(aligned,
                     |ectx| ectx.write_value_to_ptr(src_val, ptr, dest_ty))
@@ -1167,7 +1219,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         old_dest_val: Value,
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
-        if let Value::ByRef { ptr: dest_ptr, aligned } = old_dest_val {
+        if let Value::ByRef(PtrAndAlign { ptr: dest_ptr, aligned }) = old_dest_val {
             // If the value is already `ByRef` (that is, backed by an `Allocation`),
             // then we must write the new value into this allocation, because there may be
             // other pointers into the allocation. These other pointers are logically
@@ -1178,7 +1230,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             self.write_maybe_aligned_mut(aligned,
                 |ectx| ectx.write_value_to_ptr(src_val, dest_ptr, dest_ty))?;
 
-        } else if let Value::ByRef { ptr: src_ptr, aligned } = src_val {
+        } else if let Value::ByRef(PtrAndAlign { ptr: src_ptr, aligned }) = src_val {
             // If the value is not `ByRef`, then we know there are no pointers to it
             // and we can simply overwrite the `Value` in the locals array directly.
             //
@@ -1216,7 +1268,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
         match value {
-            Value::ByRef { ptr, aligned } => {
+            Value::ByRef(PtrAndAlign { ptr, aligned }) => {
                 self.read_maybe_aligned_mut(aligned, |ectx| ectx.copy(ptr, dest, dest_ty))
             },
             Value::ByVal(primval) => {
@@ -1551,7 +1603,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 //let src = adt::MaybeSizedValue::sized(src);
                 //let dst = adt::MaybeSizedValue::sized(dst);
                 let src_ptr = match src {
-                    Value::ByRef { ptr, aligned: true } => ptr,
+                    Value::ByRef(PtrAndAlign { ptr, aligned: true }) => ptr,
                     // TODO: Is it possible for unaligned pointers to occur here?
                     _ => bug!("expected aligned pointer, got {:?}", src),
                 };
@@ -1598,7 +1650,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 Err(err) => {
                     panic!("Failed to access local: {:?}", err);
                 }
-                Ok(Value::ByRef { ptr, aligned }) => match ptr.into_inner_primval() {
+                Ok(Value::ByRef(PtrAndAlign{ ptr, aligned })) => match ptr.into_inner_primval() {
                     PrimVal::Ptr(ptr) => {
                         write!(msg, " by {}ref:", if aligned { "" } else { "unaligned " }).unwrap();
                         allocs.push(ptr.alloc_id);

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -33,7 +33,7 @@ pub trait Machine<'tcx>: Sized {
     fn eval_fn_call<'a>(
         ecx: &mut EvalContext<'a, 'tcx, Self>,
         instance: ty::Instance<'tcx>,
-        destination: Option<(Lvalue<'tcx>, mir::BasicBlock)>,
+        destination: Option<(Lvalue, mir::BasicBlock)>,
         arg_operands: &[mir::Operand<'tcx>],
         span: Span,
         sig: ty::FnSig<'tcx>,
@@ -44,7 +44,7 @@ pub trait Machine<'tcx>: Sized {
         ecx: &mut EvalContext<'a, 'tcx, Self>,
         instance: ty::Instance<'tcx>,
         args: &[mir::Operand<'tcx>],
-        dest: Lvalue<'tcx>,
+        dest: Lvalue,
         dest_ty: ty::Ty<'tcx>,
         dest_layout: &'tcx ty::layout::Layout,
         target: mir::BasicBlock,

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -46,7 +46,7 @@ pub use self::memory::{
     AllocId,
     Memory,
     MemoryPointer,
-    Kind,
+    MemoryKind,
     HasMemory,
 };
 

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -38,7 +38,6 @@ pub use self::eval_context::{
 pub use self::lvalue::{
     Lvalue,
     LvalueExtra,
-    Global,
     GlobalId,
 };
 

--- a/src/librustc_mir/interpret/mod.rs
+++ b/src/librustc_mir/interpret/mod.rs
@@ -33,6 +33,7 @@ pub use self::eval_context::{
     StackPopCleanup,
     DynamicLifetime,
     TyAndPacked,
+    PtrAndAlign,
 };
 
 pub use self::lvalue::{

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -39,7 +39,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         op: mir::BinOp,
         left: &mir::Operand<'tcx>,
         right: &mir::Operand<'tcx>,
-        dest: Lvalue<'tcx>,
+        dest: Lvalue,
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx> {
         let (val, overflowed) = self.binop_with_overflow(op, left, right)?;
@@ -54,7 +54,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         op: mir::BinOp,
         left: &mir::Operand<'tcx>,
         right: &mir::Operand<'tcx>,
-        dest: Lvalue<'tcx>,
+        dest: Lvalue,
         dest_ty: Ty<'tcx>,
     ) -> EvalResult<'tcx, bool> {
         let (val, overflowed) = self.binop_with_overflow(op, left, right)?;

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -15,7 +15,7 @@ use super::{
     EvalResult,
     EvalContext, StackPopCleanup, TyAndPacked, PtrAndAlign,
     GlobalId, Lvalue,
-    HasMemory, Kind,
+    HasMemory, MemoryKind,
     Machine,
 };
 
@@ -179,7 +179,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             // FIXME: check that it's `#[linkage = "extern_weak"]`
             trace!("Initializing an extern global with NULL");
             let ptr_size = self.memory.pointer_size();
-            let ptr = self.memory.allocate(ptr_size, ptr_size, Kind::UninitializedStatic)?;
+            let ptr = self.memory.allocate(ptr_size, ptr_size, MemoryKind::UninitializedStatic)?;
             self.memory.write_usize(ptr, 0)?;
             self.memory.mark_static_initalized(ptr.alloc_id, mutability)?;
             self.globals.insert(cid, PtrAndAlign { ptr: ptr.into(), aligned: true });
@@ -188,7 +188,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         let mir = self.load_mir(instance.def)?;
         let size = self.type_size_with_substs(mir.return_ty, substs)?.expect("unsized global");
         let align = self.type_align_with_substs(mir.return_ty, substs)?;
-        let ptr = self.memory.allocate(size, align, Kind::UninitializedStatic)?;
+        let ptr = self.memory.allocate(size, align, MemoryKind::UninitializedStatic)?;
         let aligned = !self.is_packed(mir.return_ty)?;
         self.globals.insert(cid, PtrAndAlign { ptr: ptr.into(), aligned });
         let internally_mutable = !mir.return_ty.is_freeze(
@@ -265,7 +265,7 @@ impl<'a, 'b, 'tcx, M: Machine<'tcx>> Visitor<'tcx> for ConstantExtractor<'a, 'b,
                 self.try(|this| {
                     let size = this.ecx.type_size_with_substs(mir.return_ty, this.instance.substs)?.expect("unsized global");
                     let align = this.ecx.type_align_with_substs(mir.return_ty, this.instance.substs)?;
-                    let ptr = this.ecx.memory.allocate(size, align, Kind::UninitializedStatic)?;
+                    let ptr = this.ecx.memory.allocate(size, align, MemoryKind::UninitializedStatic)?;
                     let aligned = !this.ecx.is_packed(mir.return_ty)?;
                     this.ecx.globals.insert(cid, PtrAndAlign { ptr: ptr.into(), aligned });
                     trace!("pushing stack frame for {:?}", index);

--- a/src/librustc_mir/interpret/terminator/drop.rs
+++ b/src/librustc_mir/interpret/terminator/drop.rs
@@ -11,7 +11,7 @@ use interpret::{
 };
 
 impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
-    pub(crate) fn drop_lvalue(&mut self, lval: Lvalue<'tcx>, instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
+    pub(crate) fn drop_lvalue(&mut self, lval: Lvalue, instance: ty::Instance<'tcx>, ty: Ty<'tcx>, span: Span) -> EvalResult<'tcx> {
         trace!("drop_lvalue: {:#?}", lval);
         // We take the address of the object.  This may well be unaligned, which is fine for us here.
         // However, unaligned accesses will probably make the actual drop implementation fail -- a problem shared

--- a/src/librustc_mir/interpret/terminator/drop.rs
+++ b/src/librustc_mir/interpret/terminator/drop.rs
@@ -17,9 +17,9 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         // However, unaligned accesses will probably make the actual drop implementation fail -- a problem shared
         // by rustc.
         let val = match self.force_allocation(lval)? {
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable), aligned: _ } => ptr.to_value_with_vtable(vtable),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len), aligned: _ } => ptr.to_value_with_len(len),
-            Lvalue::Ptr { ptr, extra: LvalueExtra::None, aligned: _ } => ptr.to_value(),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Vtable(vtable) } => ptr.ptr.to_value_with_vtable(vtable),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::Length(len) } => ptr.ptr.to_value_with_len(len),
+            Lvalue::Ptr { ptr, extra: LvalueExtra::None } => ptr.ptr.to_value(),
             _ => bug!("force_allocation broken"),
         };
         self.drop(val, instance, ty, span)

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -6,7 +6,7 @@ use syntax::abi::Abi;
 
 use super::{
     EvalError, EvalResult, EvalErrorKind,
-    EvalContext, eval_context, TyAndPacked,
+    EvalContext, eval_context, TyAndPacked, PtrAndAlign,
     Lvalue,
     MemoryPointer,
     PrimVal, Value,
@@ -311,10 +311,10 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                             if self.frame().mir.args_iter().count() == fields.len() + 1 {
                                 let offsets = variant.offsets.iter().map(|s| s.bytes());
                                 match arg_val {
-                                    Value::ByRef { ptr, aligned } => {
+                                    Value::ByRef(PtrAndAlign { ptr, aligned }) => {
                                         assert!(aligned, "Unaligned ByRef-values cannot occur as function arguments");
                                         for ((offset, ty), arg_local) in offsets.zip(fields).zip(arg_locals) {
-                                            let arg = Value::ByRef { ptr: ptr.offset(offset, &self)?, aligned: true};
+                                            let arg = Value::by_ref(ptr.offset(offset, &self)?);
                                             let dest = self.eval_lvalue(&mir::Lvalue::Local(arg_local))?;
                                             trace!("writing arg {:?} to {:?} (type: {})", arg, dest, ty);
                                             self.write_value(arg, dest, ty)?;

--- a/src/librustc_mir/interpret/terminator/mod.rs
+++ b/src/librustc_mir/interpret/terminator/mod.rs
@@ -204,7 +204,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
     fn eval_fn_call(
         &mut self,
         instance: ty::Instance<'tcx>,
-        destination: Option<(Lvalue<'tcx>, mir::BasicBlock)>,
+        destination: Option<(Lvalue, mir::BasicBlock)>,
         arg_operands: &[mir::Operand<'tcx>],
         span: Span,
         sig: ty::FnSig<'tcx>,

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -8,7 +8,7 @@ use syntax::ast::{self, Mutability};
 use super::{
     EvalResult,
     EvalContext, eval_context,
-    MemoryPointer, Kind,
+    MemoryPointer, MemoryKind,
     Value, PrimVal,
     Machine,
 };
@@ -51,7 +51,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
 
         let ptr_size = self.memory.pointer_size();
         let methods = ::rustc::traits::get_vtable_methods(self.tcx, trait_ref);
-        let vtable = self.memory.allocate(ptr_size * (3 + methods.count() as u64), ptr_size, Kind::UninitializedStatic)?;
+        let vtable = self.memory.allocate(ptr_size * (3 + methods.count() as u64), ptr_size, MemoryKind::UninitializedStatic)?;
 
         let drop = eval_context::resolve_drop_in_place(self.tcx, ty);
         let drop = self.memory.create_fn_alloc(drop);

--- a/src/librustc_mir/interpret/validation.rs
+++ b/src/librustc_mir/interpret/validation.rs
@@ -213,7 +213,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         };
         if is_owning {
             match query.lval {
-                Lvalue::Ptr { ptr, extra, aligned: _ } => {
+                Lvalue::Ptr { ptr, extra } => {
                     // Determine the size
                     // FIXME: Can we reuse size_and_align_of_dst for Lvalues?
                     let len = match self.type_size(query.ty)? {

--- a/src/librustc_mir/interpret/validation.rs
+++ b/src/librustc_mir/interpret/validation.rs
@@ -16,7 +16,7 @@ use super::{
     Machine,
 };
 
-pub type ValidationQuery<'tcx> = ValidationOperand<'tcx, Lvalue<'tcx>>;
+pub type ValidationQuery<'tcx> = ValidationOperand<'tcx, Lvalue>;
 
 #[derive(Copy, Clone, Debug)]
 enum ValidationMode {
@@ -242,8 +242,8 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                         }
                     }
                 }
-                Lvalue::Local { .. } | Lvalue::Global(..) => {
-                    // These are not backed by memory, so we have nothing to do.
+                Lvalue::Local { .. }  => {
+                    // Not backed by memory, so we have nothing to do.
                 }
             }
         }

--- a/src/librustc_mir/interpret/value.rs
+++ b/src/librustc_mir/interpret/value.rs
@@ -133,6 +133,12 @@ impl ::std::convert::From<MemoryPointer> for Pointer {
     }
 }
 
+impl<'a> ::std::convert::From<&'a MemoryPointer> for Pointer {
+    fn from(ptr: &'a MemoryPointer) -> Self {
+        PrimVal::Ptr(*ptr).into()
+    }
+}
+
 /// A `PrimVal` represents an immediate, primitive value existing outside of a
 /// `memory::Allocation`. It is in many ways like a small chunk of a `Allocation`, up to 8 bytes in
 /// size. Like a range of bytes in an `Allocation`, a `PrimVal` can either represent the raw bytes

--- a/src/librustc_mir/interpret/value.rs
+++ b/src/librustc_mir/interpret/value.rs
@@ -7,6 +7,7 @@ use super::{
     EvalResult,
     Memory, MemoryPointer, HasMemory, PointerArithmetic,
     Machine,
+    PtrAndAlign,
 };
 
 pub(super) fn bytes_to_f32(bytes: u128) -> f32 {
@@ -36,7 +37,7 @@ pub(super) fn f64_to_bytes(f: f64) -> u128 {
 /// operations and fat pointers. This idea was taken from rustc's trans.
 #[derive(Clone, Copy, Debug)]
 pub enum Value {
-    ByRef { ptr: Pointer, aligned: bool},
+    ByRef(PtrAndAlign),
     ByVal(PrimVal),
     ByValPair(PrimVal, PrimVal),
 }
@@ -133,12 +134,6 @@ impl ::std::convert::From<MemoryPointer> for Pointer {
     }
 }
 
-impl<'a> ::std::convert::From<&'a MemoryPointer> for Pointer {
-    fn from(ptr: &'a MemoryPointer) -> Self {
-        PrimVal::Ptr(*ptr).into()
-    }
-}
-
 /// A `PrimVal` represents an immediate, primitive value existing outside of a
 /// `memory::Allocation`. It is in many ways like a small chunk of a `Allocation`, up to 8 bytes in
 /// size. Like a range of bytes in an `Allocation`, a `PrimVal` can either represent the raw bytes
@@ -172,7 +167,7 @@ pub enum PrimValKind {
 impl<'a, 'tcx: 'a> Value {
     #[inline]
     pub fn by_ref(ptr: Pointer) -> Self {
-        Value::ByRef { ptr, aligned: true }
+        Value::ByRef(PtrAndAlign { ptr, aligned: true })
     }
 
     /// Convert the value into a pointer (or a pointer-sized integer).  If the value is a ByRef,
@@ -180,7 +175,7 @@ impl<'a, 'tcx: 'a> Value {
     pub fn into_ptr<M: Machine<'tcx>>(&self, mem: &Memory<'a, 'tcx, M>) -> EvalResult<'tcx, Pointer> {
         use self::Value::*;
         match *self {
-            ByRef { ptr, aligned } => {
+            ByRef(PtrAndAlign { ptr, aligned }) => {
                 mem.read_maybe_aligned(aligned, |mem| mem.read_ptr(ptr.to_ptr()?) )
             },
             ByVal(ptr) | ByValPair(ptr, _) => Ok(ptr.into()),
@@ -193,7 +188,7 @@ impl<'a, 'tcx: 'a> Value {
     ) -> EvalResult<'tcx, (Pointer, MemoryPointer)> {
         use self::Value::*;
         match *self {
-            ByRef { ptr: ref_ptr, aligned } => {
+            ByRef(PtrAndAlign { ptr: ref_ptr, aligned }) => {
                 mem.read_maybe_aligned(aligned, |mem| {
                     let ptr = mem.read_ptr(ref_ptr.to_ptr()?)?;
                     let vtable = mem.read_ptr(ref_ptr.offset(mem.pointer_size(), mem.layout)?.to_ptr()?)?;
@@ -211,7 +206,7 @@ impl<'a, 'tcx: 'a> Value {
     pub(super) fn into_slice<M: Machine<'tcx>>(&self, mem: &Memory<'a, 'tcx, M>) -> EvalResult<'tcx, (Pointer, u64)> {
         use self::Value::*;
         match *self {
-            ByRef { ptr: ref_ptr, aligned } => {
+            ByRef(PtrAndAlign { ptr: ref_ptr, aligned } ) => {
                 mem.read_maybe_aligned(aligned, |mem| {
                     let ptr = mem.read_ptr(ref_ptr.to_ptr()?)?;
                     let len = mem.read_usize(ref_ptr.offset(mem.pointer_size(), mem.layout)?.to_ptr()?)?;

--- a/tests/compile-fail/fn_ptr_offset.rs
+++ b/tests/compile-fail/fn_ptr_offset.rs
@@ -10,5 +10,5 @@ fn main() {
     let y : *mut u8 = unsafe { mem::transmute(x) };
     let y = y.wrapping_offset(1);
     let x : fn() = unsafe { mem::transmute(y) };
-    x(); //~ ERROR: tried to use an integer pointer or a dangling pointer as a function pointer
+    x(); //~ ERROR: tried to use a function pointer after offsetting it
 }

--- a/tests/run-pass/packed_static.rs
+++ b/tests/run-pass/packed_static.rs
@@ -1,0 +1,10 @@
+#[repr(packed)]
+struct Foo {
+    i: i32
+}
+
+fn main() {
+    assert_eq!({FOO.i}, 42);
+}
+
+static FOO: Foo = Foo { i: 42 };


### PR DESCRIPTION
I did this for functions, since they were already separate. I decided on simply using the first two bits of the `u64` in `AllocId` to distinguish between locals (or heap), statics and functions. That still leaves `2^62 - 1` local allocations before we run into trouble.

Also statics can't be `ByVal` anymore, which found a bug in the `sysconf` code.

cc #285