### PR TITLE
Implement `Eq`, `Clone` and `Hash` for MemoryData and Evaluator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,13 @@ use rustc::hir::def_id::DefId;
 use rustc::mir;
 use rustc::middle::const_val;
 
+use rustc_data_structures::fx::FxHasher;
+
 use syntax::ast::Mutability;
 use syntax::codemap::Span;
 
 use std::collections::{HashMap, BTreeMap};
+use std::hash::{Hash, Hasher};
 
 pub use rustc::mir::interpret::*;
 pub use rustc_mir::interpret::*;
@@ -295,7 +298,7 @@ pub fn eval_main<'a, 'tcx: 'a>(
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct Evaluator<'tcx> {
     /// Environment variables set by `setenv`
     /// Miri does not expose env vars from the host to the emulated program
@@ -305,15 +308,34 @@ pub struct Evaluator<'tcx> {
     pub(crate) suspended: HashMap<DynamicLifetime, Vec<ValidationQuery<'tcx>>>,
 }
 
+impl<'tcx> Hash for Evaluator<'tcx> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let Evaluator {
+            env_vars,
+            suspended: _,
+        } = self;
+
+        env_vars.iter()
+            .map(|(env, ptr)| {
+                let mut h = FxHasher::default();
+                env.hash(&mut h);
+                ptr.hash(&mut h);
+                h.finish()
+            })
+            .fold(0u64, |acc, hash| acc.wrapping_add(hash))
+            .hash(state);
+    }
+}
+
 pub type TlsKey = u128;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub struct TlsEntry<'tcx> {
     data: Scalar, // Will eventually become a map from thread IDs to `Scalar`s, if we ever support more than one thread.
     dtor: Option<ty::Instance<'tcx>>,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct MemoryData<'tcx> {
     /// The Key to use for the next thread-local allocation.
     next_thread_local: TlsKey,
@@ -328,6 +350,19 @@ pub struct MemoryData<'tcx> {
     locks: HashMap<AllocId, RangeMap<LockInfo<'tcx>>>,
 
     statics: HashMap<GlobalId<'tcx>, AllocId>,
+}
+
+impl<'tcx> Hash for MemoryData<'tcx> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let MemoryData {
+            next_thread_local: _,
+            thread_local,
+            locks: _,
+            statics: _,
+        } = self;
+
+        thread_local.hash(state);
+    }
 }
 
 impl<'mir, 'tcx: 'mir> Machine<'mir, 'tcx> for Evaluator<'tcx> {

--- a/src/locks.rs
+++ b/src/locks.rs
@@ -7,7 +7,7 @@ use rustc::ty::layout::Size;
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Information about a lock that is currently held.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LockInfo<'tcx> {
     /// Stores for which lifetimes (of the original write lock) we got
     /// which suspensions.

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 use std::ops;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RangeMap<T> {
     map: BTreeMap<Range, T>,
 }


### PR DESCRIPTION
In order to implement [infinite loop detection)[https://github.com/rust-lang/rust/pull/51702] while executing MIR, both the implementer of `Machine` (`Evaluator`) and its associated type (`MemoryData`), must implement `Eq`, `Clone` and `Hash`. This PR adds the required trait implementations.

It's possible that the `Hash` implementations need to be improved; only the `env_vars` field of `Evaluator` and the `thread_local` field of `MemoryData` are actually being hashed. Omitting fields from a `Hash` implementation is not incorrect, but could lead to collisions if the ignored fields are changing constantly. Perhaps I should instead derive `Hash` on a few more fields related to MIR validation?