### PR TITLE
Adjust tests for funciton pointer changes

### DIFF
--- a/tests/run-pass/function_pointers.rs
+++ b/tests/run-pass/function_pointers.rs
@@ -10,12 +10,12 @@ fn h(i: i32, j: i32) -> i32 {
     j * i * 7
 }
 
-fn return_fn_ptr() -> fn() -> i32 {
+fn return_fn_ptr(f: fn() -> i32) -> fn() -> i32 {
     f
 }
 
 fn call_fn_ptr() -> i32 {
-    return_fn_ptr()()
+    return_fn_ptr(f)()
 }
 
 fn indirect<F: Fn() -> i32>(f: F) -> i32 { f() }
@@ -41,6 +41,7 @@ fn main() {
     assert_eq!(indirect3(h), 210);
     assert_eq!(indirect_mut3(h), 210);
     assert_eq!(indirect_once3(h), 210);
-    assert!(return_fn_ptr() == f);
-    assert!(return_fn_ptr() as unsafe fn() -> i32 == f as fn() -> i32 as unsafe fn() -> i32);
+    let g = f as fn() -> i32;
+    assert!(return_fn_ptr(g) == g);
+    assert!(return_fn_ptr(g) as unsafe fn() -> i32 == g as fn() -> i32 as unsafe fn() -> i32);
 }

--- a/tests/run-pass/mir_coercions.rs
+++ b/tests/run-pass/mir_coercions.rs
@@ -60,7 +60,10 @@ fn main() {
     let a = [0,1,2];
     let square_local : fn(u32) -> u32 = square;
     let (f,g) = fn_coercions(&square_local);
-    assert_eq!(f as *const (), square as *const());
+    // cannot use `square as *const ()` because we can't know whether the compiler duplicates
+    // functions, so two function pointers are only equal if they result from the same function
+    // to function pointer cast
+    assert_eq!(f as *const (), square_local as *const());
     assert_eq!(g(4), 16);
     assert_eq!(identity_coercion(g)(5), 25);
 


### PR DESCRIPTION
So... This is how we'd have to change the tests if we're keeping with `main as fn() != main as fn()`. If we want the original behaviour back in miri, but not const eval, I can also change our comparison code to special case function pointers.