### PR TITLE
cargo miri: show version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ cargo_metadata = { version = "0.6", optional = true }
 env_logger = "0.5"
 log = "0.4"
 
+[build-dependencies]
+vergen = "2"
+
 [features]
 cargo_miri = ["cargo_metadata"]
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+extern crate vergen;
+
 use std::env;
 
 fn main() {
@@ -5,4 +7,18 @@ fn main() {
     println!("cargo:rustc-env=PROFILE={}", env::var("PROFILE").unwrap());
     // Don't rebuild miri even if nothing changed
     println!("cargo:rerun-if-changed=build.rs");
+    // vergen
+    vergen().expect("Unable to generate vergen constants!");
+}
+
+fn vergen() -> vergen::Result<()> {
+    use vergen::{ConstantsFlags, Vergen};
+
+    let vergen = Vergen::new(ConstantsFlags::all())?;
+
+    for (k, v) in vergen.build_info() {
+        println!("cargo:rustc-env={}={}", k.name(), v);
+    }
+
+    Ok(())
 }

--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -30,7 +30,8 @@ fn show_help() {
 }
 
 fn show_version() {
-    println!("{}", env!("CARGO_PKG_VERSION"));
+    println!("miri {} ({} {})",
+        env!("CARGO_PKG_VERSION"), env!("VERGEN_SHA_SHORT"), env!("VERGEN_COMMIT_DATE"));
 }
 
 fn main() {


### PR DESCRIPTION
@shepmaster does this look right?
```
$ target/debug/cargo-miri --version
miri 0.1.0 (f925e5d 2018-09-16)
```

I am having some trouble triggering a rebuild when the commit changes ([it doesn't really trigger](https://github.com/rustyhorde/vergen/issues/7)), but that should not be a problem for playground which always does a clean build.

Fixes https://github.com/solson/miri/issues/452