### PR TITLE
build libstd with minimal features

### DIFF
--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -155,6 +155,9 @@ fn setup(ask_user: bool) {
     File::create(dir.join("Xargo.toml")).unwrap()
         .write_all(br#"
 [dependencies.std]
+default_features = false
+# We need the `panic_unwind` feature because we use the `unwind` panic strategy.
+# Using `abort` works for libstd, but then libtest will not compile.
 features = ["panic_unwind"]
 
 [dependencies.test]


### PR DESCRIPTION
We want libstd to be as stripped-down as we can make it.

Currently, this does not make a difference, but it might in the future (e.g. when/if https://github.com/rust-lang/rust/pull/56435 lands).