### PR TITLE
Remove `#[linkage(foo)]` statics from core miri

### DIFF
--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -245,4 +245,14 @@ impl<'tcx> super::Machine<'tcx> for CompileTimeFunctionEvaluator {
             ConstEvalError::NeedsRfc("Heap allocations via `box` keyword".to_string()).into(),
         )
     }
+
+    fn global_item_with_linkage<'a>(
+        _ecx: &mut EvalContext<'a, 'tcx, Self>,
+        _instance: ty::Instance<'tcx>,
+        _mutability: Mutability,
+    ) -> EvalResult<'tcx> {
+        Err(
+            ConstEvalError::NotConst("statics with `linkage` attribute".to_string()).into(),
+        )
+    }
 }

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -6,6 +6,7 @@ use super::{EvalResult, EvalContext, Lvalue, PrimVal, ValTy};
 
 use rustc::{mir, ty};
 use syntax::codemap::Span;
+use syntax::ast::Mutability;
 
 /// Methods of this trait signifies a point where CTFE evaluation would fail
 /// and some use case dependent behaviour can instead be applied
@@ -70,4 +71,11 @@ pub trait Machine<'tcx>: Sized {
         ecx: &mut EvalContext<'a, 'tcx, Self>,
         ty: ty::Ty<'tcx>,
     ) -> EvalResult<'tcx, PrimVal>;
+
+    /// Called when trying to access a global declared with a `linkage` attribute
+    fn global_item_with_linkage<'a>(
+        ecx: &mut EvalContext<'a, 'tcx, Self>,
+        instance: ty::Instance<'tcx>,
+        mutability: Mutability,
+    ) -> EvalResult<'tcx>;
 }

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -205,23 +205,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             return Ok(false);
         }
         if self.tcx.has_attr(def_id, "linkage") {
-            // FIXME: check that it's `#[linkage = "extern_weak"]`
-            trace!("Initializing an extern global with NULL");
-            let ptr_size = self.memory.pointer_size();
-            let ptr = self.memory.allocate(
-                ptr_size,
-                ptr_size,
-                MemoryKind::UninitializedStatic,
-            )?;
-            self.memory.write_ptr_sized_unsigned(ptr, PrimVal::Bytes(0))?;
-            self.memory.mark_static_initalized(ptr.alloc_id, mutability)?;
-            self.globals.insert(
-                cid,
-                PtrAndAlign {
-                    ptr: ptr.into(),
-                    aligned: true,
-                },
-            );
+            M::global_item_with_linkage(self, cid.instance, mutability)?;
             return Ok(false);
         }
         let mir = self.load_mir(instance.def)?;


### PR DESCRIPTION
cc #217