### PR TITLE
Remove conservative_impl_trait feature

### DIFF
--- a/miri/lib.rs
+++ b/miri/lib.rs
@@ -1,7 +1,6 @@
 #![feature(
     i128_type,
     rustc_private,
-    conservative_impl_trait,
     catch_expr,
 )]
 


### PR DESCRIPTION
This is needed to land the stabilization of impl Trait

cc https://github.com/rust-lang/rust/pull/49255#issuecomment-375996468

r? @oli-obk 