### PR TITLE
do not even look for cargo metadata in 'cargo miri setup'

### DIFF
--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -223,6 +223,10 @@ fn main() {
         // We always setup
         let ask = subcommand != MiriCommand::Setup;
         setup(ask);
+        if subcommand == MiriCommand::Setup {
+            // Stop here.
+            return;
+        }
 
         // Now run the command.
         for target in list_targets(std::env::args().skip(skip)) {


### PR DESCRIPTION
This should fix https://github.com/integer32llc/rust-playground/issues/438