### PR TITLE
std::ptr no longer needs whitelisting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,6 @@ impl<'a, 'mir, 'tcx> Machine<'a, 'mir, 'tcx> for Evaluator<'tcx> {
         // We walk up the stack a few frames to also cover their callees.
         const WHITELIST: &[(&str, &str)] = &[
             // Uses mem::uninitialized
-            ("std::ptr::read", ""),
             ("std::sys::windows::mutex::Mutex::", ""),
         ];
         for frame in ecx.stack().iter()


### PR DESCRIPTION
With the next nightly, anyway.