### PR TITLE
README: show AppVeyor status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Miri [[slides](https://solson.me/miri-slides.pdf)] [[report](https://solson.me/miri-report.pdf)] [![Build Status](https://travis-ci.org/solson/miri.svg?branch=master)](https://travis-ci.org/solson/miri) [![Windows build status](https://ci.appveyor.com/api/projects/status/github/solson/miri?svg=true)](https://ci.appveyor.com/project/solson/miri)
+# Miri [[slides](https://solson.me/miri-slides.pdf)] [[report](https://solson.me/miri-report.pdf)] [![Build Status](https://travis-ci.org/solson/miri.svg?branch=master)](https://travis-ci.org/solson/miri) [![Windows build status](https://ci.appveyor.com/api/projects/status/github/solson/miri?svg=true)](https://ci.appveyor.com/project/solson63299/miri)
 
 
 An experimental interpreter for [Rust][rust]'s [mid-level intermediate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Miri [[slides](https://solson.me/miri-slides.pdf)] [[report](https://solson.me/miri-report.pdf)] [![Build Status](https://travis-ci.org/solson/miri.svg?branch=master)](https://travis-ci.org/solson/miri)
+# Miri [[slides](https://solson.me/miri-slides.pdf)] [[report](https://solson.me/miri-report.pdf)] [![Build Status](https://travis-ci.org/solson/miri.svg?branch=master)](https://travis-ci.org/solson/miri) [![Windows build status](https://ci.appveyor.com/api/projects/status/github/solson/miri?svg=true)](https://ci.appveyor.com/project/solson/miri)
 
 
 An experimental interpreter for [Rust][rust]'s [mid-level intermediate


### PR DESCRIPTION
However, AppVeyor URL <https://ci.appveyor.com/project/solson/miri> does not work for me:
> Project not found or access denied.

Same problem for clippy. Is the URL wrong, or are the permissions broken?