### PR TITLE
treat ref-to-raw cast like a reborrow: do a special kind of retag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,36 +474,10 @@ impl<'a, 'mir, 'tcx> Machine<'a, 'mir, 'tcx> for Evaluator<'tcx> {
         }
     }
 
-    #[inline]
-    fn escape_to_raw(
-        ecx: &mut EvalContext<'a, 'mir, 'tcx, Self>,
-        ptr: OpTy<'tcx, Self::PointerTag>,
-    ) -> EvalResult<'tcx> {
-        // It is tempting to check the type here, but drop glue does EscapeToRaw
-        // on a raw pointer.
-        // This is deliberately NOT `deref_operand` as we do not want `tag_dereference`
-        // to be called!  That would kill the original tag if we got a raw ptr.
-        let place = ecx.ref_to_mplace(ecx.read_immediate(ptr)?)?;
-        let size = ecx.size_and_align_of_mplace(place)?.map(|(size, _)| size)
-            // for extern types, just cover what we can
-            .unwrap_or_else(|| place.layout.size);
-        if !ecx.tcx.sess.opts.debugging_opts.mir_emit_retag ||
-            !ecx.machine.validate || size == Size::ZERO
-        {
-            // No tracking, or no retagging. The latter is possible because a dependency of ours
-            // might be called with different flags than we are, so there are `Retag`
-            // statements but we do not want to execute them.
-            Ok(())
-        } else {
-            ecx.escape_to_raw(place, size)
-        }
-    }
-
     #[inline(always)]
     fn retag(
         ecx: &mut EvalContext<'a, 'mir, 'tcx, Self>,
-        fn_entry: bool,
-        two_phase: bool,
+        kind: mir::RetagKind,
         place: PlaceTy<'tcx, Borrow>,
     ) -> EvalResult<'tcx> {
         if !ecx.tcx.sess.opts.debugging_opts.mir_emit_retag || !Self::enforce_validity(ecx) {
@@ -514,7 +488,7 @@ impl<'a, 'mir, 'tcx> Machine<'a, 'mir, 'tcx> for Evaluator<'tcx> {
             // uninitialized data.
              Ok(())
         } else {
-            ecx.retag(fn_entry, two_phase, place)
+            ecx.retag(kind, place)
         }
     }
 

--- a/tests/compile-fail/stacked_borrows/transmute-is-no-escape.rs
+++ b/tests/compile-fail/stacked_borrows/transmute-is-no-escape.rs
@@ -1,13 +1,14 @@
 // Make sure we cannot use raw ptrs that got transmuted from mutable references
 // (i.e, no EscapeToRaw happened).
-// We could, in principle, to EscapeToRaw lazily to allow this code, but that
+// We could, in principle, do EscapeToRaw lazily to allow this code, but that
 // would no alleviate the need for EscapeToRaw (see `ref_raw_int_raw` in
 // `run-pass/stacked-borrows.rs`), and thus increase overall complexity.
 use std::mem;
 
 fn main() {
-    let mut x: i32 = 42;
-    let raw: *mut i32 = unsafe { mem::transmute(&mut x) };
-    let raw = raw as usize as *mut i32; // make sure we killed the tag
+    let mut x: [i32; 2] = [42, 43];
+    let _raw: *mut i32 = unsafe { mem::transmute(&mut x[0]) };
+    // `raw` still carries a tag, so we get another pointer to the same location that does not carry a tag
+    let raw = (&mut x[1] as *mut i32).wrapping_offset(-1);
     unsafe { *raw = 13; } //~ ERROR does not exist on the stack
 }


### PR DESCRIPTION
Includes https://github.com/solson/miri/pull/570.

Waiting for https://github.com/rust-lang/rust/pull/56741 to land