### PR TITLE
enable a test that waited for a rustc fix

### DIFF
--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -1454,7 +1454,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             return Ok(());
         }
         let ptr = ptr.to_ptr()?;
-        let mut alloc = self.get_mut(ptr.alloc_id)?;
+        let alloc = self.get_mut(ptr.alloc_id)?;
         alloc.undef_mask.set_range(
             ptr.offset,
             ptr.offset + size,

--- a/src/librustc_mir/interpret/value.rs
+++ b/src/librustc_mir/interpret/value.rs
@@ -1,5 +1,4 @@
 #![allow(unknown_lints)]
-#![allow(float_cmp)]
 
 use rustc::ty::layout::HasDataLayout;
 

--- a/tests/run-pass-fullmir/integer-ops.rs
+++ b/tests/run-pass-fullmir/integer-ops.rs
@@ -9,8 +9,7 @@
 // except according to those terms.
 
 // FIXME: remove -Zmir-opt-level once https://github.com/rust-lang/rust/issues/43359 is fixed
-// FIXME: remove -Zmir-emit-validate=0 once https://github.com/rust-lang/rust/pull/43748 is merged
-// compile-flags: -Zmir-opt-level=0 -Zmir-emit-validate=0
+// compile-flags: -Zmir-opt-level=0
 
 use std::i32;
 

--- a/tests/run-pass/pointers.rs
+++ b/tests/run-pass/pointers.rs
@@ -34,7 +34,7 @@ fn tuple_ref_mut() -> (i8, i8) {
 fn match_ref_mut() -> i8 {
     let mut t = (20, 22);
     {
-        let mut opt = Some(&mut t);
+        let opt = Some(&mut t);
         match opt {
             Some(&mut (ref mut x, ref mut y)) => *x += *y,
             None => {},

--- a/tests/run-pass/thread-local.rs
+++ b/tests/run-pass/thread-local.rs
@@ -29,10 +29,10 @@ pub fn record(r: usize) {
     unsafe { RECORD = RECORD*10 + r };
 }
 
-unsafe extern fn dtor(mut ptr: *mut u64) {
+unsafe extern fn dtor(ptr: *mut u64) {
     assert!(CANNARY != 0 as *mut _); // make sure we do not get run too often
     let val = *ptr;
-    
+
     let which_key = GLOBALS.iter().position(|global| global as *const _ == ptr).expect("Should find my global");
     record(which_key);
 


### PR DESCRIPTION
Now that <https://github.com/rust-lang/rust/pull/43748> has been merged, we can enable validation in this test. (However, we have to wait for the next nightly.)