### PR TITLE
[LOCKSTEP UPGRADE #45525] stop using Instance::def_ty

### DIFF
--- a/miri/fn_call.rs
+++ b/miri/fn_call.rs
@@ -385,7 +385,7 @@ impl<'a, 'tcx> EvalContextExt<'tcx> for EvalContext<'a, 'tcx, super::Evaluator<'
                         // compute global if not cached
                         let val = match self.tcx.interpret_interner.borrow().get_cached(cid) {
                             Some(ptr) => ptr,
-                            None => eval_body(self.tcx, instance, ty::ParamEnv::empty(traits::Reveal::All)).0?.0,
+                            None => eval_body(self.tcx, instance, ty::ParamEnv::empty(traits::Reveal::All))?.0,
                         };
                         let val = self.value_to_primval(ValTy { value: Value::ByRef(val), ty: args[0].ty })?.to_u64()?;
                         if val == name {

--- a/miri/lib.rs
+++ b/miri/lib.rs
@@ -20,6 +20,7 @@ extern crate lazy_static;
 use rustc::ty::{self, TyCtxt};
 use rustc::ty::layout::{TyLayout, LayoutOf};
 use rustc::hir::def_id::DefId;
+use rustc::ty::subst::Substs;
 use rustc::mir;
 use rustc::traits;
 
@@ -157,7 +158,7 @@ pub fn eval_main<'a, 'tcx: 'a>(
         Ok(())
     }
 
-    let mut ecx = EvalContext::new(tcx, ty::ParamEnv::empty(traits::Reveal::All), limits, Default::default(), Default::default());
+    let mut ecx = EvalContext::new(tcx, ty::ParamEnv::empty(traits::Reveal::All), limits, Default::default(), Default::default(), Substs::empty());
     match run_main(&mut ecx, main_id, start_wrapper) {
         Ok(()) => {
             let leaks = ecx.memory().leak_report();

--- a/miri/lib.rs
+++ b/miri/lib.rs
@@ -105,7 +105,7 @@ pub fn eval_main<'a, 'tcx: 'a>(
             // First argument: pointer to main()
             let main_ptr = ecx.memory_mut().create_fn_alloc(main_instance);
             let dest = ecx.eval_place(&mir::Place::Local(args.next().unwrap()))?;
-            let main_ty = main_instance.def.def_ty(ecx.tcx);
+            let main_ty = main_instance.ty(ecx.tcx);
             let main_ptr_ty = ecx.tcx.mk_fn_ptr(main_ty.fn_sig(ecx.tcx));
             ecx.write_value(
                 ValTy {


### PR DESCRIPTION
that function has been removed