### PR TITLE
Enable enforcing the validity invariant per default

### DIFF
--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -64,6 +64,7 @@ fn compile_fail(sysroot: &Path, path: &str, target: &str, host: &str, need_fullm
     flags.push("-Dwarnings -Dunused".to_owned()); // overwrite the -Aunused in compiletest-rs
     config.src_base = PathBuf::from(path.to_string());
     flags.push("-Zmir-emit-validate=1".to_owned());
+    flags.push("-Zmiri-disable-validation".to_owned());
     config.target_rustcflags = Some(flags.join(" "));
     config.target = target.to_owned();
     config.host = host.to_owned();

--- a/tests/run-pass/btreemap.rs
+++ b/tests/run-pass/btreemap.rs
@@ -1,5 +1,5 @@
-// mir validation can't cope with `mem::uninitialized()`, so this test fails with validation & full-MIR.
-// compile-flags: -Zmir-emit-validate=0
+// FIXME: Validation disabled due to https://github.com/rust-lang/rust/issues/54957
+// compile-flags: -Zmiri-disable-validation
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub enum Foo {
@@ -14,4 +14,6 @@ pub fn main() {
     b.insert(Foo::A("/="));
     b.insert(Foo::A("#"));
     b.insert(Foo::A("0o"));
+    assert!(b.remove(&Foo::A("/=")));
+    assert!(!b.remove(&Foo::A("/=")));
 }

--- a/tests/run-pass/call_drop_through_owned_slice.rs
+++ b/tests/run-pass/call_drop_through_owned_slice.rs
@@ -1,3 +1,6 @@
+// FIXME validation disabled because ptr::read uses mem::uninitialized
+// compile-flags: -Zmiri-disable-validation
+
 struct Bar;
 
 static mut DROP_COUNT: usize = 0;

--- a/tests/run-pass/issue-29746.rs
+++ b/tests/run-pass/issue-29746.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// FIXME validation disabled because ptr::read uses mem::uninitialized
+// compile-flags: -Zmiri-disable-validation
+
 // zip!(a1,a2,a3,a4) is equivalent to:
 //  a1.zip(a2).zip(a3).zip(a4).map(|(((x1,x2),x3),x4)| (x1,x2,x3,x4))
 macro_rules! zip {

--- a/tests/run-pass/rc.rs
+++ b/tests/run-pass/rc.rs
@@ -1,3 +1,6 @@
+// FIXME: Validation disabled due to https://github.com/rust-lang/rust/issues/54908
+// compile-flags: -Zmiri-disable-validation
+
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/tests/run-pass/ref-invalid-ptr.rs
+++ b/tests/run-pass/ref-invalid-ptr.rs
@@ -1,3 +1,6 @@
+// FIXME validation disabled because it checks these references too eagerly
+// compile-flags: -Zmiri-disable-validation
+
 fn main() {
     let x = 2usize as *const u32;
     // this is not aligned, but we immediately cast it to a raw ptr so that must be okay

--- a/tests/run-pass/sendable-class.rs
+++ b/tests/run-pass/sendable-class.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// FIXME validation disabled because ptr::read uses mem::uninitialized
+// compile-flags: -Zmiri-disable-validation
+
 // Test that a class with only sendable fields can be sent
 
 use std::sync::mpsc::channel;

--- a/tests/run-pass/unique-send.rs
+++ b/tests/run-pass/unique-send.rs
@@ -8,6 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// FIXME validation disabled because ptr::read uses mem::uninitialized
+// compile-flags: -Zmiri-disable-validation
+
 #![feature(box_syntax)]
 
 use std::sync::mpsc::channel;


### PR DESCRIPTION
But add a flag to disable it and use that for some run-pass tests. compile-fail does not do validation yet.

NOTE: This is a PR against the rustup branch, because it's based on top of that branch.