### PR TITLE
stop producing binaries

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -87,10 +87,7 @@ impl<'a> CompilerCalls<'a> for MiriCompilerCalls {
         control.after_hir_lowering.callback = Box::new(after_hir_lowering);
         let start_fn = this.start_fn;
         control.after_analysis.callback = Box::new(move |state| after_analysis(state, start_fn));
-        if sess.target.target != sess.host {
-            // only fully compile targets on the host. linking will fail for cross-compilation.
-            control.after_analysis.stop = Compilation::Stop;
-        }
+        control.after_analysis.stop = Compilation::Stop;
         control
     }
 }

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -229,9 +229,6 @@ fn main() {
         }
     });
 
-    // Make sure we always have all the MIR (e.g. for auxilary builds in unit tests).
-    args.push("-Zalways-encode-mir".to_owned());
-
     rustc_driver::run_compiler(&args, Box::new(MiriCompilerCalls {
         default: Box::new(RustcDefaultCalls),
         start_fn,

--- a/tests/run-pass/aux_test.rs
+++ b/tests/run-pass/aux_test.rs
@@ -1,9 +1,0 @@
-// aux-build:dep.rs
-
-// ignore-cross-compile
-
-extern crate dep;
-
-fn main() {
-    dep::foo();
-}

--- a/tests/run-pass/auxiliary/dep.rs
+++ b/tests/run-pass/auxiliary/dep.rs
@@ -1,1 +1,0 @@
-pub fn foo() {}


### PR DESCRIPTION
I think that's really not miri's job. If we really want to keep these inter-crate tests, I think we should either (a) make them `cargo-miri` tests, and let cargo handle the other crates, or (b) attempt to fix compiletest so that one can run different binaries for auxiliary builds than for the final build.

Fixes #357