### PR TITLE
Call exchange_malloc for box stmt

### DIFF
--- a/src/librustc_mir/interpret/const_eval.rs
+++ b/src/librustc_mir/interpret/const_eval.rs
@@ -240,7 +240,8 @@ impl<'tcx> super::Machine<'tcx> for CompileTimeFunctionEvaluator {
     fn box_alloc<'a>(
         _ecx: &mut EvalContext<'a, 'tcx, Self>,
         _ty: ty::Ty<'tcx>,
-    ) -> EvalResult<'tcx, PrimVal> {
+        _dest: Lvalue,
+    ) -> EvalResult<'tcx> {
         Err(
             ConstEvalError::NeedsRfc("Heap allocations via `box` keyword".to_string()).into(),
         )

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -877,8 +877,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             }
 
             NullaryOp(mir::NullOp::Box, ty) => {
-                let ptr = M::box_alloc(self, ty)?;
-                self.write_primval(dest, ptr, dest_ty)?;
+                M::box_alloc(self, ty, dest)?;
             }
 
             NullaryOp(mir::NullOp::SizeOf, ty) => {

--- a/src/librustc_mir/interpret/lvalue.rs
+++ b/src/librustc_mir/interpret/lvalue.rs
@@ -497,7 +497,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         Ok(Lvalue::Ptr { ptr, extra })
     }
 
-    pub(super) fn lvalue_ty(&self, lvalue: &mir::Lvalue<'tcx>) -> Ty<'tcx> {
+    pub fn lvalue_ty(&self, lvalue: &mir::Lvalue<'tcx>) -> Ty<'tcx> {
         self.monomorphize(
             lvalue.ty(self.mir(), self.tcx).to_ty(self.tcx),
             self.substs(),

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -70,7 +70,8 @@ pub trait Machine<'tcx>: Sized {
     fn box_alloc<'a>(
         ecx: &mut EvalContext<'a, 'tcx, Self>,
         ty: ty::Ty<'tcx>,
-    ) -> EvalResult<'tcx, PrimVal>;
+        dest: Lvalue,
+    ) -> EvalResult<'tcx>;
 
     /// Called when trying to access a global declared with a `linkage` attribute
     fn global_item_with_linkage<'a>(

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -92,6 +92,11 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
         trace!("{:?}", stmt);
 
         use rustc::mir::StatementKind::*;
+
+        // Some statements (e.g. box) push new stack frames.  We have to record the stack frame number
+        // *before* executing the statement.
+        let frame_idx = self.cur_frame();
+
         match stmt.kind {
             Assign(ref lvalue, ref rvalue) => self.eval_rvalue_into_lvalue(rvalue, lvalue)?,
 
@@ -175,7 +180,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> EvalContext<'a, 'tcx, M> {
             InlineAsm { .. } => return err!(InlineAsm),
         }
 
-        self.frame_mut().stmt += 1;
+        self.stack[frame_idx].stmt += 1;
         Ok(())
     }
 

--- a/tests/compile-fail/oom2.rs
+++ b/tests/compile-fail/oom2.rs
@@ -1,10 +1,14 @@
 // Validation forces more allocation; disable it.
 // compile-flags: -Zmir-emit-validate=0
 #![feature(box_syntax, custom_attribute, attr_literals)]
-#![miri(memory_size=2048)]
+#![miri(memory_size=1024)]
+
+// On 64bit platforms, the allocator needs 32 bytes allocated to pass a return value, so that's the error we see.
+// On 32bit platforms, it's just 16 bytes.
+// error-pattern: tried to allocate
 
 fn main() {
     loop {
-        ::std::mem::forget(box 42); //~ ERROR tried to allocate 4 more bytes
+        ::std::mem::forget(box 42);
     }
 }


### PR DESCRIPTION
This turns out to work even for mir-free libstd.