### PR TITLE
update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-language: rust
-cache: cargo
-rust:
-- nightly
+language: generic
+cache:
+  # Cache the global cargo directory, but NOT the local `target` directory which
+  # we cannot reuse anyway when the nightly changes (and it grows quite large
+  # over time).
+  directories:
+    - /home/travis/.cargo
 
 os:
 - linux
@@ -9,17 +12,25 @@ os:
 
 before_script:
 # mac os weirdness (https://github.com/travis-ci/travis-ci/issues/6307)
-- curl -sSL https://rvm.io/mpapis.asc | gpg --import -
 - rvm get stable
-# in a cronjob, use latest (not pinned) nightly
-- if [ "$TRAVIS_EVENT_TYPE" = cron ]; then rustup override set nightly; fi
-# prepare
-- export PATH=$HOME/.local/bin:$PATH
+# Compute the rust version we use. We do not use "language: rust" to have more control here.
+- |
+  if [ "$TRAVIS_EVENT_TYPE" = cron ]; then
+    RUST_TOOLCHAIN=nightly
+  else
+    RUST_TOOLCHAIN=$(cat rust-toolchain)
+  fi
+- rm rust-toolchain
+# install Rust
+- curl https://build.travis-ci.org/files/rustup-init.sh -sSf | sh -s -- -y --default-toolchain "$RUST_TOOLCHAIN"
+- export PATH=$HOME/.cargo/bin:$PATH
+- rustc --version
+# customize installation
 - rustup target add i686-unknown-linux-gnu
 - rustup target add i686-pc-windows-gnu
 - rustup target add i686-pc-windows-msvc
 - rustup component add rust-src
-- cargo install xargo || echo "skipping xargo install"
+- cargo install xargo || echo "Skipping xargo install"
 
 script:
 - set -e
@@ -27,7 +38,7 @@ script:
   # Test and install plain miri
   cargo build --release --all-features &&
   cargo test --release --all-features &&
-  cargo install --all-features --force
+  cargo install --all-features --force --path .
 - |
   # test that the rustc_tests binary compiles
   cd rustc_tests &&
@@ -66,4 +77,3 @@ branches:
 env:
   global:
   - RUST_TEST_NOCAPTURE=1
-  - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,18 +14,21 @@ branches:
     - master
 
 install:
-    - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+    # install Rust
+    - set PATH=C:\Program Files\Git\mingw64\bin;C:\msys64\mingw%MSYS2_BITS%\bin;%PATH%
+    - set /p RUST_TOOLCHAIN=<rust-toolchain
     - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-    - rustup-init.exe -y --default-host %TARGET% --default-toolchain nightly
-    - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin;C:\Users\appveyor\.rustup\toolchains\nightly-%TARGET%\bin
-    - if defined MSYS2_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS2_BITS%\bin
-    - rustc -V
-    - cargo -V
+    - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_TOOLCHAIN%
+    - set PATH=%USERPROFILE%\.cargo\bin;%PATH%
+    - rustc --version
+    # customize installation
     - rustup component add rust-src
     - cargo install xargo
+    # prepare a libstd with MIR (cannot use bash script, obviously)
     - cd xargo
     - set RUSTFLAGS=-Zalways-encode-mir -Zmir-emit-validate=1
     - xargo build
+    - set RUSTFLAGS=
     - cd ..
 
 build: false
@@ -35,7 +38,7 @@ test_script:
     - set RUST_BACKTRACE=1
     - cargo build --release
     - cargo test --release
-    - set MIRI_SYSROOT=C:\Users\appveyor\.xargo\HOST
+    - set MIRI_SYSROOT=%USERPROFILE%\.xargo\HOST
     - cargo test --release
 
 notifications:


### PR DESCRIPTION
Avoid using `language: rust` because that installs latest `nightly` even when we want the nightly for a specific date. Also remove some quirks and hacks that are no longer needed (the `gpg --import -` on macOS, adding `$HOME/.local/bin` to the PATH, and on Windows adding `C:\Users\appveyor\.rustup\toolchains\nightly-%TARGET%\bin` to the PATH).