### PR TITLE
use the new `is_ty_uninhabited_from_all_modules` helper

### DIFF
--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -2238,7 +2238,7 @@ impl IntegerExt for layout::Integer {
 }
 
 pub fn is_inhabited<'a, 'tcx: 'a>(tcx: TyCtxt<'a, 'tcx, 'tcx>, ty: Ty<'tcx>) -> bool {
-    ty.uninhabited_from(&mut HashMap::default(), tcx).is_empty()
+    !tcx.is_ty_uninhabited_from_all_modules(ty)
 }
 
 /// FIXME: expose trans::monomorphize::resolve_closure


### PR DESCRIPTION
This is needed as of https://github.com/rust-lang/rust/pull/44501