### PR TITLE
Remove the [workspace] section.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,3 @@ cargo_miri = ["cargo_metadata"]
 
 [dev-dependencies]
 compiletest_rs = { version = "0.3.3", features = ["tmp"] }
-
-[workspace]
-exclude = ["xargo", "cargo-miri-test", "rustc_tests"]


### PR DESCRIPTION
Miri does not need to maintain a workspace anymore. Also, keeping miri a
workspace conflicts with rustc's own workspace.
