### PR TITLE
Make cargo_miri a feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ script:
   xargo/build.sh
 - |
   # Test plain miri
-  cargo build --release &&
+  cargo build --release --features "cargo_miri" &&
   cargo test --release &&
-  cargo install
+  cargo install --features "cargo_miri"
 - |
   # Test cargo miri
   cd cargo-miri-test &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ doc = false
 name = "cargo-miri"
 test = false
 path = "miri/bin/cargo-miri.rs"
+required-features = ["cargo_miri"]
 
 [lib]
 test = false
@@ -28,8 +29,11 @@ byteorder = { version = "1.1", features = ["i128"]}
 env_logger = "0.4.3"
 log = "0.3.6"
 log_settings = "0.1.1"
-cargo_metadata = "0.2"
+cargo_metadata = { version = "0.2", optional = true }
 rustc_miri = { path = "src/librustc_mir" }
+
+[features]
+cargo_miri = ["cargo_metadata"]
 
 [dev-dependencies]
 compiletest_rs = "0.2.6"


### PR DESCRIPTION
1. Speeds up the common compilation path (no serde in the dependency tree)
2. Stage 1 rustc is enough (no serde -> no custom derive)

fixes #293

Sadly doesn't change anything about #166