### PR TITLE
clarify error message when sysroot was not found

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -200,7 +200,8 @@ fn find_sysroot() -> String {
         _ => {
             option_env!("RUST_SYSROOT")
                 .expect(
-                    "need to specify RUST_SYSROOT env var or use rustup or multirust",
+                    "Could not find sysroot. Either set MIRI_SYSROOT at run-time, or at \
+                     build-time specify RUST_SYSROOT env var or use rustup or multirust",
                 )
                 .to_owned()
         }


### PR DESCRIPTION
Previously it would print `need to specify RUST_SYSROOT env var or use rustup or multirust`, even when one did `RUST_SYSROOT=... path/to/binary/miri`. Not very helpful.