### PR TITLE
Rustup

### DIFF
--- a/tests/run-pass-fullmir/u128.rs
+++ b/tests/run-pass-fullmir/u128.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Zmir-emit-validate=0
+
 #![feature(i128_type)]
 
 fn b<T>(t: T) -> T { t }

--- a/tests/run-pass-fullmir/unsized-tuple-impls.rs
+++ b/tests/run-pass-fullmir/unsized-tuple-impls.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// compile-flags: -Zmir-emit-validate=0
+
 #![feature(unsized_tuple_coercion)]
 use std::mem;
 

--- a/tests/run-pass/pointers.rs
+++ b/tests/run-pass/pointers.rs
@@ -1,3 +1,5 @@
+// compile-flags: -Zmir-emit-validate=0
+
 fn one_line_ref() -> i16 {
     *&1
 }

--- a/xargo/Xargo.toml
+++ b/xargo/Xargo.toml
@@ -1,2 +1,2 @@
 [dependencies]
-std = {features = ["panic_unwind", "jemalloc"]}
+std = {features = ["panic_unwind", "jemalloc", "backtrace"]}


### PR DESCRIPTION
With full mir and on master rustc miri fails with

```
error: new Write lock at MemoryPointer { alloc_id: Runtime(2511), offset: 0 }, size 2, is in conflict with lock WriteLock(DynamicLifetime { frame: 9, region: None })
    --> /home/ws/ca8159/Projects/rust/rust/src/libcore/cell.rs:1239:9
     |
1239 |         &self.value as *const T as *mut T
     |         ^^^^^^^^^^^
     |
note: inside call to <std::cell::UnsafeCell<T>><libc::unix::notbsd::linux::pthread_mutex_t>::get
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/sys/unix/mutex.rs:67:42
     |
67   |         let r = libc::pthread_mutex_lock(self.inner.get());
     |                                          ^^^^^^^^^^^^^^^^
note: inside call to std::sys::imp::mutex::Mutex::lock
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/sys_common/mutex.rs:40:33
     |
40   |     pub unsafe fn lock(&self) { self.0.lock() }
     |                                 ^^^^^^^^^^^^^
note: inside call to std::sys_common::mutex::Mutex::lock
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/sys_common/at_exit_imp.rs:49:13
     |
49   |             LOCK.lock();
     |             ^^^^^^^^^^^
note: inside call to std::sys_common::at_exit_imp::cleanup
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/sys_common/mod.rs:109:9
     |
109  |         at_exit_imp::cleanup();
     |         ^^^^^^^^^^^^^^^^^^^^^^
note: inside call to closure
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/sync/once.rs:227:41
     |
227  |         self.call_inner(false, &mut |_| f.take().unwrap()());
     |                                         ^^^^^^^^^^^^^^^^^^^
note: inside call to closure
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/sync/once.rs:307:21
     |
307  |                     init(state == POISONED);
     |                     ^^^^^^^^^^^^^^^^^^^^^^^
note: inside call to std::sync::Once::call_inner
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/sync/once.rs:227:9
     |
227  |         self.call_inner(false, &mut |_| f.take().unwrap()());
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside call to std::sync::Once::call_once::<[closure@DefId { krate: CrateNum(1), node: DefIndex(2147489922) => std/fc99636::sys_common[0]::cleanup[0]::{{closure}}[0] }]>
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/sys_common/mod.rs:106:5
     |
106  | /     CLEANUP.call_once(|| unsafe {
107  | |         sys::args::cleanup();
108  | |         sys::stack_overflow::cleanup();
109  | |         at_exit_imp::cleanup();
110  | |     });
     | |______^
note: inside call to std::sys_common::cleanup
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/rt.rs:64:9
     |
64   |         sys_common::cleanup();
     |         ^^^^^^^^^^^^^^^^^^^^^
note: inside call to std::rt::lang_start
    --> /home/ws/ca8159/Projects/rust/rust/src/libstd/rt.rs:32:1
     |
32   | / fn lang_start(main: fn(), argc: isize, argv: *const *const u8) -> isize {
33   | |     use panic;
34   | |     use sys;
35   | |     use sys_common;
...    |
72   | |     }
73   | | }
     | |_^
```