### PR TITLE
rustup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ script:
 notifications:
   email:
     on_success: never
+branches:
+  only:
+  - master
 env:
   global:
   - RUST_TEST_NOCAPTURE=1

--- a/miri/bin/miri.rs
+++ b/miri/bin/miri.rs
@@ -131,7 +131,7 @@ fn after_analysis<'a, 'tcx>(state: &mut CompileState<'a, 'tcx>) {
         );
     } else if let Some((entry_node_id, _)) = *state.session.entry_fn.borrow() {
         let entry_def_id = tcx.hir.local_def_id(entry_node_id);
-        let start_wrapper = tcx.lang_items.start_fn().and_then(|start_fn| {
+        let start_wrapper = tcx.lang_items().start_fn().and_then(|start_fn| {
             if tcx.is_mir_available(start_fn) {
                 Some(start_fn)
             } else {

--- a/miri/intrinsic.rs
+++ b/miri/intrinsic.rs
@@ -32,7 +32,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator> 
     ) -> EvalResult<'tcx> {
         let substs = instance.substs;
 
-        let intrinsic_name = &self.tcx.item_name(instance.def_id()).as_str()[..];
+        let intrinsic_name = &self.tcx.item_name(instance.def_id())[..];
         match intrinsic_name {
             "align_offset" => {
                 // FIXME: return a real value in case the target allocation has an

--- a/rustc_tests/src/main.rs
+++ b/rustc_tests/src/main.rs
@@ -100,7 +100,7 @@ fn after_analysis<'a, 'tcx>(state: &mut CompileState<'a, 'tcx>) {
         state.hir_crate.unwrap().visit_all_item_likes(&mut Visitor(limits, tcx, state));
     } else if let Some((entry_node_id, _)) = *state.session.entry_fn.borrow() {
         let entry_def_id = tcx.hir.local_def_id(entry_node_id);
-        let start_wrapper = tcx.lang_items.start_fn().and_then(|start_fn|
+        let start_wrapper = tcx.lang_items().start_fn().and_then(|start_fn|
                                 if tcx.is_mir_available(start_fn) { Some(start_fn) } else { None });
         miri::eval_main(tcx, entry_def_id, start_wrapper, limits);
 

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -2267,7 +2267,7 @@ fn fn_once_adapter_instance<'a, 'tcx>(
     substs: ty::ClosureSubsts<'tcx>,
 ) -> ty::Instance<'tcx> {
     debug!("fn_once_adapter_shim({:?}, {:?})", closure_did, substs);
-    let fn_once = tcx.lang_items.fn_once_trait().unwrap();
+    let fn_once = tcx.lang_items().fn_once_trait().unwrap();
     let call_once = tcx.associated_items(fn_once)
         .find(|it| it.kind == ty::AssociatedKind::Method)
         .unwrap()
@@ -2346,7 +2346,7 @@ pub fn resolve<'a, 'tcx>(
                 ty::InstanceDef::Intrinsic(def_id)
             }
             _ => {
-                if Some(def_id) == tcx.lang_items.drop_in_place_fn() {
+                if Some(def_id) == tcx.lang_items().drop_in_place_fn() {
                     let ty = substs.type_at(0);
                     if needs_drop_glue(tcx, ty) {
                         debug!(" => nontrivial drop glue");
@@ -2440,7 +2440,7 @@ fn resolve_associated_item<'a, 'tcx>(
             }
         }
         ::rustc::traits::VtableClosure(closure_data) => {
-            let trait_closure_kind = tcx.lang_items.fn_trait_kind(trait_id).unwrap();
+            let trait_closure_kind = tcx.lang_items().fn_trait_kind(trait_id).unwrap();
             resolve_closure(
                 tcx,
                 closure_data.closure_def_id,
@@ -2461,7 +2461,7 @@ fn resolve_associated_item<'a, 'tcx>(
                 substs: rcvr_substs,
             }
         }
-        ::rustc::traits::VtableBuiltin(..) if Some(trait_id) == tcx.lang_items.clone_trait() => {
+        ::rustc::traits::VtableBuiltin(..) if Some(trait_id) == tcx.lang_items().clone_trait() => {
             ty::Instance {
                 def: ty::InstanceDef::CloneShim(def_id, trait_ref.self_ty()),
                 substs: rcvr_substs

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -268,7 +268,7 @@ pub struct Memory<'a, 'tcx, M: Machine<'tcx>> {
     writes_are_aligned: Cell<bool>,
 
     /// The current stack frame.  Used to check accesses against locks.
-    pub cur_frame: usize,
+    pub(super) cur_frame: usize,
 }
 
 impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -268,7 +268,7 @@ pub struct Memory<'a, 'tcx, M: Machine<'tcx>> {
     writes_are_aligned: Cell<bool>,
 
     /// The current stack frame.  Used to check accesses against locks.
-    cur_frame: usize,
+    pub cur_frame: usize,
 }
 
 impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
@@ -529,10 +529,6 @@ impl<'a, 'tcx, M: Machine<'tcx>> Memory<'a, 'tcx, M> {
             });
         }
         Ok(())
-    }
-
-    pub(crate) fn set_cur_frame(&mut self, cur_frame: usize) {
-        self.cur_frame = cur_frame;
     }
 }
 

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -164,7 +164,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 }
             }
             EndRegion(ce) => {
-                self.end_region(ce)?;
+                self.end_region(Some(ce))?;
             }
 
             // Defined to do nothing. These are added by optimization passes, to avoid changing the

--- a/src/librustc_mir/interpret/validation.rs
+++ b/src/librustc_mir/interpret/validation.rs
@@ -56,17 +56,17 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             use regex::Regex;
             lazy_static! {
                 static ref RE: Regex = Regex::new("^(\
-                    std::mem::uninitialized::|\
-                    std::mem::forget::|\
+                    (std|alloc::heap::__core)::mem::uninitialized::|\
+                    (std|alloc::heap::__core)::mem::forget::|\
                     <(std|alloc)::heap::Heap as (std::heap|alloc::allocator)::Alloc>::|\
-                    <std::mem::ManuallyDrop<T>><.*>::new$|\
-                    <std::mem::ManuallyDrop<T> as std::ops::DerefMut><.*>::deref_mut$|\
-                    std::ptr::read::|\
+                    <(std|alloc::heap::__core)::mem::ManuallyDrop<T>><.*>::new$|\
+                    <(std|alloc::heap::__core)::mem::ManuallyDrop<T> as std::ops::DerefMut><.*>::deref_mut$|\
+                    (std|alloc::heap::__core)::ptr::read::|\
                     \
                     <std::sync::Arc<T>><.*>::inner$|\
                     <std::sync::Arc<T>><.*>::drop_slow$|\
                     (std::heap|alloc::allocator)::Layout::for_value::|\
-                    std::mem::(size|align)_of_val::\
+                    (std|alloc::heap::__core)::mem::(size|align)_of_val::\
                 )").unwrap();
             }
             // Now test

--- a/src/librustc_mir/interpret/validation.rs
+++ b/src/librustc_mir/interpret/validation.rs
@@ -543,7 +543,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
                 Ok(())
             }
             TyAdt(adt, subst) => {
-                if Some(adt.did) == self.tcx.lang_items.unsafe_cell_type() &&
+                if Some(adt.did) == self.tcx.lang_items().unsafe_cell_type() &&
                     query.mutbl == MutImmutable
                 {
                     // No locks for shared unsafe cells.  Also no other validation, the only field is private anyway.

--- a/tests/compile-fail/deallocate-bad-alignment.rs
+++ b/tests/compile-fail/deallocate-bad-alignment.rs
@@ -7,7 +7,6 @@ use alloc::allocator::*;
 
 // error-pattern: tried to deallocate or reallocate using incorrect alignment or size
 
-use alloc::heap::*;
 fn main() {
     unsafe {
         let x = Heap.alloc(Layout::from_size_align_unchecked(1, 1)).unwrap();

--- a/tests/compile-fail/deallocate-bad-size.rs
+++ b/tests/compile-fail/deallocate-bad-size.rs
@@ -7,7 +7,6 @@ use alloc::allocator::*;
 
 // error-pattern: tried to deallocate or reallocate using incorrect alignment or size
 
-use alloc::heap::*;
 fn main() {
     unsafe {
         let x = Heap.alloc(Layout::from_size_align_unchecked(1, 1)).unwrap();

--- a/tests/compile-fail/deallocate-twice.rs
+++ b/tests/compile-fail/deallocate-twice.rs
@@ -7,7 +7,6 @@ use alloc::allocator::*;
 
 // error-pattern: tried to deallocate dangling pointer
 
-use alloc::heap::*;
 fn main() {
     unsafe {
         let x = Heap.alloc(Layout::from_size_align_unchecked(1, 1)).unwrap();

--- a/tests/compile-fail/reallocate-bad-alignment-2.rs
+++ b/tests/compile-fail/reallocate-bad-alignment-2.rs
@@ -7,7 +7,6 @@ use alloc::allocator::*;
 
 // error-pattern: tried to deallocate or reallocate using incorrect alignment or size
 
-use alloc::heap::*;
 fn main() {
     unsafe {
         let x = Heap.alloc(Layout::from_size_align_unchecked(1, 1)).unwrap();

--- a/tests/compile-fail/reallocate-bad-alignment.rs
+++ b/tests/compile-fail/reallocate-bad-alignment.rs
@@ -7,7 +7,6 @@ use alloc::allocator::*;
 
 // error-pattern: tried to deallocate or reallocate using incorrect alignment or size
 
-use alloc::heap::*;
 fn main() {
     unsafe {
         let x = Heap.alloc(Layout::from_size_align_unchecked(1, 2)).unwrap();

--- a/tests/compile-fail/reallocate-bad-size.rs
+++ b/tests/compile-fail/reallocate-bad-size.rs
@@ -7,7 +7,6 @@ use alloc::allocator::*;
 
 // error-pattern: tried to deallocate or reallocate using incorrect alignment or size
 
-use alloc::heap::*;
 fn main() {
     unsafe {
         let x = Heap.alloc(Layout::from_size_align_unchecked(1, 1)).unwrap();

--- a/tests/compile-fail/reallocate-dangling.rs
+++ b/tests/compile-fail/reallocate-dangling.rs
@@ -7,7 +7,6 @@ use alloc::allocator::*;
 
 // error-pattern: dangling pointer was dereferenced
 
-use alloc::heap::*;
 fn main() {
     unsafe {
         let x = Heap.alloc(Layout::from_size_align_unchecked(1, 1)).unwrap();

--- a/tests/run-pass-fullmir/u128.rs
+++ b/tests/run-pass-fullmir/u128.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Zmir-emit-validate=0
-
 #![feature(i128_type)]
 
 fn b<T>(t: T) -> T { t }

--- a/tests/run-pass-fullmir/unsized-tuple-impls.rs
+++ b/tests/run-pass-fullmir/unsized-tuple-impls.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// compile-flags: -Zmir-emit-validate=0
-
 #![feature(unsized_tuple_coercion)]
 use std::mem;
 

--- a/tests/run-pass/dst-field-align.rs
+++ b/tests/run-pass/dst-field-align.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME: Broken by #296
-// compile-flags: -Zmir-emit-validate=0
-
 #![allow(dead_code)]
 
 struct Foo<T: ?Sized> {

--- a/tests/run-pass/mir_coercions.rs
+++ b/tests/run-pass/mir_coercions.rs
@@ -8,9 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// FIXME: investigate again once #296 is fixed
-// compile-flags: -Zmir-emit-validate=0
-
 #![feature(coerce_unsized, unsize)]
 
 use std::ops::CoerceUnsized;

--- a/tests/run-pass/non_capture_closure_to_fn_ptr.rs
+++ b/tests/run-pass/non_capture_closure_to_fn_ptr.rs
@@ -1,6 +1,3 @@
-// FIXME: investigate again once #296 is fixed
-// compile-flags: -Zmir-emit-validate=0
-
 // allow(const_err) to work around a bug in warnings
 #[allow(const_err)]
 static FOO: fn() = || { assert_ne!(42, 43) };

--- a/tests/run-pass/pointers.rs
+++ b/tests/run-pass/pointers.rs
@@ -1,5 +1,3 @@
-// compile-flags: -Zmir-emit-validate=0
-
 fn one_line_ref() -> i16 {
     *&1
 }

--- a/tests/run-pass/subslice_array.rs
+++ b/tests/run-pass/subslice_array.rs
@@ -1,6 +1,3 @@
-// FIXME: investigate again once #296 is fixed
-// compile-flags: -Zmir-emit-validate=0
-
 #![feature(advanced_slice_patterns)]
 #![feature(slice_patterns)]
 

--- a/tests/run-pass/tuple_like_enum_variant_constructor_pointer_opt.rs
+++ b/tests/run-pass/tuple_like_enum_variant_constructor_pointer_opt.rs
@@ -1,6 +1,3 @@
-// FIXME: investigate again once #296 is fixed
-// compile-flags: -Zmir-emit-validate=0
-
 fn main() {
     let x = 5;
     assert_eq!(Some(&x).map(Some), Some(Some(&x)));


### PR DESCRIPTION
This doesn't work yet. I get some validation failures around heap allocators:

@RalfJung help!

```
error: attempted to read undefined bytes
   --> /home/ws/ca8159/Projects/rust/rust/src/libcore/mem.rs:487:5
    |
487 |     intrinsics::uninit()
    |     ^^^^^^^^^^^^^^^^^^^^
    |
note: inside call to alloc::heap::__core::mem::uninitialized::<alloc::allocator::AllocErr>
   --> /home/ws/ca8159/Projects/rust/rust/src/liballoc/heap.rs:83:41
    |
83  |         let mut err = ManuallyDrop::new(mem::uninitialized::<AllocErr>());
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside call to <alloc::heap::Heap as alloc::allocator::Alloc>::alloc
   --> /home/ws/ca8159/Projects/rust/rust/src/liballoc/raw_vec.rs:97:21
    |
97  |                     a.alloc(Layout::from_size_align(alloc_size, align).unwrap())
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside call to <alloc::raw_vec::RawVec<T, A>><u8, alloc::heap::Heap>::allocate_in
   --> /home/ws/ca8159/Projects/rust/rust/src/liballoc/raw_vec.rs:141:9
    |
141 |         RawVec::allocate_in(cap, false, Heap)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside call to <alloc::raw_vec::RawVec<T>><u8>::with_capacity
   --> /home/ws/ca8159/Projects/rust/rust/src/liballoc/vec.rs:359:18
    |
359 |             buf: RawVec::with_capacity(capacity),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside call to <alloc::Vec<T>><u8>::with_capacity
   --> /home/ws/ca8159/Projects/rust/rust/src/liballoc/slice.rs:163:26
    |
163 |         let mut vector = Vec::with_capacity(s.len());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside call to alloc::slice::hack::to_vec::<u8>
   --> /home/ws/ca8159/Projects/rust/rust/src/liballoc/slice.rs:1509:9
    |
1509|         hack::to_vec(self)
    |         ^^^^^^^^^^^^^^^^^^
note: inside call to alloc::slice::<impl [T]><u8>::to_vec
   --> /home/ws/ca8159/Projects/rust/rust/src/liballoc/slice.rs:1634:9
    |
1634|         self.to_vec()
    |         ^^^^^^^^^^^^^
note: inside call to alloc::slice::<impl alloc::borrow::ToOwned for [T]><u8>::to_owned
   --> /home/ws/ca8159/Projects/rust/rust/src/liballoc/str.rs:189:46
    |
189 |         unsafe { String::from_utf8_unchecked(self.as_bytes().to_owned()) }
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside call to alloc::str::<impl alloc::borrow::ToOwned for str>::to_owned
   --> /home/ws/ca8159/Projects/rust/rust/src/libstd/rt.rs:51:39
    |
51  |         let thread = Thread::new(Some("main".to_owned()));
    |                                       ^^^^^^^^^^^^^^^^^
note: inside call to std::rt::lang_start
   --> /home/ws/ca8159/Projects/rust/rust/src/libstd/rt.rs:32:1
    |
32  | / fn lang_start(main: fn(), argc: isize, argv: *const *const u8) -> isize {
33  | |     use panic;
34  | |     use sys;
35  | |     use sys_common;
...   |
72  | |     }
73  | | }
    | |_^
```